### PR TITLE
docs: remove beta tags and clean up Vite version UI (#991)

### DIFF
--- a/packages/vite-plugin-docs/docs/getting-started/_create-project-tabs.mdx
+++ b/packages/vite-plugin-docs/docs/getting-started/_create-project-tabs.mdx
@@ -1,26 +1,20 @@
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import Admonition from '@theme/Admonition';
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+import Admonition from '@theme/Admonition'
 
-export  const CreateProjectTabs = ({ projectType }) => 
-    <>
-      <p>Use your favorite package manager to scaffold a new project and follow the prompts to create a {projectType} project.</p>
-      <Tabs groupId='vite-version'>
-        <TabItem value='vite2' label='Vite 2' default>
-          <pre>
-            <code>npm init vite@^2.9.4</code>
-          </pre>
-        </TabItem>
-        <TabItem value='vite3' label='Vite 3 (beta)'>
-          <pre>
-            <code>npm init vite@latest</code>
-          </pre>
-          <Admonition type="info" title="beta">
-            CRXJS support for Vite 3 is in beta.
-          </Admonition>
-          <Admonition type="info" title="React Users">
-            HMR in CRXJS is incompatible with <code>@vite/plugin-react-swc</code>. We recommend using <code>@vitejs/plugin-react</code> instead.
-          </Admonition>
-        </TabItem>
-      </Tabs>
-    </>
+export const CreateProjectTabs = ({ projectType }) => (
+  <>
+    <p>
+      Use your favorite package manager to scaffold a new project and follow the
+      prompts to create a {projectType} project.
+    </p>
+    <pre>
+      <code>npm create vite@latest</code>
+    </pre>
+    <Admonition type='info' title='Compatibility'>
+      CRXJS supports Vite 3 and above. For React users, HMR in CRXJS is
+      incompatible with <code>@vite/plugin-react-swc</code>. We recommend using{' '}
+      <code>@vitejs/plugin-react</code> instead.
+    </Admonition>
+  </>
+)

--- a/packages/vite-plugin-docs/docs/getting-started/react/00-create-project.md
+++ b/packages/vite-plugin-docs/docs/getting-started/react/00-create-project.md
@@ -23,14 +23,14 @@ extension React HTML page. The first two sections take about 90 seconds!
 :::tip package.json
 
 Check `package.json` to ensure that `"type": "module"` is set. If this package
-key is missing, Vite might not be able to build `vite.config.js`. 
+key is missing, Vite might not be able to build `vite.config.js`.
 
 :::
 
 ## Install CRXJS
 
 ```sh
-npm install --save-dev @crxjs/vite-plugin@beta
+npm install --save-dev @crxjs/vite-plugin
 ```
 
 ## Create a web extension manifest

--- a/packages/vite-plugin-docs/docs/getting-started/solid/00-create-project.md
+++ b/packages/vite-plugin-docs/docs/getting-started/solid/00-create-project.md
@@ -45,7 +45,7 @@ key is missing, Vite might not be able to build `vite.config.ts`.
 Now install the CRXJS Vite plugin using your favorite package manager.
 
 ```sh
-npm i @crxjs/vite-plugin@beta -D
+npm i @crxjs/vite-plugin -D
 ```
 
 The official SolidJS templates use Vite 3, but CRXJS support for Vite 3 is

--- a/packages/vite-plugin-docs/docs/getting-started/solid/00-create-project.md
+++ b/packages/vite-plugin-docs/docs/getting-started/solid/00-create-project.md
@@ -48,8 +48,7 @@ Now install the CRXJS Vite plugin using your favorite package manager.
 npm i @crxjs/vite-plugin -D
 ```
 
-The official SolidJS templates use Vite 3, but CRXJS support for Vite 3 is
-currently in beta.
+The official SolidJS templates use Vite 3, which is fully supported by CRXJS.
 
 ## Update the Vite config
 

--- a/packages/vite-plugin-docs/docs/getting-started/vanilla-js/00-create-project.md
+++ b/packages/vite-plugin-docs/docs/getting-started/vanilla-js/00-create-project.md
@@ -39,7 +39,7 @@ key is missing, Vite might not be able to build `vite.config.js`.
 ## Install CRXJS
 
 ```sh
-npm install --save-dev @crxjs/vite-plugin@beta
+npm install --save-dev @crxjs/vite-plugin
 ```
 
 ## Create a Vite config file

--- a/packages/vite-plugin-docs/docs/getting-started/vue/00-create-project.md
+++ b/packages/vite-plugin-docs/docs/getting-started/vue/00-create-project.md
@@ -23,14 +23,14 @@ extension Vue HTML page. The first two sections take about 90 seconds!
 :::tip package.json
 
 Check `package.json` to ensure that `"type": "module"` is set. If this package
-key is missing, Vite might not be able to build `vite.config.js`. 
+key is missing, Vite might not be able to build `vite.config.js`.
 
 :::
 
 ## Install CRXJS
 
 ```sh
-npm install --save-dev @crxjs/vite-plugin@beta
+npm install --save-dev @crxjs/vite-plugin
 ```
 
 ## Update the Vite config


### PR DESCRIPTION
## Remove beta tags and clean up documentation UI

This PR addresses issue #991 by removing beta tags from the @crxjs/vite-plugin
installation instructions and cleaning up the documentation UI.

### Changes Made

#### 1. Remove @beta tags from installation instructions

Updated all framework getting-started guides to install the stable version:

- `packages/vite-plugin-docs/docs/getting-started/react/00-create-project.md`
- `packages/vite-plugin-docs/docs/getting-started/vue/00-create-project.md`
- `packages/vite-plugin-docs/docs/getting-started/vanilla-js/00-create-project.md`
- `packages/vite-plugin-docs/docs/getting-started/solid/00-create-project.md`

**Before:**

```sh
npm install --save-dev @crxjs/vite-plugin@beta
```

**After:**

```sh
npm install --save-dev @crxjs/vite-plugin
```

#### 2. Remove Vite version 2/3 widget

Simplified the project creation flow by removing the confusing version toggle:

- `packages/vite-plugin-docs/docs/getting-started/_create-project-tabs.mdx`

**Before:**

- Tabs showing separate instructions for Vite 2 and Vite 3 (beta)
- Different commands for each version
- Beta warnings for Vite 3

**After:**

- Single, clear command: `npm create vite@latest`
- Clean compatibility note stating "CRXJS supports Vite 3 and above"
- Maintained important React compatibility information

#### 3. Update Solid documentation

Removed outdated beta reference:

- `packages/vite-plugin-docs/docs/getting-started/solid/00-create-project.md`

**Before:**

> The official SolidJS templates use Vite 3, but CRXJS support for Vite 3 is
> currently in beta.

**After:**

> The official SolidJS templates use Vite 3, which is fully supported by CRXJS.

### Summary

These changes reflect the stable status of @crxjs/vite-plugin and provide a
cleaner, more straightforward documentation experience. Users now see a single,
clear installation path without confusing version toggles or beta warnings.
