### PR TITLE
allow <all_urls> in matches section for web accessible resources

### DIFF
--- a/.changeset/large-dogs-kiss.md
+++ b/.changeset/large-dogs-kiss.md
@@ -1,0 +1,5 @@
+---
+'@crxjs/vite-plugin': patch
+---
+
+Allow <all_urls> in content_scripts.matches section of manifest.json

--- a/packages/vite-plugin/src/node/helpers.ts
+++ b/packages/vite-plugin/src/node/helpers.ts
@@ -162,6 +162,13 @@ export function encodeManifest(manifest: ManifestV3): string {
  * #282](https://github.com/crxjs/chrome-extension-tools/issues/282)
  */
 export const stubMatchPattern = (pattern: string): string => {
+  /**
+   * Allow <all_urls> in matches section. 
+   * [Issue #459](https://github.com/crxjs/chrome-extension-tools/issues/459)
+   */
+  if (pattern === "<all_urls>") {
+    return pattern;
+  }
   const [schema, rest] = pattern.split('://')
   const [origin, pathname] = rest.split('/')
   const root = `${schema}://${origin}`

--- a/packages/vite-plugin/src/node/stubMatchPattern.test.ts
+++ b/packages/vite-plugin/src/node/stubMatchPattern.test.ts
@@ -8,6 +8,7 @@ test.each`
   ${'http://b.com'}                | ${'http://b.com'}
   ${'https://a.com/*'}             | ${'https://a.com/*'}
   ${'https://a.com/subpath/* '}    | ${'https://a.com/*'}
+  ${'<all_urls>'}                  | ${'<all_urls>'}
 `(
   '$pattern -> $expected',
   ({ pattern, expected }: { pattern: string; expected: string }) => {


### PR DESCRIPTION
Closes #459. Allows to put `<all_urls>` in `manifest.json`. Please see issue for details.