### PR TITLE
README - Fix npm links for @crxjs/vite-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ all the features of Vite to the Chrome Extension developer experience.
 | MV2                           |                                                                      -                                                                      |                                                                           Yes                                                                           |
 | Auto Web-accessible Resources |                                                                     Yes                                                                     |                                                                            -                                                                            |
 | Documentation                 |                                           [CRXJS Vite Plugin Docs](https://crxjs.dev/vite-plugin)                                           |                                              [Extend Chrome Docs](https://www.extend-chrome.dev/rollup-plugin)                                              |
-| NPM                           | [![npm (scoped)](https://img.shields.io/npm/v/@crxjs/vite-plugin/latest.svg)](https://www.npmjs.com/package/rollup-plugin-chrome-extension) | [![npm (scoped)](https://img.shields.io/npm/v/rollup-plugin-chrome-extension/latest.svg)](https://www.npmjs.com/package/rollup-plugin-chrome-extension) |
+| NPM                           | [![npm (scoped)](https://img.shields.io/npm/v/@crxjs/vite-plugin/latest.svg)](https://www.npmjs.com/package/@crxjs/vite-plugin) | [![npm (scoped)](https://img.shields.io/npm/v/rollup-plugin-chrome-extension/latest.svg)](https://www.npmjs.com/package/rollup-plugin-chrome-extension) |
 
 ## Supporting
 

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -1,6 +1,6 @@
 # ![CRXJS](./banner-github.png)
 
-[![npm (scoped)](https://img.shields.io/npm/v/rollup-plugin-chrome-extension.svg)](https://www.npmjs.com/package/rollup-plugin-chrome-extension)
+[![npm (scoped)](https://img.shields.io/npm/v/rollup-plugin-chrome-extension.svg)](https://www.npmjs.com/package/@crxjs/vite-plugin)
 [![GitHub last commit](https://img.shields.io/github/last-commit/crxjs/chrome-extension-tools.svg?logo=github)](https://github.com/crxjs/rollup-plugin-chrome-extension)
 ![GitHub action badge](https://github.com/crxjs/chrome-extension-tools/actions/workflows/vite-plugin.yml/badge.svg)
 


### PR DESCRIPTION
The NPM badges were still linking to rollup-plugin-chrome-extension, now they link to https://npmjs.com/package/@crxjs/vite-plugin