### PR TITLE
Add Maintenance Status Notifications

### DIFF
--- a/.changeset/modern-drinks-retire.md
+++ b/.changeset/modern-drinks-retire.md
@@ -1,0 +1,7 @@
+---
+"rollup-plugin-chrome-extension": patch
+"vite-plugin-docs": patch
+"@crxjs/vite-plugin": patch
+---
+
+Add project status announcements

--- a/.github/workflows/status-notice.yml
+++ b/.github/workflows/status-notice.yml
@@ -1,0 +1,72 @@
+name: 'Maintenance Status Notice'
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  add-notice:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const message = `⚠️ **Important Notice:** CRXJS is currently seeking new maintainers. 
+
+            - New issues and PRs may not receive immediate attention
+            - If no maintenance team is established by March 31, 2025, this repository will be archived on June 1, 2025
+            - [Learn more about the transition](https://github.com/crxjs/chrome-extension-tools/discussions/974)
+
+            ---
+            *This is an automated message. Please do not reply to this comment.*`;
+            
+            async function hasExistingNotice(comments) {
+              const botLogin = 'github-actions[bot]';
+              return comments.data.some(comment => 
+                comment.user.login === botLogin && 
+                comment.body.includes('Important Notice: CRXJS is currently seeking new maintainers')
+              );
+            }
+            
+            try {
+              let commentList;
+              let issueNumber;
+              
+              // Determine context and get issue/PR number
+              if (context.eventName === 'issues' || context.eventName === 'issue_comment') {
+                issueNumber = context.issue.number;
+                commentList = await github.rest.issues.listComments({
+                  owner: context.repo.owner,
+                  repo: context.repo.name,
+                  issue_number: issueNumber
+                });
+              } else {
+                issueNumber = context.payload.pull_request.number;
+                commentList = await github.rest.issues.listComments({
+                  owner: context.repo.owner,
+                  repo: context.repo.name,
+                  issue_number: issueNumber
+                });
+              }
+              
+              // Only post if no existing notice found
+              if (!await hasExistingNotice(commentList)) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.name,
+                  issue_number: issueNumber,
+                  body: message
+                });
+              }
+            } catch (error) {
+              console.error('Error in Maintenance Notice Action:', error);
+            }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# ![CRXJS](./banner-github.png)
-
 > [!IMPORTANT]
 > CRXJS is seeking new maintainers. If no maintenance team is established by March 31, 2025, this repository will be archived. [Learn more](https://github.com/crxjs/chrome-extension-tools/discussions/974).
+
+# ![CRXJS](./banner-github.png)
 
 ## What is CRXJS?
 

--- a/packages/rollup-plugin/README.md
+++ b/packages/rollup-plugin/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> CRXJS is seeking new maintainers. If no maintenance team is established by March 31, 2025, this repository will be archived. [Learn more](https://github.com/crxjs/chrome-extension-tools/discussions/974).
+
 # [rollup-plugin-chrome-extension](https://www.extend-chrome.dev/rollup-plugin)
 
 [![npm (scoped)](https://img.shields.io/npm/v/rollup-plugin-chrome-extension.svg)](https://www.npmjs.com/package/rollup-plugin-chrome-extension)

--- a/packages/vite-plugin-docs/README.md
+++ b/packages/vite-plugin-docs/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> CRXJS is seeking new maintainers. If no maintenance team is established by March 31, 2025, this repository will be archived. [Learn more](https://github.com/crxjs/chrome-extension-tools/discussions/974).
+
 # CRXJS Vite Plugin Docs
 
 This website is built using [Docusaurus 2](https://docusaurus.io/), a modern

--- a/packages/vite-plugin-docs/docusaurus.config.js
+++ b/packages/vite-plugin-docs/docusaurus.config.js
@@ -22,6 +22,11 @@ const config = {
     locales: ['en'],
   },
 
+  // Add custom scripts to inject the banner
+  customFields: {
+    maintenanceBanner: true,
+  },
+
   presets: [
     [
       'classic',
@@ -34,7 +39,9 @@ const config = {
             'https://github.com/crxjs/chrome-extension-tools/tree/main/packages/vite-plugin-docs/',
         },
         theme: {
-          customCss: require.resolve('./src/css/custom.css'),
+          customCss: [
+            require.resolve('./src/css/custom.css'),
+          ],
         },
         blog: false,
       }),
@@ -76,48 +83,6 @@ const config = {
       },
       footer: {
         style: 'dark',
-        // Add these later: GitHub, Discord, Community (GH Discussions)
-        // links: [
-        //   {
-        //     title: 'Docs',
-        //     items: [
-        //       {
-        //         label: 'Tutorial',
-        //         to: '/docs/intro',
-        //       },
-        //     ],
-        //   },
-        //   {
-        //     title: 'Community',
-        //     items: [
-        //       {
-        //         label: 'Stack Overflow',
-        //         href: 'https://stackoverflow.com/questions/tagged/docusaurus',
-        //       },
-        //       {
-        //         label: 'Discord',
-        //         href: 'https://discordapp.com/invite/docusaurus',
-        //       },
-        //       {
-        //         label: 'Twitter',
-        //         href: 'https://twitter.com/docusaurus',
-        //       },
-        //     ],
-        //   },
-        //   {
-        //     title: 'More',
-        //     items: [
-        //       {
-        //         label: 'Blog',
-        //         to: '/blog',
-        //       },
-        //       {
-        //         label: 'GitHub',
-        //         href: 'https://github.com/facebook/docusaurus',
-        //       },
-        //     ],
-        //   },
-        // ],
         copyright: `Copyright © ${new Date().getFullYear()} CRXJS`,
       },
       prism: {

--- a/packages/vite-plugin-docs/src/components/MaintenanceBanner/index.tsx
+++ b/packages/vite-plugin-docs/src/components/MaintenanceBanner/index.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import styles from './styles.module.css'
+
+export default function MaintenanceBanner() {
+  return (
+    <div className={styles.banner}>
+      <div className={styles.bannerContent}>
+        ⚠️ CRXJS is seeking new maintainers. If no maintenance team is
+        established by March 31, 2025, this repository will be archived.{' '}
+        <a href='https://github.com/crxjs/chrome-extension-tools/discussions/974'>
+          Learn more
+        </a>
+      </div>
+    </div>
+  )
+}

--- a/packages/vite-plugin-docs/src/components/MaintenanceBanner/styles.module.css
+++ b/packages/vite-plugin-docs/src/components/MaintenanceBanner/styles.module.css
@@ -1,0 +1,28 @@
+.banner {
+  width: 100%;
+  background-color: #fff3cd;
+  color: #856404;
+  border-bottom: 1px solid #ffeeba;
+  padding: 0.75rem 1.25rem;
+  text-align: center;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.bannerContent {
+  max-width: 1320px;
+  margin: 0 auto;
+}
+
+.banner a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+/* Dark mode styles */
+[data-theme='dark'] .banner {
+  background-color: #352c1a;
+  color: #ffe69c;
+  border-bottom-color: #665328;
+}

--- a/packages/vite-plugin-docs/src/theme/Root.tsx
+++ b/packages/vite-plugin-docs/src/theme/Root.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import MaintenanceBanner from '@site/src/components/MaintenanceBanner';
+
+// Default implementation, that you can customize
+export default function Root({children}) {
+  return (
+    <>
+      <MaintenanceBanner />
+      {children}
+    </>
+  );
+}

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -1,11 +1,11 @@
+> [!IMPORTANT]
+> CRXJS is seeking new maintainers. If no maintenance team is established by March 31, 2025, this repository will be archived. [Learn more](https://github.com/crxjs/chrome-extension-tools/discussions/974).
+
 # ![CRXJS](./banner-github.png)
 
 [![npm (scoped)](https://img.shields.io/npm/v/@crxjs/vite-plugin.svg)](https://www.npmjs.com/package/@crxjs/vite-plugin)
 [![GitHub last commit](https://img.shields.io/github/last-commit/crxjs/chrome-extension-tools.svg?logo=github)](https://github.com/crxjs/rollup-plugin-chrome-extension)
 ![GitHub action badge](https://github.com/crxjs/chrome-extension-tools/actions/workflows/vite-plugin.yml/badge.svg)
-
-> [!IMPORTANT]
-> CRXJS is seeking new maintainers. If no maintenance team is established by March 31, 2025, this repository will be archived. [Learn more](https://github.com/crxjs/chrome-extension-tools/discussions/974).
 
 ## CRXJS Vite Plugin
 

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -4,6 +4,9 @@
 [![GitHub last commit](https://img.shields.io/github/last-commit/crxjs/chrome-extension-tools.svg?logo=github)](https://github.com/crxjs/rollup-plugin-chrome-extension)
 ![GitHub action badge](https://github.com/crxjs/chrome-extension-tools/actions/workflows/vite-plugin.yml/badge.svg)
 
+> [!IMPORTANT]
+> CRXJS is seeking new maintainers. If no maintenance team is established by March 31, 2025, this repository will be archived. [Learn more](https://github.com/crxjs/chrome-extension-tools/discussions/974).
+
 ## CRXJS Vite Plugin
 
 > Build a Chrome Extension with [Vite](https://vitejs.dev)⚡


### PR DESCRIPTION
# Add Maintenance Status Notifications

This PR implements maintenance status notifications across the CRXJS project to inform users about the search for new maintainers and potential archival date.

## Changes

### GitHub Workflows
- Added new `status-notice.yml` workflow that automatically adds maintenance notices to:
  - New issues
  - New pull requests
  - New comments on issues
  - New comments on pull requests
- Implemented duplicate detection to prevent multiple notices on the same issue/PR
- Added error handling and logging for the GitHub Actions workflow
- Added appropriate permissions for issues and pull requests

### Documentation Updates
- Added maintenance notice banner to all README files:
  - Root repository
  - Rollup plugin package
  - Vite plugin package
  - Vite plugin documentation
- Repositioned root README banner for better visibility

### Documentation Site
- Added new `MaintenanceBanner` component with:
  - Responsive design
  - Dark mode support
  - Sticky positioning for persistent visibility
- Modified Docusaurus configuration to:
  - Include the maintenance banner component
  - Add custom fields for banner control
  - Update theme configuration
- Added banner styling with appropriate color schemes for both light and dark modes

## Testing Checklist

- [ ] Verify GitHub Action triggers on new issues
- [ ] Verify GitHub Action triggers on new pull requests
- [ ] Confirm duplicate notices are prevented
- [ ] Test documentation site banner in both light and dark mode
- [ ] Verify all README banners are properly displayed

## Screenshots

Please add screenshots of:
- The documentation site banner in both light and dark mode
- A GitHub issue with the automated notice
- The README banner display