### PR TITLE
fix: background scripts for firefox build

### DIFF
--- a/.changeset/fluffy-geckos-flash.md
+++ b/.changeset/fluffy-geckos-flash.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+fix: background scripts for firefox build

--- a/packages/vite-plugin/src/node/plugin-background.ts
+++ b/packages/vite-plugin/src/node/plugin-background.ts
@@ -108,6 +108,7 @@ export const pluginBackground: CrxPluginFn = () => {
         } else {
           manifest.background = {
             scripts: [this.getFileName(refId)],
+            type: 'module',
           }
         }
 

--- a/packages/vite-plugin/src/node/plugin-manifest.ts
+++ b/packages/vite-plugin/src/node/plugin-manifest.ts
@@ -239,6 +239,17 @@ export const pluginManifest: CrxPluginFn = () => {
             manifest.background.service_worker = refId
           }
 
+          if (manifest.background && 'scripts' in manifest.background) {
+            const file = manifest.background.scripts[0]
+            const id = join(config.root, file)
+            const refId = this.emitFile({
+              type: 'chunk',
+              id,
+              name: basename(file),
+            })
+            manifest.background.scripts = [refId]
+          }
+
           for (const file of htmlFiles(manifest)) {
             const id = join(config.root, file)
             this.emitFile({
@@ -276,6 +287,12 @@ export const pluginManifest: CrxPluginFn = () => {
             const ref = manifest.background.service_worker
             const name = this.getFileName(ref)
             manifest.background.service_worker = name
+          }
+
+          if (manifest.background && 'scripts' in manifest.background) {
+            const ref = manifest.background.scripts[0]
+            const name = this.getFileName(ref)
+            manifest.background.scripts = [name]
           }
 
           // update content script file names from refs


### PR DESCRIPTION
This is a follow up to https://github.com/crxjs/chrome-extension-tools/pull/776
I tried it out and the firefox build ignores background scripts, this PR fixes it