### PR TITLE
fix all_urls

### DIFF
--- a/.changeset/late-paws-change.md
+++ b/.changeset/late-paws-change.md
@@ -1,0 +1,5 @@
+---
+'rollup-plugin-chrome-extension': patch
+---
+
+Allows <all_urls> match in manifest.json within rollup package

--- a/packages/rollup-plugin/src/manifest-input/convertMatchPatterns.ts
+++ b/packages/rollup-plugin/src/manifest-input/convertMatchPatterns.ts
@@ -1,4 +1,5 @@
 export const convertMatchPatterns = (m: string): string => {
+  if (m === ('<all_urls>')) return m
   // Use URL to parse match pattern
   // URL must have valid url scheme
   const [scheme, rest] = m.split('://')


### PR DESCRIPTION
Currently the all_urls match pattern causes builds to fail. 

This is just a fix that was introduced for the vite plugin:
https://github.com/crxjs/chrome-extension-tools/issues/511
https://github.com/crxjs/chrome-extension-tools/pull/460