### PR TITLE
fix: make HMR working again with latest vite version

### DIFF
--- a/.changeset/blue-sheep-enjoy.md
+++ b/.changeset/blue-sheep-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+fix: make HMR working again with latest vite version

--- a/packages/vite-plugin/src/client/es/hmr-client-worker.ts
+++ b/packages/vite-plugin/src/client/es/hmr-client-worker.ts
@@ -10,6 +10,7 @@ import type { HMRPayload } from 'vite'
 // injected by the hmr plugin when served
 declare const __BASE__: string
 declare const __HMR_PROTOCOL__: string
+declare const __HMR_TOKEN__: string
 declare const __HMR_HOSTNAME__: string
 declare const __HMR_PORT__: string
 declare const __HMR_TIMEOUT__: number
@@ -94,8 +95,9 @@ console.log('[vite] connecting...')
 // use server configuration, then fallback to inference
 const socketProtocol =
   __HMR_PROTOCOL__ || (location.protocol === 'https:' ? 'wss' : 'ws')
+const socketToken = __HMR_TOKEN__;
 const socketHost = `${__HMR_HOSTNAME__ || location.hostname}:${__HMR_PORT__}`
-const socket = new WebSocket(`${socketProtocol}://${socketHost}`, 'vite-hmr')
+const socket = new WebSocket(`${socketProtocol}://${socketHost}?token=${socketToken}`, 'vite-hmr')
 const base = __BASE__ || '/'
 
 // Listen for messages

--- a/packages/vite-plugin/src/node/defineClientValues.ts
+++ b/packages/vite-plugin/src/node/defineClientValues.ts
@@ -1,8 +1,8 @@
-import { ResolvedConfig } from 'vite'
+import { ResolvedConfigWithHMRToken } from './types'
 import { isObject } from './helpers'
 import { join, normalize } from './path'
 
-export function defineClientValues(code: string, config: ResolvedConfig) {
+export function defineClientValues(code: string, config: ResolvedConfigWithHMRToken) {
   let options = config.server.hmr
   options = options && typeof options !== 'boolean' ? options : {}
   const host = options.host || null
@@ -30,6 +30,8 @@ export function defineClientValues(code: string, config: ResolvedConfig) {
     .replace(`__MODE__`, JSON.stringify(config.mode))
     .replace(`__BASE__`, JSON.stringify(config.base))
     .replace(`__DEFINES__`, serializeDefine(config.define || {}))
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .replace(`__HMR_TOKEN__`, JSON.stringify(config.webSocketToken || ""))
     .replace(`__HMR_PROTOCOL__`, JSON.stringify(protocol))
     .replace(`__HMR_HOSTNAME__`, JSON.stringify(host))
     .replace(`__HMR_PORT__`, JSON.stringify(hmrPort))

--- a/packages/vite-plugin/src/node/types.ts
+++ b/packages/vite-plugin/src/node/types.ts
@@ -1,7 +1,7 @@
 import type { Node as AcornNode } from 'acorn'
 import type { Options as FastGlobOptions } from 'fast-glob'
 import type { OutputBundle, PluginContext } from 'rollup'
-import type { HMRPayload, Plugin as VitePlugin } from 'vite'
+import type { HMRPayload, ResolvedConfig, Plugin as VitePlugin } from 'vite'
 import { ManifestV3 } from './manifest'
 
 export interface AcornLiteral extends AcornNode {
@@ -125,3 +125,7 @@ export type CrxHMRPayload =
       event: 'crx:content-script-payload'
       data: HMRPayload
     }
+
+export interface ResolvedConfigWithHMRToken extends ResolvedConfig {
+  webSocketToken?: string
+}


### PR DESCRIPTION
Fixing HMR with latest version of the Vite (`>=6.0.9`, `>=5.4.12, <6.0.0`, `>=4.5.6, <5.0.0`) - passing web socket token.

Changes based on comment from vite dev (https://github.com/crxjs/chrome-extension-tools/issues/971#issuecomment-2608871639) -  passing `config.webSocketToken` to `hmr-client-worker.ts` under the key `__HMR_TOKEN__`.

Closes #971 