### PR TITLE
Optimize rollup input

### DIFF
--- a/.changeset/gorgeous-eyes-add.md
+++ b/.changeset/gorgeous-eyes-add.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+Optimize rollup input

--- a/packages/vite-plugin/src/node/plugin-manifest.ts
+++ b/packages/vite-plugin/src/node/plugin-manifest.ts
@@ -13,7 +13,7 @@ import {
   structuredClone,
 } from './helpers'
 import { ManifestV3 } from './manifest'
-import { basename, join } from './path'
+import { basename, isAbsolute, join, relative } from './path'
 import { CrxPlugin, CrxPluginFn, ManifestFiles } from './types'
 import { manifestId, stubId } from './virtualFileIds'
 
@@ -46,20 +46,29 @@ export const pluginManifest =
           // TODO: build this out into full validation plugin
           if (manifest.manifest_version !== 3)
             throw new Error(
-              `Manifest v${manifest.manifest_version} is currently unsupported, please use manifest v3`,
+              `CRXJS does not support Manifest v${manifest.manifest_version}, please use Manifest v3`,
             )
 
           // pre-bundle dependencies
           if (env.command === 'serve') {
+            // Vite should crawl manifest entry files
             const {
               contentScripts: js,
               background: sw,
               html,
             } = await manifestFiles(manifest)
-            let { entries = [] } = config.optimizeDeps ?? {}
-            entries = [entries].flat()
-            const set = new Set<string>(entries)
-            for (const x of [...js, ...sw, ...html]) set.add(x)
+            const { entries = [] } = config.optimizeDeps ?? {}
+            // Vite ignores build inputs if explicit entries,
+            // so we need to merge both to include extra HTML files
+            let { input = [] } = config.build?.rollupOptions ?? {}
+            if (typeof input === 'string') input = [input]
+            else input = Object.values(input)
+            input = input.map((f) =>
+              config.root && isAbsolute(f) ? relative(config.root, f) : f,
+            )
+            // Merging explicit entries and build inputs
+            const set = new Set<string>([entries, input].flat())
+            for (const x of [js, sw, html].flat()) set.add(x)
 
             return {
               ...config,

--- a/packages/vite-plugin/src/node/plugin-manifest.ts
+++ b/packages/vite-plugin/src/node/plugin-manifest.ts
@@ -63,9 +63,13 @@ export const pluginManifest =
             let { input = [] } = config.build?.rollupOptions ?? {}
             if (typeof input === 'string') input = [input]
             else input = Object.values(input)
-            input = input.map((f) =>
-              config.root && isAbsolute(f) ? relative(config.root, f) : f,
-            )
+            input = input.map((f) => {
+              let result = f
+              if (isAbsolute(f)) {
+                result = relative(config.root ?? process.cwd(), f)
+              }
+              return result
+            })
             // Merging explicit entries and build inputs
             const set = new Set<string>([entries, input].flat())
             for (const x of [js, sw, html].flat()) set.add(x)

--- a/packages/vite-plugin/tests/mv3/basic-js/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/basic-js/__snapshots__/serve.test.ts.snap
@@ -57,6 +57,14 @@ Array [
 ]
 `;
 
+exports[`serve fs output: _02 optimized deps 1`] = `
+Set {
+  "src/content.js",
+  "src/background.js",
+  "src/popup.html",
+}
+`;
+
 exports[`serve fs output: assets/content-script-loader.content.js.js 1`] = `
 "(function () {
   'use strict';

--- a/packages/vite-plugin/tests/mv3/basic-ts/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/basic-ts/__snapshots__/serve.test.ts.snap
@@ -54,6 +54,14 @@ Array [
 ]
 `;
 
+exports[`serve fs output: _02 optimized deps 1`] = `
+Set {
+  "src/content.ts",
+  "src/background.ts",
+  "src/popup.html",
+}
+`;
+
 exports[`serve fs output: assets/content-script-loader.content.ts.js.js 1`] = `
 "(function () {
   'use strict';

--- a/packages/vite-plugin/tests/mv3/dynamic-script/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/dynamic-script/__snapshots__/serve.test.ts.snap
@@ -53,6 +53,13 @@ Array [
 ]
 `;
 
+exports[`serve fs output: _02 optimized deps 1`] = `
+Set {
+  "src/declared-script.ts",
+  "src/background.ts",
+}
+`;
+
 exports[`serve fs output: assets/content-script-loader.declared-script.ts.js.js 1`] = `
 "(function () {
   'use strict';

--- a/packages/vite-plugin/tests/mv3/vite-content-script-css-imports-2/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/vite-content-script-css-imports-2/__snapshots__/serve.test.ts.snap
@@ -62,6 +62,13 @@ Array [
 ]
 `;
 
+exports[`serve fs output: _02 optimized deps 1`] = `
+Set {
+  "src/content1/index.ts",
+  "src/content2/index.ts",
+}
+`;
+
 exports[`serve fs output: assets/content-script-loader.index.ts.js.js 1`] = `
 "(function () {
   'use strict';

--- a/packages/vite-plugin/tests/mv3/vite-content-script-css-imports-3/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/vite-content-script-css-imports-3/__snapshots__/serve.test.ts.snap
@@ -64,6 +64,13 @@ Array [
 ]
 `;
 
+exports[`serve fs output: _02 optimized deps 1`] = `
+Set {
+  "src/content1/index.ts",
+  "src/content2/index.ts",
+}
+`;
+
 exports[`serve fs output: assets/content-script-loader.index.ts.js.js 1`] = `
 "(function () {
   'use strict';

--- a/packages/vite-plugin/tests/mv3/vite-content-script-css-imports/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/vite-content-script-css-imports/__snapshots__/serve.test.ts.snap
@@ -50,6 +50,12 @@ Array [
 ]
 `;
 
+exports[`serve fs output: _02 optimized deps 1`] = `
+Set {
+  "src/content.ts",
+}
+`;
+
 exports[`serve fs output: assets/content-script-loader.content.ts.js.js 1`] = `
 "(function () {
   'use strict';

--- a/packages/vite-plugin/tests/mv3/vite-declared-script-resources/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/vite-declared-script-resources/__snapshots__/serve.test.ts.snap
@@ -55,6 +55,12 @@ Array [
 ]
 `;
 
+exports[`serve fs output: _02 optimized deps 1`] = `
+Set {
+  "src/content.ts",
+}
+`;
+
 exports[`serve fs output: assets/content-script-loader.content.ts.js.js 1`] = `
 "(function () {
   'use strict';

--- a/packages/vite-plugin/tests/mv3/vite-dynamic-script-resources/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/vite-dynamic-script-resources/__snapshots__/serve.test.ts.snap
@@ -47,6 +47,12 @@ Array [
 ]
 `;
 
+exports[`serve fs output: _02 optimized deps 1`] = `
+Set {
+  "src/background.ts",
+}
+`;
+
 exports[`serve fs output: assets/content-script-loader.content1.js.js 1`] = `
 "(function () {
   'use strict';

--- a/packages/vite-plugin/tests/mv3/vite-react-fast-refresh/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/vite-react-fast-refresh/__snapshots__/serve.test.ts.snap
@@ -58,6 +58,13 @@ Array [
 ]
 `;
 
+exports[`serve fs output: _02 optimized deps 1`] = `
+Set {
+  "src/content.tsx",
+  "src/popup.html",
+}
+`;
+
 exports[`serve fs output: assets/content-script-loader.content.tsx.js.js 1`] = `
 "(function () {
   'use strict';

--- a/packages/vite-plugin/tests/mv3/vite-self-directive-in-csp/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/vite-self-directive-in-csp/__snapshots__/serve.test.ts.snap
@@ -57,6 +57,14 @@ Array [
 ]
 `;
 
+exports[`works with 'self' directive: _02 optimized deps 1`] = `
+Set {
+  "src/content.ts",
+  "src/background.ts",
+  "src/popup.html",
+}
+`;
+
 exports[`works with 'self' directive: assets/content-script-loader.content.ts.js.js 1`] = `
 "(function () {
   'use strict';

--- a/packages/vite-plugin/tests/mv3/with-copied-assets/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/with-copied-assets/__snapshots__/serve.test.ts.snap
@@ -77,6 +77,8 @@ Array [
 ]
 `;
 
+exports[`serve fs output: _02 optimized deps 1`] = `Set {}`;
+
 exports[`serve fs output: assets/crx-client-port.js 1`] = `
 "function isCrxHMRPayload(x) {
   return x.type === \\"custom\\" && x.event.startsWith(\\"crx:\\");

--- a/packages/vite-plugin/tests/mv3/with-public-dir/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/with-public-dir/__snapshots__/serve.test.ts.snap
@@ -49,6 +49,12 @@ Array [
 ]
 `;
 
+exports[`serve fs output: _02 optimized deps 1`] = `
+Set {
+  "src/popup.html",
+}
+`;
+
 exports[`serve fs output: assets/crx-client-port.js 1`] = `
 "function isCrxHMRPayload(x) {
   return x.type === \\"custom\\" && x.event.startsWith(\\"crx:\\");

--- a/packages/vite-plugin/tests/mv3/with-web-accessible-html/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/with-web-accessible-html/__snapshots__/serve.test.ts.snap
@@ -41,6 +41,13 @@ Array [
 ]
 `;
 
+exports[`serve fs output: _02 optimized deps 1`] = `
+Set {
+  "src/sidebar.html",
+  "src/welcome.html",
+}
+`;
+
 exports[`serve fs output: assets/crx-client-port.js 1`] = `
 "function isCrxHMRPayload(x) {
   return x.type === \\"custom\\" && x.event.startsWith(\\"crx:\\");

--- a/packages/vite-plugin/tests/testOutput.ts
+++ b/packages/vite-plugin/tests/testOutput.ts
@@ -61,6 +61,11 @@ export async function testOutput(
     }
   }
 
+  if (config.command === 'serve')
+    expect(new Set(config.optimizeDeps.entries)).toMatchSnapshot(
+      '_02 optimized deps',
+    )
+
   /* ------------ CHECK FOR MISSING FILES ------------ */
   const missingFiles = Object.values(
     await manifestFiles(manifest, { cwd: outDir }),


### PR DESCRIPTION
Fixes #396 by merging `build.rollupOptions.input` with the explicit `optimizeDeps.entries`.

Vite ignores Rollup input if there are explicit entries. CRXJS adds manifest entries to `optimizeDeps.entries`, so Vite always ignores the Rollup inputs. This is not correct, since Rollup input is the correct place to declare extra HTML files.

This PR parses `rollupOptions.input` and adds them to `optimizeDeps.entries` alongside the manifest entries.

It also adds an output snapshot to the tests to assert that optimized deps don't change.