### PR TITLE
Fix background global constant replacement

### DIFF
--- a/packages/vite-plugin/src/node/plugin-background.ts
+++ b/packages/vite-plugin/src/node/plugin-background.ts
@@ -58,9 +58,10 @@ export const pluginBackground: CrxPluginFn = () => {
           if (typeof port === 'undefined')
             throw new Error('server port is undefined in watch mode')
 
+          // development, required to define env vars
+          loader = `import 'http:/localhost:${port}/@vite/env';\n`
           // development, required hmr client
-          loader = `import 'http:/localhost:${port}/@vite/env';
-          import 'http://localhost:${port}${workerClientId}';`
+          loader += `import 'http://localhost:${port}${workerClientId}';\n`
           // development, optional service worker
           if (worker) loader += `import 'http://localhost:${port}/${worker}';\n`
         } else if (worker) {

--- a/packages/vite-plugin/src/node/plugin-background.ts
+++ b/packages/vite-plugin/src/node/plugin-background.ts
@@ -59,7 +59,8 @@ export const pluginBackground: CrxPluginFn = () => {
             throw new Error('server port is undefined in watch mode')
 
           // development, required hmr client
-          loader = `import 'http://localhost:${port}${workerClientId}';\n`
+          loader = `import 'http:/localhost:${port}/@vite/env';
+          import 'http://localhost:${port}${workerClientId}';`
           // development, optional service worker
           if (worker) loader += `import 'http://localhost:${port}/${worker}';\n`
         } else if (worker) {

--- a/packages/vite-plugin/tests/e2e/mv3-vite-hmr-background-define/manifest.json
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-hmr-background-define/manifest.json
@@ -1,0 +1,10 @@
+{
+  "manifest_version": 3,
+  "description": "test extension",
+  "name": "test extension",
+  "options_page": "src/options.html",
+  "version": "1.0.0",
+  "background": {
+    "service_worker": "src/background.ts"
+  }
+}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-hmr-background-define/src/background.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-hmr-background-define/src/background.ts
@@ -1,0 +1,11 @@
+// This fixes `self`'s type.
+declare const self: ServiceWorkerGlobalScope
+declare const __HELLO_WORLD__: string
+
+export {}
+
+console.log('defined', __HELLO_WORLD__)
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.runtime.openOptionsPage()
+})

--- a/packages/vite-plugin/tests/e2e/mv3-vite-hmr-background-define/src/options.html
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-hmr-background-define/src/options.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1000, initial-scale=1.0" />
+    <title>Options Page</title>
+  </head>
+  <body>
+    <h1>Options Page</h1>
+  </body>
+</html>

--- a/packages/vite-plugin/tests/e2e/mv3-vite-hmr-background-define/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-hmr-background-define/vite-serve.test.ts
@@ -1,0 +1,8 @@
+import { getPage } from '../helpers'
+import { serve } from '../runners'
+
+test('crx runs from server output', async () => {
+  const { browser } = await serve(__dirname)
+  // if page opens, service worker is ok
+  await getPage(browser, 'chrome-extension')
+})

--- a/packages/vite-plugin/tests/e2e/mv3-vite-hmr-background-define/vite.config.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-hmr-background-define/vite.config.ts
@@ -1,0 +1,11 @@
+import { crx } from 'src/index'
+import { defineConfig } from 'vite'
+import manifest from './manifest.json'
+
+export default defineConfig({
+  build: { minify: false },
+  clearScreen: false,
+  logLevel: 'error',
+  plugins: [crx({ manifest })],
+  define: { __HELLO_WORLD__: 'Hello, world!' },
+})

--- a/packages/vite-plugin/tests/e2e/mv3-vite-hmr-background-define/vite.config.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-hmr-background-define/vite.config.ts
@@ -7,5 +7,5 @@ export default defineConfig({
   clearScreen: false,
   logLevel: 'error',
   plugins: [crx({ manifest })],
-  define: { __HELLO_WORLD__: 'Hello, world!' },
+  define: { __HELLO_WORLD__: JSON.stringify('Hello, world!') },
 })

--- a/packages/vite-plugin/tests/mv3/basic-js/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/basic-js/__snapshots__/serve.test.ts.snap
@@ -166,7 +166,8 @@ setTimeout(() => clearInterval(id), 5e3);
 `;
 
 exports[`serve fs output: service-worker-loader.js 1`] = `
-"import 'http://localhost:3000/crx-client-worker';
+"import 'http:/localhost:3000/@vite/env';
+import 'http://localhost:3000/crx-client-worker';
 import 'http://localhost:3000/src/background.js';
 "
 `;

--- a/packages/vite-plugin/tests/mv3/basic-ts/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/basic-ts/__snapshots__/serve.test.ts.snap
@@ -163,7 +163,8 @@ setTimeout(() => clearInterval(id), 5e3);
 `;
 
 exports[`serve fs output: service-worker-loader.js 1`] = `
-"import 'http://localhost:3000/crx-client-worker';
+"import 'http:/localhost:3000/@vite/env';
+import 'http://localhost:3000/crx-client-worker';
 import 'http://localhost:3000/src/background.ts';
 "
 `;

--- a/packages/vite-plugin/tests/mv3/dynamic-script/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/dynamic-script/__snapshots__/serve.test.ts.snap
@@ -185,7 +185,8 @@ setTimeout(() => clearInterval(id), 5e3);
 `;
 
 exports[`serve fs output: service-worker-loader.js 1`] = `
