### PR TITLE
fix: reset contentScripts when main plugin is initialized

### DIFF
--- a/.changeset/grumpy-brooms-exist.md
+++ b/.changeset/grumpy-brooms-exist.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+fix: reset contentScripts when main plugin is initialized

--- a/packages/vite-plugin/src/node/index.ts
+++ b/packages/vite-plugin/src/node/index.ts
@@ -14,12 +14,14 @@ import { pluginHtmlInlineScripts } from './plugin-htmlInlineScripts'
 import { pluginManifest } from './plugin-manifest'
 import { pluginWebAccessibleResources } from './plugin-webAccessibleResources'
 import type { CrxOptions, CrxPlugin } from './types'
+import { contentScripts } from './contentScripts'
 
 export const crx = (
   options: {
     manifest: ManifestV3Export
   } & CrxOptions,
 ): PluginOption[] => {
+  contentScripts.clear()
   return [
     pluginOptionsProvider(options),
     pluginBackground(),


### PR DESCRIPTION
Resets the contentScripts Map when the main plugin is initialized (allows Vite JS API to make multiple builds).