### PR TITLE
Vite 3 support notice

### DIFF
--- a/packages/vite-plugin-docs/docs/_tip-getting-started.md
+++ b/packages/vite-plugin-docs/docs/_tip-getting-started.md
@@ -8,7 +8,7 @@ We have getting started guides for the following frameworks:
 
 ### ![JS Logo](./assets/JS-icon.svg) [Vanilla JavaScript](/getting-started/vanilla-js/create-project)
 
-### ![Vue Logo](./assets/Vue-icon.svg) Vue (coming soon!)
+### ![Vue Logo](./assets/Vue-icon.svg) [Vue](/getting-started/vue/create-project)
 
 The first two sections for any framework only take 90 seconds to complete.
 

--- a/packages/vite-plugin-docs/docs/getting-started/_create-project-tabs.mdx
+++ b/packages/vite-plugin-docs/docs/getting-started/_create-project-tabs.mdx
@@ -1,0 +1,51 @@
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+## Create a project
+
+Use your favorite package manager to scaffold a new project and follow the
+prompts to create a vanilla JS project.
+
+<Tabs groupId='vite-version'>
+  <TabItem value='vite2' label='Vite 2' default>
+
+```sh
+npm init vite@^2.9.4
+```
+
+  </TabItem>
+  <TabItem value='vite3' label='Vite 3 (beta)'>
+
+```sh
+npm init vite@latest
+```
+
+:::info beta
+
+CRXJS support for Vite 3 is in beta.
+
+:::
+
+  </TabItem>
+</Tabs>
+
+## Install CRXJS Vite plugin
+
+Now install the CRXJS Vite plugin using your favorite package manager.
+
+<Tabs groupId='vite-version'>
+  <TabItem value='vite2' label='Vite 2' default>
+
+```sh
+npm i @crxjs/vite-plugin@latest -D
+```
+
+  </TabItem>
+  <TabItem value='vite3' label='Vite 3 (beta)'>
+
+```sh
+npm i @crxjs/vite-plugin@beta -D
+```
+
+  </TabItem>
+</Tabs>

--- a/packages/vite-plugin-docs/docs/getting-started/react/00-create-project.md
+++ b/packages/vite-plugin-docs/docs/getting-started/react/00-create-project.md
@@ -10,28 +10,15 @@ pagination_prev: null
 slug: create-project
 ---
 
+import CreateProjectTabs from '../\_create-project-tabs.mdx'
+
 # Get Started with React
 
 This quick guide will get you up and running with a Chrome Extension popup page.
 You'll see how to integrate CRXJS with Vite, then explore Vite HMR in an
 extension React HTML page. The first two sections take about 90 seconds!
 
-## Create a Vite project
-
-Use your favorite package manager to scaffold a new project and follow the
-prompts to create a React project.
-
-```sh
-npm init vite@latest
-```
-
-## Install CRXJS Vite plugin
-
-Now install the CRXJS Vite plugin using your favorite package manager.
-
-```sh
-npm i @crxjs/vite-plugin -D
-```
+<CreateProjectTabs />
 
 ## Update the Vite config
 

--- a/packages/vite-plugin-docs/docs/getting-started/solid/00-create-project.md
+++ b/packages/vite-plugin-docs/docs/getting-started/solid/00-create-project.md
@@ -10,6 +10,8 @@ pagination_prev: null
 slug: create-project
 ---
 
+import CreateProjectTabs from '../\_create-project-tabs.mdx'
+
 # Get Started with Solid
 
 This quick guide will get you up and running with a Chrome Extension popup page.
@@ -31,18 +33,23 @@ npx degit solidjs/templates/js vite-solid-crxjs
 npx degit solidjs/templates/ts vite-solid-crxjs
 ```
 
-## `package.json`
+:::caution package.json
 
 Check the `package.json` file to ensure that `"type": "module"` is set. If this
 package key is missing, Vite might not be able to build `vite.config.ts`.
+
+:::
 
 ## Install CRXJS Vite plugin
 
 Now install the CRXJS Vite plugin using your favorite package manager.
 
 ```sh
