### PR TITLE
fix: usage of `a deprecated Node.js version` in CI

### DIFF
--- a/.changeset/sour-teachers-learn.md
+++ b/.changeset/sour-teachers-learn.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+fix: usage of `a deprecated Node.js version` in CI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@ jobs:
     environment: production
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "16"
 
@@ -34,7 +34,7 @@ jobs:
           # run_install: true
 
       - name: Cache pnpm modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-pnpm-modules
         with:


### PR DESCRIPTION
Fixes #948