### PR TITLE
Add declarativeNetRequestWithHostAccess

### DIFF
--- a/packages/rollup-plugin/schema/manifest-v3.schema.json
+++ b/packages/rollup-plugin/schema/manifest-v3.schema.json
@@ -115,6 +115,7 @@
           "declarativeContent",
           "declarativeNetRequest",
           "declarativeNetRequestFeedback",
+          "declarativeNetRequestWithHostAccess",
           "declarativeWebRequest",
           "desktopCapture",
           "documentScan",


### PR DESCRIPTION

This PR addresses the introduction of the `declarativeNetRequestWithHostAccess` permission in Chrome 96.

As per the recent changes in the Chrome Extensions Manifest V3, the `declarativeNetRequestWithHostAccess` permission has been introduced. However, this new permission was not defined in the permissions scheme.

This PR adds the `declarativeNetRequestWithHostAccess` permission to the scheme, ensuring that our extension's permissions align with the latest Chrome Extension Manifest V3 standards.

Please review and let me know if any changes are required.


https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/