-npm i @crxjs/vite-plugin -D
+npm i @crxjs/vite-plugin@beta -D
 ```
+
+The official SolidJS templates use Vite 3, but CRXJS support for Vite 3 is in
+currently in beta.
 
 ## Update the Vite config
 

--- a/packages/vite-plugin-docs/docs/getting-started/solid/00-create-project.md
+++ b/packages/vite-plugin-docs/docs/getting-started/solid/00-create-project.md
@@ -48,7 +48,7 @@ Now install the CRXJS Vite plugin using your favorite package manager.
 npm i @crxjs/vite-plugin@beta -D
 ```
 
-The official SolidJS templates use Vite 3, but CRXJS support for Vite 3 is in
+The official SolidJS templates use Vite 3, but CRXJS support for Vite 3 is
 currently in beta.
 
 ## Update the Vite config

--- a/packages/vite-plugin-docs/docs/getting-started/solid/00-create-project.md
+++ b/packages/vite-plugin-docs/docs/getting-started/solid/00-create-project.md
@@ -33,10 +33,10 @@ npx degit solidjs/templates/js vite-solid-crxjs
 npx degit solidjs/templates/ts vite-solid-crxjs
 ```
 
-:::caution package.json
+:::tip package.json
 
-Check the `package.json` file to ensure that `"type": "module"` is set. If this
-package key is missing, Vite might not be able to build `vite.config.ts`.
+Check `package.json` to ensure that `"type": "module"` is set. If this package
+key is missing, Vite might not be able to build `vite.config.ts`.
 
 :::
 

--- a/packages/vite-plugin-docs/docs/getting-started/vanilla-js/00-create-project.md
+++ b/packages/vite-plugin-docs/docs/getting-started/vanilla-js/00-create-project.md
@@ -12,6 +12,8 @@ tags:
 pagination_prev: null
 ---
 
+import CreateProjectTabs from '../\_create-project-tabs.mdx'
+
 # Get Started with Vanilla JS
 
 Sometimes you don't want to use a framework for your Chrome Extension, or you
@@ -25,22 +27,7 @@ reload.
 
 :::
 
-## Create a project
-
-Use your favorite package manager to scaffold a new project and follow the
-prompts to create a vanilla JS project.
-
-```sh
-npm init vite@latest
-```
-
-## Install CRXJS Vite plugin
-
-Now install the CRXJS Vite plugin using your favorite package manager.
-
-```sh
-npm i @crxjs/vite-plugin -D
-```
+<CreateProjectTabs />
 
 ## Create a Vite config file
 

--- a/packages/vite-plugin-docs/docs/getting-started/vue/00-create-project.md
+++ b/packages/vite-plugin-docs/docs/getting-started/vue/00-create-project.md
@@ -10,28 +10,15 @@ pagination_prev: null
 slug: create-project
 ---
 
+import CreateProjectTabs from '../\_create-project-tabs.mdx'
+
 # Get Started with Vue
 
 This quick guide will get you up and running with a Chrome Extension popup page.
 You'll see how to integrate CRXJS with Vite, then explore Vite HMR in an
 extension Vue HTML page. The first two sections take about 90 seconds!
 
-## Create a Vite project
-
-Use your favorite package manager to scaffold a new project and follow the
-prompts to create a Vue project.
-
-```sh
-npm init vite@latest
-```
-
-## Install CRXJS Vite plugin
-
-Now install the CRXJS Vite plugin using your favorite package manager.
-
-```sh
-npm i @crxjs/vite-plugin -D
-```
+<CreateProjectTabs />
 
 ## Update the Vite config
 


### PR DESCRIPTION
Adds a Vite 3 tab to the code blocks on React, Vanilla, and Vue getting started guides.