### PR TITLE
fix: filter out vite serve plugin context

### DIFF
--- a/packages/vite-plugin/src/node/plugin-manifest.ts
+++ b/packages/vite-plugin/src/node/plugin-manifest.ts
@@ -93,7 +93,7 @@ export const pluginManifest: CrxPluginFn = () => {
       name: 'crx:manifest-loader',
       enforce: 'pre',
       buildStart(options) {
-        if (typeof options.input !== 'undefined') {
+        if (typeof options.input !== 'undefined' && !('ssr' in this)) {
           refId = this.emitFile({
             type: 'chunk',
             id: manifestId,


### PR DESCRIPTION
Fixes warning for projects configs with multiple HTML files 

Error:

<img width="839" alt="image" src="https://user-images.githubusercontent.com/23390212/206267507-46c87875-5a66-4433-a9cf-f2e9996f684e.png">

Vite config:

```
    rollupOptions: {
      input: ["src/pages/websocket.html"],
    },
```