### PR TITLE
docs(vite-plugin): reorder some docs in the Getting Started with React

### DIFF
--- a/packages/vite-plugin-docs/docs/getting-started/react/00-create-project.md
+++ b/packages/vite-plugin-docs/docs/getting-started/react/00-create-project.md
@@ -33,6 +33,19 @@ key is missing, Vite might not be able to build `vite.config.js`.
 npm install --save-dev @crxjs/vite-plugin@beta
 ```
 
+## Create a web extension manifest
+
+Create a file named `manifest.json` next to `vite.config.js`.
+
+```json title=manifest.json
+{
+  "manifest_version": 3,
+  "name": "CRXJS React Vite Example",
+  "version": "1.0.0",
+  "action": { "default_popup": "index.html" }
+}
+```
+
 ## Update the Vite config
 
 Update `vite.config.js` to match the code below.
@@ -52,17 +65,6 @@ export default defineConfig({
     crx({ manifest }),
   ],
 })
-```
-
-Create a file named `manifest.json` next to `vite.config.js`.
-
-```json title=manifest.json
-{
-  "manifest_version": 3,
-  "name": "CRXJS React Vite Example",
-  "version": "1.0.0",
-  "action": { "default_popup": "index.html" }
-}
 ```
 
 ## First development build


### PR DESCRIPTION
## Description

as a consumer of the "getting started with react" vite plugin docs, it can be confusing to see references to a file in the setup process that is not yet created or available to import.

maybe we can assert that users should create the manifest file _before_ instructing them to reference a manifest file in their Vite config?

## Screenshots 

| before | after |
| ---- | --- |
| <img width="1411" alt="Screenshot 2025-05-18 at 4 10 48 PM" src="https://github.com/user-attachments/assets/800ba5d3-5bdf-408a-91e4-ca197875b81d" /> |  <img width="1411" alt="Screenshot 2025-05-18 at 4 10 24 PM" src="https://github.com/user-attachments/assets/47eb4a76-8b71-4782-8e9f-d0557b3f8651" />|
