### PR TITLE
fix: infinite recursion on circular dependency

### DIFF
--- a/.changeset/moody-ligers-exercise.md
+++ b/.changeset/moody-ligers-exercise.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+fix: infinite recursion on circular dependency

--- a/packages/vite-plugin/src/node/compileFileResources.ts
+++ b/packages/vite-plugin/src/node/compileFileResources.ts
@@ -26,14 +26,20 @@ export function compileFileResources(
     css: new Set(),
     imports: new Set(),
   },
+  processedFiles = new Set(),
 ): FileResources {
+  if (processedFiles.has(fileName)) {
+    return resources
+  }
+  processedFiles.add(fileName)
+
   const chunk = chunks.get(fileName)
   if (chunk) {
     const { modules, facadeModuleId, imports, dynamicImports } = chunk
     for (const x of imports) resources.imports.add(x)
     for (const x of dynamicImports) resources.imports.add(x)
     for (const x of [...imports, ...dynamicImports])
-      compileFileResources(x, { chunks, files, config }, resources)
+      compileFileResources(x, { chunks, files, config }, resources, processedFiles)
     for (const m of Object.keys(modules))
       if (m !== facadeModuleId) {
         const key = prefix('/', relative(config.root, m.split('?')[0]))
@@ -47,6 +53,7 @@ export function compileFileResources(
               script.fileName,
               { chunks, files, config },
               resources,
+              processedFiles,
             )
           }
       }


### PR DESCRIPTION
In order to handle the case of a circular dependency on js chunk, 
`compileFileResources` function has been modified to return immediately in the case of processed files.

[#719](https://github.com/crxjs/chrome-extension-tools/issues/719)