### PR TITLE
fix: pass war through a set to dedupe

### DIFF
--- a/.changeset/stupid-years-whisper.md
+++ b/.changeset/stupid-years-whisper.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+fix: pass war through a set to dedupe

--- a/packages/vite-plugin/src/node/files.ts
+++ b/packages/vite-plugin/src/node/files.ts
@@ -45,7 +45,7 @@ export async function manifestFiles(
           return r
         }),
     )
-    webAccessibleResources = resources.flat().filter(isString)
+    webAccessibleResources = [...new Set(resources.flat())].filter(isString)
   }
 
   return {


### PR DESCRIPTION
Sometimes `web_accessible_resources` requires redundant match patterns:
```typescript
{
    matches: ["<all_urls>"],
    resources: [
      "images/*",
      "images/**/*",
    ],
  }
```
This usage creates duplicates in the files list, which, in turn, causes warnings during the build.