### PR TITLE
Fix Vercel preview deployment for docsite

### DIFF
--- a/packages/vite-plugin-docs/docusaurus.config.js
+++ b/packages/vite-plugin-docs/docusaurus.config.js
@@ -9,7 +9,7 @@ const config = {
   title: 'CRXJS Vite Plugin',
   tagline: 'Build Chrome Extensions with Vite',
   url: 'https://crxjs.dev',
-  baseUrl: '/vite-plugin/',
+  baseUrl: process.env.VERCEL_ENV === 'production' ? '/vite-plugin/' : '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',


### PR DESCRIPTION
Vercel deploys a preview of the docsite, but it doesn't show correctly b/c we are using a rewrite on `https://crxjs.dev` to host the docsite at `https://crxjs.dev/vite-plugin`. During production, the Docusaurus config should use `baseUrl = '/vite-plugin/`, otherwise it should use `baseUrl = '/'`.