### PR TITLE
docs: add missing extension install guide for react

### DIFF
--- a/packages/vite-plugin-docs/docs/getting-started/react/01-dev-basics.md
+++ b/packages/vite-plugin-docs/docs/getting-started/react/01-dev-basics.md
@@ -18,6 +18,9 @@ import Installing from '../\_install-extension.md';
 
 <Intro/>
 
+## Install the extension
+
+<Installing/>
 
 ## Opening the extension
 


### PR DESCRIPTION
as [reported in the discussion here](https://github.com/crxjs/chrome-extension-tools/discussions/709) - docs section "Development Basics with React" is missing the extension installation part. It exist for other libraries

Before:
<details>

![image](https://github.com/crxjs/chrome-extension-tools/assets/9840635/3a75b2e3-4079-4b8f-a3e5-1b38c9a8227a)


</details>

After:

<details>

![image](https://github.com/crxjs/chrome-extension-tools/assets/9840635/9172c198-6b2f-4741-bdee-cccdf9e2e9c0)

</details>