-"import 'http://localhost:3000/crx-client-worker';
+"import 'http:/localhost:3000/@vite/env';
+import 'http://localhost:3000/crx-client-worker';
 import 'http://localhost:3000/src/background.ts';
 "
 `;

--- a/packages/vite-plugin/tests/mv3/vite-content-script-css-imports-2/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/vite-content-script-css-imports-2/__snapshots__/serve.test.ts.snap
@@ -194,7 +194,8 @@ setTimeout(() => clearInterval(id), 5e3);
 `;
 
 exports[`serve fs output: service-worker-loader.js 1`] = `
-"import 'http://localhost:3000/crx-client-worker';
+"import 'http:/localhost:3000/@vite/env';
+import 'http://localhost:3000/crx-client-worker';
 "
 `;
 

--- a/packages/vite-plugin/tests/mv3/vite-content-script-css-imports-3/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/vite-content-script-css-imports-3/__snapshots__/serve.test.ts.snap
@@ -196,7 +196,8 @@ setTimeout(() => clearInterval(id), 5e3);
 `;
 
 exports[`serve fs output: service-worker-loader.js 1`] = `
-"import 'http://localhost:3000/crx-client-worker';
+"import 'http:/localhost:3000/@vite/env';
+import 'http://localhost:3000/crx-client-worker';
 "
 `;
 

--- a/packages/vite-plugin/tests/mv3/vite-content-script-css-imports/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/vite-content-script-css-imports/__snapshots__/serve.test.ts.snap
@@ -157,7 +157,8 @@ setTimeout(() => clearInterval(id), 5e3);
 `;
 
 exports[`serve fs output: service-worker-loader.js 1`] = `
-"import 'http://localhost:3000/crx-client-worker';
+"import 'http:/localhost:3000/@vite/env';
+import 'http://localhost:3000/crx-client-worker';
 "
 `;
 

--- a/packages/vite-plugin/tests/mv3/vite-declared-script-resources/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/vite-declared-script-resources/__snapshots__/serve.test.ts.snap
@@ -162,7 +162,8 @@ setTimeout(() => clearInterval(id), 5e3);
 `;
 
 exports[`serve fs output: service-worker-loader.js 1`] = `
-"import 'http://localhost:3000/crx-client-worker';
+"import 'http:/localhost:3000/@vite/env';
+import 'http://localhost:3000/crx-client-worker';
 "
 `;
 

--- a/packages/vite-plugin/tests/mv3/vite-dynamic-script-resources/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/vite-dynamic-script-resources/__snapshots__/serve.test.ts.snap
@@ -178,7 +178,8 @@ setTimeout(() => clearInterval(id), 5e3);
 `;
 
 exports[`serve fs output: service-worker-loader.js 1`] = `
-"import 'http://localhost:3000/crx-client-worker';
+"import 'http:/localhost:3000/@vite/env';
+import 'http://localhost:3000/crx-client-worker';
 import 'http://localhost:3000/src/background.ts';
 "
 `;

--- a/packages/vite-plugin/tests/mv3/vite-react-fast-refresh/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/vite-react-fast-refresh/__snapshots__/serve.test.ts.snap
@@ -176,7 +176,8 @@ setTimeout(() => clearInterval(id), 5e3);
 `;
 
 exports[`serve fs output: service-worker-loader.js 1`] = `
-"import 'http://localhost:3000/crx-client-worker';
+"import 'http:/localhost:3000/@vite/env';
+import 'http://localhost:3000/crx-client-worker';
 "
 `;
 

--- a/packages/vite-plugin/tests/mv3/vite-self-directive-in-csp/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/vite-self-directive-in-csp/__snapshots__/serve.test.ts.snap
@@ -166,7 +166,8 @@ setTimeout(() => clearInterval(id), 5e3);
 `;
 
 exports[`works with 'self' directive: service-worker-loader.js 1`] = `
-"import 'http://localhost:3000/crx-client-worker';
+"import 'http:/localhost:3000/@vite/env';
+import 'http://localhost:3000/crx-client-worker';
 import 'http://localhost:3000/src/background.ts';
 "
 `;

--- a/packages/vite-plugin/tests/mv3/with-copied-assets/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/with-copied-assets/__snapshots__/serve.test.ts.snap
@@ -156,6 +156,7 @@ setTimeout(() => clearInterval(id), 5e3);
 `;
 
 exports[`serve fs output: service-worker-loader.js 1`] = `
-"import 'http://localhost:3000/crx-client-worker';
+"import 'http:/localhost:3000/@vite/env';
+import 'http://localhost:3000/crx-client-worker';
 "
 `;

--- a/packages/vite-plugin/tests/mv3/with-public-dir/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/with-public-dir/__snapshots__/serve.test.ts.snap
@@ -132,7 +132,8 @@ setTimeout(() => clearInterval(id), 5e3);
 `;
 
 exports[`serve fs output: service-worker-loader.js 1`] = `
-"import 'http://localhost:3000/crx-client-worker';
+"import 'http:/localhost:3000/@vite/env';
+import 'http://localhost:3000/crx-client-worker';
 "
 `;
 

--- a/packages/vite-plugin/tests/mv3/with-web-accessible-html/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/mv3/with-web-accessible-html/__snapshots__/serve.test.ts.snap
@@ -150,7 +150,8 @@ exports[`serve fs output: public.js 1`] = `
 `;
 
 exports[`serve fs output: service-worker-loader.js 1`] = `
-"import 'http://localhost:3000/crx-client-worker';
+"import 'http:/localhost:3000/@vite/env';
+import 'http://localhost:3000/crx-client-worker';
 "
 `;
 


### PR DESCRIPTION
Closes #266 

The background loader wasn't loading the Vite env module, so environment variables were not loaded during dev mode.