### PR TITLE
fix: cjs require file

### DIFF
--- a/.changeset/calm-lies-argue.md
+++ b/.changeset/calm-lies-argue.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+fix: cjs require file

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -35,14 +35,13 @@
       "types": "./client.d.ts"
     }
   },
-  "main": "/index.cjs",
+  "main": "index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
     "types",
     "manifest.schema.json",
-    "schema",
     "index.cjs",
     "client.d.ts"
   ],

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -26,7 +26,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "require": "./dist/index.cjs",
+      "require": "./index.cjs",
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.ts"
     },
@@ -35,7 +35,7 @@
       "types": "./client.d.ts"
     }
   },
-  "main": "dist/index.cjs",
+  "main": "/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "files": [
@@ -43,6 +43,7 @@
     "types",
     "manifest.schema.json",
     "schema",
+    "index.cjs",
     "client.d.ts"
   ],
   "scripts": {


### PR DESCRIPTION
https://github.com/crxjs/chrome-extension-tools/issues/939
https://github.com/crxjs/chrome-extension-tools/issues/758

Support CommonJS. 
Under CommonJS, the old `index.cjs` configured in the project's `package.json` does not contain all methods. Modify the required configuration file to support CommonJS.