### PR TITLE
Fix defineManifest example in docs

### DIFF
--- a/packages/vite-plugin-docs/docs/concepts/00-manifest.md
+++ b/packages/vite-plugin-docs/docs/concepts/00-manifest.md
@@ -38,7 +38,7 @@ const [major, minor, patch, label = '0'] = version
   // split into version parts
   .split(/[.-]/)
 
-export default defineManifest(async (config, env) => ({
+export default defineManifest(async (env) => ({
   manifest_version: 3,
   name:
     env.mode === 'staging'


### PR DESCRIPTION
Example from the docs doesn't work, since `defineManifest` only accepts one parameter:

```typescript
// defineManifest.ts
export type ManifestV3Fn = (env: ConfigEnv) => ManifestV3 | Promise<ManifestV3>
```