### PR TITLE
Proxy Cache-Control header

### DIFF
--- a/.changeset/chatty-teachers-compare.md
+++ b/.changeset/chatty-teachers-compare.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+Proxy Cache-Control header

--- a/packages/vite-plugin/src/client/es/hmr-client-worker.ts
+++ b/packages/vite-plugin/src/client/es/hmr-client-worker.ts
@@ -46,6 +46,7 @@ async function sendToServer(url: URL): Promise<Response> {
   return new Response(response.body, {
     headers: {
       'Content-Type': response.headers.get('Content-Type') ?? 'text/javascript',
+      'Cache-Control': response.headers.get('Cache-Control') ?? '',
     },
   })
 }


### PR DESCRIPTION
I was running into an issue where refreshing an extension page would load stale code.

This happened because without the cache-control header, refreshing would use the cached version of index.html. Vite already sets the header appropriately, so we just need to pass it down through the service worker.