### PR TITLE
Fix fs-extra imports

### DIFF
--- a/.changeset/tame-mirrors-give.md
+++ b/.changeset/tame-mirrors-give.md
@@ -1,0 +1,5 @@
+---
+'@crxjs/vite-plugin': patch
+---
+
+Remove & refactor use of fs-extra

--- a/packages/vite-plugin/src/node/plugin-fileWriter--chunks.ts
+++ b/packages/vite-plugin/src/node/plugin-fileWriter--chunks.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'fs-extra'
+import { promises as fs } from 'fs'
 import MagicString from 'magic-string'
 import { PreRenderedAsset, PreRenderedChunk } from 'rollup'
 import { TransformResult, ViteDevServer } from 'vite'
@@ -21,6 +21,7 @@ import {
   reactRefreshId,
   viteClientId,
 } from './virtualFileIds'
+const { readFile } = fs
 
 const debug = _debug('file-writer').extend('chunks')
 

--- a/packages/vite-plugin/src/node/plugin-fileWriter--polyfill.ts
+++ b/packages/vite-plugin/src/node/plugin-fileWriter--polyfill.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs-extra'
+import { readFileSync } from 'fs'
 import MagicString from 'magic-string'
 import { createRequire } from 'module'
 import { idByUrl } from './fileMeta'

--- a/packages/vite-plugin/src/node/plugin-fileWriter--public.ts
+++ b/packages/vite-plugin/src/node/plugin-fileWriter--public.ts
@@ -2,7 +2,8 @@ import { CrxPluginFn } from './types'
 import glob from 'fast-glob'
 import { ResolvedConfig } from 'vite'
 import { relative } from './path'
-import { readFile } from 'fs-extra'
+import { promises as fs } from 'fs'
+const { readFile } = fs
 
 export const pluginFileWriterPublic: CrxPluginFn = () => {
   let config: ResolvedConfig

--- a/packages/vite-plugin/src/node/plugin-manifest.ts
+++ b/packages/vite-plugin/src/node/plugin-manifest.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'fs'
-import { readFile } from 'fs-extra'
+import { promises as fs } from 'fs'
 import colors from 'picocolors'
 import { OutputAsset, OutputChunk } from 'rollup'
 import { ResolvedConfig } from 'vite'
@@ -16,6 +16,7 @@ import { ManifestV3 } from './manifest'
 import { basename, isAbsolute, join, relative } from './path'
 import { CrxPlugin, CrxPluginFn, ManifestFiles } from './types'
 import { manifestId, stubId } from './virtualFileIds'
+const { readFile } = fs
 
 // const debug = _debug('manifest')
 


### PR DESCRIPTION
I've been getting sporadic problems with `fs-extra` imports, similar to #398

This PR switches from `fs-extra` to NodeJS `fs.promises`, which fixes the problem.