### PR TITLE
fix: do not use IIFE for contents scripts without imports

### DIFF
--- a/packages/vite-plugin/src/node/plugin-contentScripts.ts
+++ b/packages/vite-plugin/src/node/plugin-contentScripts.ts
@@ -135,7 +135,7 @@ export const pluginContentScripts: CrxPluginFn = () => {
           },
         }
       },
-      generateBundle() {
+      generateBundle(_options, bundle) {
         // emit content script loaders
         for (const [key, script] of contentScripts)
           if (key === script.refId) {
@@ -145,12 +145,28 @@ export const pluginContentScripts: CrxPluginFn = () => {
             } else if (script.type === 'loader') {
               const fileName = this.getFileName(script.refId)
               script.fileName = fileName
-              const refId = this.emitFile({
-                type: 'asset',
-                name: getFileName({ type: 'loader', id: basename(script.id) }),
-                source: createProLoader({ fileName }),
-              })
-              script.loaderName = this.getFileName(refId)
+
+              const bundleFileInfo = bundle[fileName]
+              // the loader uses IIFE which in this case needlessly
+              // delays content script execution which may not be desired
+              const shouldUseLoader = !(
+                bundleFileInfo.type === 'chunk' &&
+                bundleFileInfo.imports.length === 0 &&
+                bundleFileInfo.dynamicImports.length === 0
+              )
+
+              if (shouldUseLoader) {
+                const refId = this.emitFile({
+                  type: 'asset',
+                  name: getFileName({
+                    type: 'loader',
+                    id: basename(script.id),
+                  }),
+                  source: createProLoader({ fileName }),
+                })
+
+                script.loaderName = this.getFileName(refId)
+              }
             } else if (script.type === 'iife') {
               throw new Error('IIFE content scripts are not implemented')
             }


### PR DESCRIPTION
Motivation: wrapping in IIFE may delay script injection, which is a needless tradeoff if the script has no (ES module) imports

inspired by https://github.com/samrum/vite-plugin-web-extension/blob/main/src/utils/loader.ts#L57-L66