### PR TITLE
docs: fix manifest ts example regex

### DIFF
--- a/packages/vite-plugin-docs/docs/concepts/00-manifest.md
+++ b/packages/vite-plugin-docs/docs/concepts/00-manifest.md
@@ -34,7 +34,7 @@ const { version } = packageJson
 // Convert from Semver (example: 0.1.0-beta6)
 const [major, minor, patch, label = '0'] = version
   // can only contain digits, dots, or dash
-  .replace(/[^\n.-]/, '')
+  .replace(/[^\d.-]+/g, '')
   // split into version parts
   .split(/[.-]/)
 


### PR DESCRIPTION
Example from the docs has an issue with the regex not replacing all the non digits, dots, or dash characters.