### PR TITLE
fixed build vite-plugin on windows (fix #473)

### DIFF
--- a/packages/vite-plugin/rollup.config.ts
+++ b/packages/vite-plugin/rollup.config.ts
@@ -4,7 +4,7 @@ import resolve from '@rollup/plugin-node-resolve'
 import _debug from 'debug'
 import fs from 'fs-extra'
 import jsesc from 'jsesc'
-import { posix as path } from 'path'
+import path from 'path'
 import { defineConfig, Plugin, rollup, RollupOptions } from 'rollup'
 import esbuild from 'rollup-plugin-esbuild'
 import dts from 'rollup-plugin-dts'
@@ -44,7 +44,9 @@ const bundleClientCode = (): Plugin => {
       if (id.includes('?client')) {
         const url = new URL(id, 'stub://stub')
         const filepath = url.pathname
-        const format = path.dirname(filepath).split('/').pop() as
+        const normalizedFilepath = path.normalize(filepath);
+        const dirname = path.dirname(normalizedFilepath);
+        const format = dirname.split(path.sep).pop() as
           | 'es'
           | 'iife'
           | 'html'

--- a/packages/vite-plugin/src/node/path.ts
+++ b/packages/vite-plugin/src/node/path.ts
@@ -1,4 +1,4 @@
-import { posix } from 'path'
+import path from 'path'
 
 export const {
   basename,
@@ -14,4 +14,4 @@ export const {
   resolve,
   toNamespacedPath,
   sep,
-} = posix
+} = path


### PR DESCRIPTION
It's build now, but `pnpm run test` has a lot of errors. I think it's because `path.posix` is used in tests, but I don't know much about testing.