### PR TITLE
fix: schema of input_components

### DIFF
--- a/.changeset/wicked-moose-listen.md
+++ b/.changeset/wicked-moose-listen.md
@@ -1,0 +1,6 @@
+---
+"rollup-plugin-chrome-extension": patch
+"@crxjs/vite-plugin": patch
+---
+
+fix: schema of input_components

--- a/packages/rollup-plugin/schema/manifest-v3.schema.json
+++ b/packages/rollup-plugin/schema/manifest-v3.schema.json
@@ -472,22 +472,22 @@
       "items": {
         "additionalProperties": false,
         "properties": {
-          "description": {
+          "name": {
             "type": "string"
           },
           "id": {
             "type": "string"
           },
           "language": {
-            "type": "string"
+            "type": ["string", "array"]
           },
           "layouts": {
-            "type": "array"
+            "type": ["string", "array"]
           },
-          "name": {
+          "input_view": {
             "type": "string"
           },
-          "type": {
+          "options_page": {
             "type": "string"
           }
         },

--- a/packages/vite-plugin/src/node/manifest.ts
+++ b/packages/vite-plugin/src/node/manifest.ts
@@ -158,12 +158,12 @@ export interface ManifestV3 {
   incognito?: string | undefined
   input_components?:
     | {
-        name?: string | undefined
-        type?: string | undefined
+        name: string
         id?: string | undefined
-        description?: string | undefined
-        language?: string | undefined
-        layouts?: string[] | undefined
+        language?: string | string[] | undefined
+        layouts?: string | string[] | undefined
+        input_view?: string | undefined
+        options_page?: string | undefined
       }[]
     | undefined
   key?: string | undefined

--- a/schema/manifest-v3.schema.json
+++ b/schema/manifest-v3.schema.json
@@ -476,22 +476,22 @@
       "items": {
         "additionalProperties": false,
         "properties": {
-          "description": {
+          "name": {
             "type": "string"
           },
           "id": {
             "type": "string"
           },
           "language": {
-            "type": "string"
+            "type": ["string", "array"]
           },
           "layouts": {
-            "type": "array"
+            "type": ["string", "array"]
           },
-          "name": {
+          "input_view": {
             "type": "string"
           },
-          "type": {
+          "options_page": {
             "type": "string"
           }
         },


### PR DESCRIPTION
The current definition of input_components is outdated. Update them to match [the official document](https://developer.chrome.com/docs/extensions/mv3/manifest/input_components/). Only v3 is updated because I cannot find v2 document anymore.