### PR TITLE
Propagate headers in hmr-client-worker.ts/sendToServer

### DIFF
--- a/.changeset/great-fishes-remember.md
+++ b/.changeset/great-fishes-remember.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+Propagate headers in hmr-client-worker.ts/sendToServer


### PR DESCRIPTION
Fixes #909 

crxjs vite plugins client worker currently doesn't propagate headers.

https://github.com/crxjs/chrome-extension-tools/blob/a6d882a5091da474ffcfde815c53bf4eda19b6a6/packages/vite-plugin/src/client/es/hmr-client-worker.ts#L24

^ Request headers are lost immideately.

https://github.com/crxjs/chrome-extension-tools/blob/a6d882a5091da474ffcfde815c53bf4eda19b6a6/packages/vite-plugin/src/client/es/hmr-client-worker.ts#L47-L49


For some reason response headers are also omitted.