### PR TITLE
Add tip `type: module` to vue page

### DIFF
--- a/.changeset/eleven-buttons-dream.md
+++ b/.changeset/eleven-buttons-dream.md
@@ -1,0 +1,6 @@
+---
+"vite-plugin-docs": patch
+"@crxjs/vite-plugin": patch
+---
+
+Add tip `type: module` to vue page

--- a/packages/vite-plugin-docs/docs/getting-started/vue/00-create-project.md
+++ b/packages/vite-plugin-docs/docs/getting-started/vue/00-create-project.md
@@ -20,6 +20,13 @@ extension Vue HTML page. The first two sections take about 90 seconds!
 
 <CreateProjectTabs />
 
+:::tip package.json
+
+Check `package.json` to ensure that `"type": "module"` is set. If this package
+key is missing, Vite might not be able to build `vite.config.ts`.
+
+:::
+
 ## Update the Vite config
 
 Update `vite.config.js` to match the code below.


### PR DESCRIPTION
Add info regarding this bug: https://github.com/crxjs/chrome-extension-tools/issues/567