### PR TITLE
empty out dir before writing any files

### DIFF
--- a/packages/vite-plugin/src/node/fileWriter.ts
+++ b/packages/vite-plugin/src/node/fileWriter.ts
@@ -23,7 +23,7 @@ import { CrxDevAssetId, CrxDevScriptId, CrxPlugin } from './types'
 
 export { allFilesReady, fileReady }
 
-const { outputFile, remove } = fsx
+const { outputFile } = fsx
 
 const debug = _debug('file-writer')
 
@@ -60,7 +60,6 @@ export async function start({
     format: 'es',
   }
 
-  if (server.config.build.emptyOutDir) await remove(server.config.build.outDir)
   fileWriterEvent$.next({ type: 'build_start' })
   const build = await rollup(inputOptions)
   await build.write(outputOptions)


### PR DESCRIPTION
Empties the outdir as soon as possible, before copy plugins might start writing files