### PR TITLE
docs: add type assertions to json import documentation

### DIFF
--- a/packages/vite-plugin-docs/docs/getting-started/vue/00-create-project.md
+++ b/packages/vite-plugin-docs/docs/getting-started/vue/00-create-project.md
@@ -42,7 +42,7 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 // highlight-start
 import { crx } from '@crxjs/vite-plugin'
-import manifest from './manifest.json'
+import manifest from './manifest.json' assert { type: 'json' }
 // highlight-end
 
 export default defineConfig({

--- a/packages/vite-plugin-docs/docs/getting-started/vue/00-create-project.md
+++ b/packages/vite-plugin-docs/docs/getting-started/vue/00-create-project.md
@@ -42,7 +42,8 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 // highlight-start
 import { crx } from '@crxjs/vite-plugin'
-import manifest from './manifest.json' assert { type: 'json' }
+import manifest from './manifest.json' // Node 14 & 16
+import manifest from './manifest.json' assert { type: 'json' } // Node >=17
 // highlight-end
 
 export default defineConfig({

--- a/packages/vite-plugin-docs/docs/getting-started/vue/_category_.yml
+++ b/packages/vite-plugin-docs/docs/getting-started/vue/_category_.yml
@@ -1,0 +1,2 @@
+position: 2.2
+label: Vue


### PR DESCRIPTION
This fixes #450 

Starting from Node 17, type assertions are needed to allow for json imports directly per https://github.com/tc39/proposal-import-assertions 

