### PR TITLE
fix(package): update cjs export path

### DIFF
--- a/.changeset/eleven-planes-tease.md
+++ b/.changeset/eleven-planes-tease.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+fix(package): update cjs export path

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -26,7 +26,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "require": "./index.cjs",
+      "require": "./dist/index.cjs",
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.ts"
     },


### PR DESCRIPTION
Hi, I saw the CJS export path for the beta version of Vite plugin is broken.