### PR TITLE
Add compatibility mode for Firefox

### DIFF
--- a/packages/vite-plugin/src/node/manifest.ts
+++ b/packages/vite-plugin/src/node/manifest.ts
@@ -16,6 +16,16 @@ export interface WebAccessibleResourceById {
   use_dynamic_url?: boolean
 }
 
+export interface ChromeManifestBackground {
+  service_worker: string
+  type?: 'module' // If the service worker uses ES modules
+}
+
+export interface FirefoxManifestBackground {
+  scripts: string[]
+  persistent?: false
+}
+
 export interface ManifestV3 {
   // Required
   manifest_version: number
@@ -32,10 +42,8 @@ export interface ManifestV3 {
   action?: chrome.runtime.ManifestAction | undefined
   author?: string | undefined
   background?:
-    | {
-        service_worker: string
-        type?: 'module' // If the service worker uses ES modules
-      }
+    | ChromeManifestBackground
+    | FirefoxManifestBackground
     | undefined
   chrome_settings_overrides?:
     | {

--- a/packages/vite-plugin/src/node/plugin-optionsProvider.ts
+++ b/packages/vite-plugin/src/node/plugin-optionsProvider.ts
@@ -2,7 +2,9 @@ import { PluginOption, UserConfig } from 'vite'
 import { ManifestV3Export } from './defineManifest'
 import { CrxOptions, CrxPlugin } from './types'
 
-export type CrxInputOptions = { manifest: ManifestV3Export } & CrxOptions
+export interface CrxInputOptions extends CrxOptions {
+  manifest: ManifestV3Export
+}
 
 const pluginName = 'crx:optionsProvider'
 export const pluginOptionsProvider = (options: CrxInputOptions | null) => {

--- a/packages/vite-plugin/src/node/types.ts
+++ b/packages/vite-plugin/src/node/types.ts
@@ -51,12 +51,18 @@ export type CrxDevScriptId = {
 }
 
 export interface CrxPlugin extends VitePlugin {
-  /** Runs during the transform hook for the manifest. Filenames use input filenames. */
+  /**
+   * Runs during the transform hook for the manifest. Filenames use input
+   * filenames.
+   */
   transformCrxManifest?: (
     this: PluginContext,
     manifest: ManifestV3,
   ) => Promise<ManifestV3 | null | undefined> | ManifestV3 | null | undefined
-  /** Runs during generateBundle, before manifest output. Filenames use output filenames. */
+  /**
+   * Runs during generateBundle, before manifest output. Filenames use output
+   * filenames.
+   */
   renderCrxManifest?: (
     this: PluginContext,
     manifest: ManifestV3,
@@ -73,7 +79,6 @@ export interface CrxPlugin extends VitePlugin {
 }
 
 // change this to an interface when you want to add options
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface CrxOptions {
   contentScripts?: {
     preambleCode?: string | false
@@ -81,10 +86,17 @@ export interface CrxOptions {
     injectCss?: boolean
   }
   fastGlobOptions?: FastGlobOptions
+  /**
+   * The browser that this extension is targeting, can be "firefox" or "chrome".
+   * Default is "chrome".
+   */
+  browser?: Browser
 }
 
+export type Browser = 'firefox' | 'chrome'
+
 export interface CrxPluginFn {
-  (): CrxPlugin | CrxPlugin[]
+  (options?: CrxOptions): CrxPlugin | CrxPlugin[]
 }
 
 export type ManifestFiles = {


### PR DESCRIPTION
I wanted to be able to use this extension to create MV3 extensions for both Chrome and Firefox. They each implement MV3 a little differently; in particular:
- Firefox does not allow `use_dynamic_url` in `web_accessible_resources` because it the resource URLs in Firefox are always dynamic
- Firefox continues to use background pages instead of service workers

So I added a new config option called `browser` that can be either `"firefox"`  or `"chrome"`, and if it is `"firefox"`, then the emitted `manifest.json` will respect these differences so the extension can be loaded in Firefox. 

There are some parts that don't work very well yet -- in particular, hot module reloading does not work in Firefox because the service worker generated by this extension does not work as a background page. 