### PR TITLE
Add middleware to await file ready

### DIFF
--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -88,7 +88,7 @@
     "@rollup/plugin-node-resolve": "13.2.0",
     "@sveltejs/vite-plugin-svelte": "1.1.0",
     "@types/acorn": "4.0.6",
-    "@types/chrome": "0.0.198",
+    "@types/chrome": "0.0.209",
     "@types/debug": "4.1.7",
     "@types/fs-extra": "9.0.13",
     "@types/jest-image-snapshot": "^5.1.0",

--- a/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/manifest.json
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/manifest.json
@@ -1,0 +1,10 @@
+{
+  "description": "test extension",
+  "manifest_version": 3,
+  "name": "test extension",
+  "background": { "service_worker": "src/background.ts" },
+  "options_page": "src/options.html",
+  "version": "1.0.0",
+  "host_permissions": ["<all_urls>"],
+  "permissions": ["scripting"]
+}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/src1/background.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/src1/background.ts
@@ -1,0 +1,11 @@
+import contentScript from './content?script'
+
+chrome.runtime.onInstalled.addListener(({ reason }) => {
+  if (reason === 'install') {
+    chrome.scripting
+      .registerContentScripts([
+        { id: 'contentScript', js: [contentScript], matches: ['<all_urls>'] },
+      ])
+      .catch(console.error)
+  }
+})

--- a/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/src1/content.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/src1/content.ts
@@ -1,0 +1,12 @@
+import './style.css'
+import { header } from './header'
+
+const app = document.createElement('div')
+app.id = 'app'
+app.innerHTML = `
+  <h1>${header}</h1>
+  <a href="https://vitejs.dev/guide/features.html" target="_blank">Documentation</a>
+`
+document.body.append(app)
+
+chrome.runtime.sendMessage({ type: 'content-script-load' })

--- a/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/src1/header.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/src1/header.ts
@@ -1,0 +1,1 @@
+export const header = 'Hello Vite!'

--- a/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/src1/style.css
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/src1/style.css
@@ -1,0 +1,8 @@
+#app {
+  font-family: Avenir, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-align: center;
+  color: #2c3e50;
+  margin-top: 60px;
+}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/src2/header.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/src2/header.ts
@@ -1,0 +1,1 @@
+export const header = 'Hello Vite + CRX!'

--- a/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/src2/style.css
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/src2/style.css
@@ -1,0 +1,9 @@
+#app {
+  font-family: Avenir, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-align: center;
+  color: #2c3e50;
+  margin-top: 60px;
+  background-color: red;
+}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/vite-serve.test.ts
@@ -1,0 +1,56 @@
+import fs from 'fs-extra'
+import path from 'path'
+import { expect, test } from 'vitest'
+import { waitForInnerHtml } from '../helpers'
+import { serve } from '../runners'
+import { header } from './src2/header'
+
+test('crx page update on hmr', async () => {
+  const src = path.join(__dirname, 'src')
+  const src1 = path.join(__dirname, 'src1')
+  const src2 = path.join(__dirname, 'src2')
+
+  await fs.remove(src)
+  await fs.copy(src1, src, { recursive: true })
+
+  const { browser, routes } = await serve(__dirname)
+
+  const page = await browser.newPage()
+  await page.goto('https://example.com')
+
+  const app = page.locator('#app')
+  await app.waitFor()
+
+  const styles = page.locator('head style')
+
+  // page reloads aren't reliable in CI, tracking route hits
+  let reloads = 0
+  routes.subscribe(() => {
+    reloads++
+  })
+
+  // update css file -> trigger css update
+  await fs.copy(src2, src, {
+    recursive: true,
+    overwrite: true,
+    filter: (f) => {
+      if (fs.lstatSync(f).isDirectory()) return true
+      return f.endsWith('css')
+    },
+  })
+
+  await waitForInnerHtml(styles, (h) => h.includes('background-color: red;'))
+  expect(reloads).toBe(0) // no reload on css update
+
+  // update header.ts file -> trigger full reload
+  await fs.copy(src2, src, {
+    recursive: true,
+    filter: (f) => {
+      if (fs.lstatSync(f).isDirectory()) return true
+      return f.endsWith('header.ts')
+    },
+  })
+
+  await page.locator('h1', { hasText: header }).waitFor()
+  expect(reloads).toBeGreaterThanOrEqual(1) // full reload on jsx update
+})

--- a/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/vite.config.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/vite.config.ts
@@ -1,0 +1,10 @@
+import { crx } from '../../plugin-testOptionsProvider'
+import { defineConfig } from 'vite'
+import manifest from './manifest.json'
+
+export default defineConfig({
+  build: { minify: false },
+  clearScreen: false,
+  logLevel: 'error',
+  plugins: [crx({ manifest })],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,7 +165,7 @@ importers:
       '@rollup/pluginutils': ^4.1.2
       '@sveltejs/vite-plugin-svelte': 1.1.0
       '@types/acorn': 4.0.6
-      '@types/chrome': 0.0.198
+      '@types/chrome': 0.0.209
       '@types/debug': 4.1.7
       '@types/fs-extra': 9.0.13
       '@types/jest-image-snapshot': ^5.1.0
@@ -235,7 +235,7 @@ importers:
       '@rollup/plugin-node-resolve': 13.2.0_rollup@2.78.1
       '@sveltejs/vite-plugin-svelte': 1.1.0_svelte@3.48.0+vite@3.1.7
       '@types/acorn': 4.0.6
-      '@types/chrome': 0.0.198
+      '@types/chrome': 0.0.209
       '@types/debug': 4.1.7
       '@types/fs-extra': 9.0.13
       '@types/jest-image-snapshot': 5.1.0
@@ -5751,6 +5751,13 @@ packages:
 
   /@types/chrome/0.0.198:
     resolution: {integrity: sha512-zLn6JZXwSOOY0pw+dkIxItxvjsQThDkqaFnsnmr412Wa0MqesymfdTQ/0d30J/0wiFp3TYw0i63hzGGy0W7Paw==}
+    dependencies:
+      '@types/filesystem': 0.0.32
+      '@types/har-format': 1.2.8
+    dev: true
+
+  /@types/chrome/0.0.209:
+    resolution: {integrity: sha512-YL3gz9cAKKym/b+u26p8BQuKAc3USsPRcOYZ1OWQmOw0kfYBXkxrh9ASvSRgwA8ywA4sIahio0z0chzmmLq2og==}
     dependencies:
       '@types/filesystem': 0.0.32
       '@types/har-format': 1.2.8


### PR DESCRIPTION
Relates to #589, see https://github.com/crxjs/chrome-extension-tools/pull/589#issuecomment-1328356623

This PR adds a ViteDevServer middleware to wait for the file writer to complete all content scripts before sending an HTTP response.

There was no test coverage for HMR in dynamic content scripts, so I added a test.