### PR TITLE
docs: added Vue use cases

### DIFF
--- a/packages/vite-plugin-docs/docs/getting-started/vue/02-add-content-script.md
+++ b/packages/vite-plugin-docs/docs/getting-started/vue/02-add-content-script.md
@@ -1,0 +1,121 @@
+---
+id: add-content-script
+title: Add a content script
+description: Add a Vue content script to an existing project
+tags:
+  - Content script
+  - Vue
+---
+
+import DefineContentScript from '../\_define-content-script.md'
+
+# Vue Content Scripts
+
+CRXJS brings an authentic Vite HMR experience to content scripts. Let's add a
+Vue content script to your Chrome Extension.
+
+<DefineContentScript/>
+
+## Add a content script
+
+We declare content scripts with a list of JavaScript files and match patterns
+for the pages where Chrome should execute our content script. In
+`manifest.json`, create the field `content_scripts` with an array of objects:
+
+```json title="manifest.json"
+{
+  // other fields...
+  "content_scripts": [
+    {
+      "js": ["src/content.js"],
+      "matches": ["https://www.google.com/*"]
+    }
+  ]
+}
+```
+
+Here we're telling Chrome to execute `src/content.js` on all pages that start
+with `https://www.google.com`.
+
+## Create the root element
+
+Content scripts don't use an HTML file, so we need to create our root element
+and append it to the DOM before mounting our Vue app.
+
+
+```js title=src/main.js
+import { createApp } from 'vue'
+import './style.css'
+import App from './App.vue'
+
+const app = createApp(App)
+// highlight-start
+// this element doesn't exist
+app.mount('#app')
+// highlight-end
+```
+
+Let's add that root element. Make a copy of `src/main.js` and name it
+`src/content.js`. Add the highlighted code.
+
+```js title=src/content.js
+import { createApp } from 'vue'
+import App from './App.vue'
+
+// highlight-start
+const root = document.createElement('div')
+root.id = 'crx-root'
+document.body.append(root)
+// highlight-end
+
+const app = createApp(App)
+// highlight-next-line
+app.mount(root)
+
+```
+
+## Get the right URL
+
+:::info
+
+<!-- Add link to Chrome Dev Docs -->
+
+Content scripts share the origin of the page where they run.
+
+:::
+
+The browser treats the imported value `logo` as a URL from the host page. If the
+content script is running on `https://google.com`, the following `img` tag will
+try to load from `https://google.com/src/assets/image.png`.
+
+```vue title=src/App.vue
+<script setup>
+import logo from './assets/image.png';
+
+</script>
+<img
+  // highlight-next-line 
+  :src="logo" 
+  className='App-logo' 
+  alt='logo' 
+/>
+
+```
+
+We need to get a URL with our extension id for static assets like images. Use
+the `getURL()` method to get the extension url for our logo:
+
+```vue title=src/App.vue
+<script setup>
+import logo from './assets/image.png';
+// highlight-next-line
+const logoUrl = chrome.runtime.getURL(logo);
+</script>
+
+<template>
+  <img :src="logoUrl" className='App-logo' alt='logo' />
+</template>
+```
+
+Now our content script is ready for action! Let's try it out in the next
+section.

--- a/packages/vite-plugin-docs/docs/getting-started/vue/03-dev-content-script.md
+++ b/packages/vite-plugin-docs/docs/getting-started/vue/03-dev-content-script.md
@@ -1,0 +1,68 @@
+---
+id: content-script-hmr
+title: Content script HMR
+description: Developing a Vue content script with Vite and CRXJS
+tags:
+  - Content script
+  - Vue
+# could point this to a TypeScript manifest guide
+pagination_next: concepts/manifest
+---
+
+# Vue and Content Scripts
+
+Make sure that your extension is [loaded in the browser](dev-basics) and that
+you've started Vite. Navigate to `https://www.google.com` and scroll to the
+bottom of the page.
+
+There's our familiar Vite-Vue Hello World!
+
+<!-- TODO: add screenshot of raw content script -->
+
+## Leaking CSS styles
+
+Notice how the counter button doesn't look like a button. That's because
+Google's styles affect our content script elements. The same goes the other way:
+our styles change Google's styles.
+
+:::tip
+
+The CSS of the host page will affect your content script, and the CSS of the
+content script will affect the host page.
+
+:::
+
+Let's fix that button. Replace everything in `src/style.css` with this:
+
+```css title="src/style.css"
+#crx-root {
+  position: fixed;
+  top: 3rem;
+  left: 50%;
+  transform: translate(-50%, 0);
+}
+
+#crx-root button {
+  background-color: rgb(239, 239, 239);
+  border-color: rgb(118, 118, 118);
+  border-image: initial;
+  border-style: outset;
+  border-width: 2px;
+  margin: 0;
+  padding: 1px 6px;
+}
+```
+
+CRXJS will quickly rebuild the content script, and our CSS changes will take
+effect.
+
+<!-- TODO: add screenshot of fixed content script -->
+
+Now our `div` position is fixed, and the button looks more like a button!
+
+## Vue Refresh in action
+
+CRXJS does some magic behind the scenes to get Vue Refresh working in content
+scripts.
+
+<!-- TODO: add more detailed instructions -->


### PR DESCRIPTION
I found that the documentation lacks information on how to use `content-script` of `vue`.