### PR TITLE
Bug/back forward cache

### DIFF
--- a/.changeset/poor-houses-smoke.md
+++ b/.changeset/poor-houses-smoke.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+Bug/back forward cache

--- a/packages/vite-plugin/src/client/es/hmr-client-worker.ts
+++ b/packages/vite-plugin/src/client/es/hmr-client-worker.ts
@@ -69,7 +69,7 @@ chrome.runtime.onConnect.addListener((port) => {
     ports.add(port)
     port.onDisconnect.addListener((port) => {
       if (chrome.runtime.lastError) {
-        console.log(chrome.runtime.lastError)
+        console.error(chrome.runtime.lastError)
       }
       ports.delete(port)
     })

--- a/packages/vite-plugin/src/client/es/hmr-client-worker.ts
+++ b/packages/vite-plugin/src/client/es/hmr-client-worker.ts
@@ -67,7 +67,12 @@ const ports = new Set<chrome.runtime.Port>()
 chrome.runtime.onConnect.addListener((port) => {
   if (port.name === '@crx/client') {
     ports.add(port)
-    port.onDisconnect.addListener((port) => ports.delete(port))
+    port.onDisconnect.addListener((port) => {
+      if (chrome.runtime.lastError) {
+        console.log(chrome.runtime.lastError)
+      }
+      ports.delete(port)
+    })
     port.onMessage.addListener((message: string) => {
       // console.log(
       //   `${JSON.stringify(message, null, 2)} from ${port.sender?.origin}`,


### PR DESCRIPTION
This PR is to silence this error:
> Unchecked runtime.lastError: The page keeping the extension port is moved into back/forward cache, so the message channel is closed.

Happens when you are using ports and navigate away / back.