### PR TITLE
chore: update playwright-chromium (chrome 136)

### DIFF
--- a/packages/rollup-plugin/__tests__/e2e__mv3-playwright.test.ts
+++ b/packages/rollup-plugin/__tests__/e2e__mv3-playwright.test.ts
@@ -22,7 +22,11 @@ beforeAll(async () => {
   browserContext = (await chromium.launchPersistentContext(dataDirPath, {
     headless: false,
     slowMo: 100,
-    args: [`--disable-extensions-except=${distDirPath}`, `--load-extension=${distDirPath}`],
+    args: [
+      `--disable-extensions-except=${distDirPath}`,
+      `--load-extension=${distDirPath}`,
+      '--disable-features=ExtensionDisableUnsupportedDeveloper',
+    ],
   })) as ChromiumBrowserContext
 }, 60000)
 

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -56,7 +56,7 @@
     "localforage": "^1.9.0",
     "lodash": "^4.17.21",
     "mem": "^6.0.1",
-    "playwright-chromium": "1.33.0",
+    "playwright-chromium": "1.52.0",
     "rollup": "^2.79.2",
     "slash": "^3.0.0",
     "webextension-polyfill": "^0.9.0"

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -109,7 +109,7 @@
     "eslint-plugin-react": "^7.29.4",
     "jest-image-snapshot": "^5.2.0",
     "npm-run-all": "^4.1.5",
-    "playwright-chromium": "1.33.0",
+    "playwright-chromium": "1.52.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "rimraf": "3.0.2",

--- a/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/manifest.json
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/manifest.json
@@ -3,7 +3,6 @@
   "manifest_version": 3,
   "name": "test extension",
   "background": { "service_worker": "src/background.ts" },
-  "options_page": "src/options.html",
   "version": "1.0.0",
   "host_permissions": ["<all_urls>"],
   "permissions": ["scripting"]

--- a/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/src1/background.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/src1/background.ts
@@ -1,11 +1,25 @@
 import contentScript from './content?script'
 
-chrome.runtime.onInstalled.addListener(({ reason }) => {
+// This fixes `self`'s type.
+declare const self: ServiceWorkerGlobalScope
+export { }
+
+chrome.runtime.onInstalled.addListener(async ({ reason }) => {
   if (reason === 'install') {
+    await self.skipWaiting()
+    await new Promise((r) => setTimeout(r, 100))
+
     chrome.scripting
       .registerContentScripts([
         { id: 'contentScript', js: [contentScript], matches: ['<all_urls>'] },
       ])
       .catch(console.error)
+      .then(() => {
+        console.log('Content script registered successfully.')
+        
+        chrome.tabs.create({
+          url: 'https://example.com'
+        }).catch(console.error);
+      })
   }
 })

--- a/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/vite-serve.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra'
 import path from 'pathe'
 import { expect, test } from 'vitest'
-import { createUpdate, waitForInnerHtml } from '../helpers'
+import { createUpdate, getPage, waitForInnerHtml } from '../helpers'
 import { serve } from '../runners'
 import { header } from './src2/header'
 
@@ -17,9 +17,8 @@ test(
 
     const { browser, routes } = await serve(__dirname)
 
-    const page = await browser.newPage()
     const update = createUpdate({ target: src, src: src2 })
-    await page.goto('https://example.com')
+    const page = await getPage(browser, 'example.com')
 
     const app = page.locator('#app')
     await app.waitFor({ timeout: 15_000 })

--- a/packages/vite-plugin/tests/e2e/mv3-vite-vanilla-content-script-hmr/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-vanilla-content-script-hmr/vite-serve.test.ts
@@ -47,14 +47,17 @@ test.skipIf(process.env.CI)('crx page update on hmr', async () => {
   expect(reloads).toBeGreaterThanOrEqual(1) // full reload on jsx update
   expect(optionsPage.isClosed()).toBe(false) // no runtime reload on js update
 
-  // update background.ts file -> trigger runtime reload
-  await Promise.all([
-    optionsPage.waitForEvent('close', { timeout: 5000 }),
-    firstValueFrom(routes),
-    update('bg-onload.ts'),
-  ])
 
-  await app.waitFor()
+  // update background.ts file -> trigger runtime reload
+  const closeEvent= optionsPage.waitForEvent('close', { timeout: 5000 })
+  await update('bg-onload.ts')
+  await firstValueFrom(routes)
+  await closeEvent;
+  
+
+
+  expect(reloads).toBeGreaterThanOrEqual(2) // full reload on background script update
+  await app.waitFor({ timeout: 15_000 })
 
   expect(optionsPage.isClosed()).toBe(true)
 })

--- a/packages/vite-plugin/tests/e2e/runners.ts
+++ b/packages/vite-plugin/tests/e2e/runners.ts
@@ -10,6 +10,7 @@ const chromiumArgs = (outDir: string) => {
   const args = [
     `--disable-extensions-except=${outDir}`,
     `--load-extension=${outDir}`,
+    '--disable-features=ExtensionDisableUnsupportedDeveloper',
   ]
   // run headless if not in debug mode
   if (typeof process.env.DEBUG === 'undefined') args.unshift(`--headless=new`)

--- a/packages/vite-plugin/tests/e2e/runners.ts
+++ b/packages/vite-plugin/tests/e2e/runners.ts
@@ -35,8 +35,8 @@ export async function build(dirname: string) {
     args: chromiumArgs(outDir),
   })) as ChromiumBrowserContext
 
-  await browser.route('https://example.com', (route) => {
-    route.fulfill({
+  await browser.route('https://example.com', async (route) => {
+    await route.fulfill({
       path: path.join(__dirname, 'example.html'),
     })
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ importers:
         specifier: ^6.0.1
         version: 6.1.1
       playwright-chromium:
-        specifier: 1.33.0
-        version: 1.33.0
+        specifier: 1.52.0
+        version: 1.52.0
       rollup:
         specifier: ^2.79.2
         version: 2.79.2
@@ -7245,19 +7245,9 @@ packages:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==}
     engines: {node: '>=8'}
 
-  playwright-chromium@1.33.0:
-    resolution: {integrity: sha512-aG2IqRp7Q6vRltZFT+N2stWwDUH2fEUTOTv8RxSKMK5QmIQQoNL9nJvNMIJ3yLuin8+coaa3mhJXjjUheo0+/A==}
-    engines: {node: '>=14'}
-    hasBin: true
-
   playwright-chromium@1.52.0:
     resolution: {integrity: sha512-ZTpzBzRFFRglyqRnAqdK5mFaw1P41qe8V2zSR+fA0eKPgGEEaH7r91ejXKijs3WhReatRcatHQe3ndMBMN1PLA==}
     engines: {node: '>=18'}
-    hasBin: true
-
-  playwright-core@1.33.0:
-    resolution: {integrity: sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==}
-    engines: {node: '>=14'}
     hasBin: true
 
   playwright-core@1.52.0:
@@ -19015,15 +19005,9 @@ snapshots:
     dependencies:
       find-up: 3.0.0
 
-  playwright-chromium@1.33.0:
-    dependencies:
-      playwright-core: 1.33.0
-
   playwright-chromium@1.52.0:
     dependencies:
       playwright-core: 1.52.0
-
-  playwright-core@1.33.0: {}
 
   playwright-core@1.52.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,10 +13,10 @@ importers:
         version: 2.29.4
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.20.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.43.0)(typescript@4.9.5))(eslint@8.43.0)(typescript@4.9.5)
+        version: 5.41.0(@typescript-eslint/parser@5.41.0(eslint@8.43.0)(typescript@4.9.5))(eslint@8.43.0)(typescript@4.9.5)
       '@typescript-eslint/parser':
         specifier: ^5.20.0
-        version: 5.62.0(eslint@8.43.0)(typescript@4.9.5)
+        version: 5.41.0(eslint@8.43.0)(typescript@4.9.5)
       eslint:
         specifier: 8.43.0
         version: 8.43.0
@@ -180,10 +180,10 @@ importers:
         version: 2.7.3
       '@types/react':
         specifier: ^17.0.3
-        version: 17.0.87
+        version: 17.0.52
       '@types/react-dom':
         specifier: ^17.0.3
-        version: 17.0.26(@types/react@17.0.87)
+        version: 17.0.18
       jest:
         specifier: ^27.5.1
         version: 27.5.1
@@ -240,7 +240,7 @@ importers:
         version: 8.3.4
       cheerio:
         specifier: ^1.0.0-rc.10
-        version: 1.0.0
+        version: 1.0.0-rc.11
       convert-source-map:
         specifier: ^1.7.0
         version: 1.9.0
@@ -363,8 +363,8 @@ importers:
         specifier: ^4.1.5
         version: 4.1.5
       playwright-chromium:
-        specifier: 1.33.0
-        version: 1.33.0
+        specifier: 1.52.0
+        version: 1.52.0
       react:
         specifier: 17.0.2
         version: 17.0.2
@@ -406,7 +406,7 @@ importers:
         version: 2.2.0(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)
       '@docusaurus/preset-classic':
         specifier: 2.2.0
-        version: 2.2.0(@algolia/client-search@4.24.0)(@types/react@17.0.87)(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)
+        version: 2.2.0(@algolia/client-search@4.24.0)(@types/react@17.0.52)(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)
       '@docusaurus/theme-classic':
         specifier: ^2.0.0-beta.20
         version: 2.4.3(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)
@@ -443,7 +443,7 @@ importers:
         version: 1.0.7
       '@types/react':
         specifier: ^17
-        version: 17.0.87
+        version: 17.0.52
       typescript:
         specifier: ^4.6.4
         version: 4.9.5
@@ -1950,16 +1950,6 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
-  '@eslint-community/eslint-utils@4.7.0':
-    resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-
-  '@eslint-community/regexpp@4.12.1':
-    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-
   '@eslint-community/regexpp@4.5.1':
     resolution: {integrity: sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
@@ -2792,11 +2782,6 @@ packages:
   '@types/react-dom@17.0.18':
     resolution: {integrity: sha512-rLVtIfbwyur2iFKykP2w0pl/1unw26b5td16d5xMgp7/yjTHomkyxPYChFoCr/FtEX1lN9wY6lFj1qvKdS5kDw==}
 
-  '@types/react-dom@17.0.26':
-    resolution: {integrity: sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==}
-    peerDependencies:
-      '@types/react': ^17.0.0
-
   '@types/react-router-config@5.0.11':
     resolution: {integrity: sha512-WmSAg7WgqW7m4x8Mt4N6ZyKz0BubSj/2tVUMsAHp+Yd2AMwcSbeFq9WympT19p5heCFmF97R9eD5uUR/t4HEqw==}
 
@@ -2815,9 +2800,6 @@ packages:
   '@types/react@17.0.52':
     resolution: {integrity: sha512-vwk8QqVODi0VaZZpDXQCmEmiOuyjEFPY7Ttaw5vjM112LOq37yz1CDJGrRJwA1fYEq4Iitd5rnjd1yWAc/bT+A==}
 
-  '@types/react@17.0.87':
-    resolution: {integrity: sha512-wpg9AbtJ6agjA+BKYmhG6dRWEU/2DHYwMzCaBzsz137ft6IyuqZ5fI4ic1DWL4DrI03Zy78IyVE6ucrXl0mu4g==}
-
   '@types/resolve@1.17.1':
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
 
@@ -2835,9 +2817,6 @@ packages:
 
   '@types/semver@7.3.13':
     resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
-
-  '@types/semver@7.7.0':
-    resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
 
   '@types/send@0.17.4':
     resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
@@ -2907,29 +2886,8 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/eslint-plugin@5.62.0':
-    resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   '@typescript-eslint/parser@5.41.0':
     resolution: {integrity: sha512-HQVfix4+RL5YRWZboMD1pUfFN8MpRH4laziWkkAzyO1fvNOY/uinZcvo3QiFJVS/siNHupV8E5+xSwQZrl6PZA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@typescript-eslint/parser@5.62.0':
-    resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2942,22 +2900,8 @@ packages:
     resolution: {integrity: sha512-xOxPJCnuktUkY2xoEZBKXO5DBCugFzjrVndKdUnyQr3+9aDWZReKq9MhaoVnbL+maVwWJu/N0SEtrtEUNb62QQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@typescript-eslint/scope-manager@5.62.0':
-    resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
   '@typescript-eslint/type-utils@5.41.0':
     resolution: {integrity: sha512-L30HNvIG6A1Q0R58e4hu4h+fZqaO909UcnnPbwKiN6Rc3BUEx6ez2wgN7aC0cBfcAjZfwkzE+E2PQQ9nEuoqfA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@typescript-eslint/type-utils@5.62.0':
-    resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '*'
@@ -2970,21 +2914,8 @@ packages:
     resolution: {integrity: sha512-5BejraMXMC+2UjefDvrH0Fo/eLwZRV6859SXRg+FgbhA0R0l6lDqDGAQYhKbXhPN2ofk2kY5sgGyLNL907UXpA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@typescript-eslint/types@5.62.0':
-    resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
   '@typescript-eslint/typescript-estree@5.41.0':
     resolution: {integrity: sha512-SlzFYRwFSvswzDSQ/zPkIWcHv8O5y42YUskko9c4ki+fV6HATsTODUPbRbcGDFYP86gaJL5xohUEytvyNNcXWg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  '@typescript-eslint/typescript-estree@5.62.0':
-    resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -2998,18 +2929,8 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@typescript-eslint/utils@5.62.0':
-    resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-
   '@typescript-eslint/visitor-keys@5.41.0':
     resolution: {integrity: sha512-vilqeHj267v8uzzakbm13HkPMl7cbYpKVjgFWZPIOHIJHZtinvypUhJ5xBXfWYg4eFKqztbMMpOgFpT9Gfx4fw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  '@typescript-eslint/visitor-keys@5.62.0':
-    resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@vitejs/plugin-react@2.2.0':
@@ -4518,9 +4439,6 @@ packages:
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
 
-  domutils@3.0.1:
-    resolution: {integrity: sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==}
-
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
@@ -4605,10 +4523,6 @@ packages:
 
   entities@3.0.1:
     resolution: {integrity: sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==}
-    engines: {node: '>=0.12'}
-
-  entities@4.3.0:
-    resolution: {integrity: sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg==}
     engines: {node: '>=0.12'}
 
   entities@4.5.0:
@@ -4870,10 +4784,6 @@ packages:
 
   eslint-visitor-keys@3.4.1:
     resolution: {integrity: sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  eslint-visitor-keys@3.4.3:
-    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   eslint@8.43.0:
@@ -6931,9 +6841,6 @@ packages:
     resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}
     engines: {node: '>=0.10.0'}
 
-  natural-compare-lite@1.4.0:
-    resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
-
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -7214,9 +7121,6 @@ packages:
   parse-numeric-range@1.3.0:
     resolution: {integrity: sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==}
 
-  parse5-htmlparser2-tree-adapter@7.0.0:
-    resolution: {integrity: sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==}
-
   parse5-htmlparser2-tree-adapter@7.1.0:
     resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
 
@@ -7225,9 +7129,6 @@ packages:
 
   parse5@6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
-
-  parse5@7.0.0:
-    resolution: {integrity: sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -7349,9 +7250,19 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  playwright-chromium@1.52.0:
+    resolution: {integrity: sha512-ZTpzBzRFFRglyqRnAqdK5mFaw1P41qe8V2zSR+fA0eKPgGEEaH7r91ejXKijs3WhReatRcatHQe3ndMBMN1PLA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   playwright-core@1.33.0:
     resolution: {integrity: sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==}
     engines: {node: '>=14'}
+    hasBin: true
+
+  playwright-core@1.52.0:
+    resolution: {integrity: sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==}
+    engines: {node: '>=18'}
     hasBin: true
 
   pngjs@3.4.0:
@@ -10995,14 +10906,14 @@ snapshots:
 
   '@docsearch/css@3.3.0': {}
 
-  '@docsearch/react@3.3.0(@algolia/client-search@4.24.0)(@types/react@17.0.87)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
+  '@docsearch/react@3.3.0(@algolia/client-search@4.24.0)(@types/react@17.0.52)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@algolia/autocomplete-core': 1.7.2
       '@algolia/autocomplete-preset-algolia': 1.7.2(@algolia/client-search@4.24.0)(algoliasearch@4.13.1)
       '@docsearch/css': 3.3.0
       algoliasearch: 4.13.1
     optionalDependencies:
-      '@types/react': 17.0.87
+      '@types/react': 17.0.52
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
@@ -11400,7 +11311,7 @@ snapshots:
       '@docusaurus/react-loadable': 5.5.2(react@17.0.2)
       '@docusaurus/types': 2.2.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@types/history': 4.7.11
-      '@types/react': 17.0.87
+      '@types/react': 17.0.52
       '@types/react-router-config': 5.0.6
       '@types/react-router-dom': 5.3.3
       react: 17.0.2
@@ -11418,7 +11329,7 @@ snapshots:
       '@docusaurus/react-loadable': 5.5.2(react@17.0.2)
       '@docusaurus/types': 2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@types/history': 4.7.11
-      '@types/react': 17.0.87
+      '@types/react': 17.0.52
       '@types/react-router-config': 5.0.11
       '@types/react-router-dom': 5.3.3
       react: 17.0.2
@@ -11634,7 +11545,7 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-debug@2.2.0(@types/react@17.0.87)(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)':
+  '@docusaurus/plugin-debug@2.2.0(@types/react@17.0.52)(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)':
     dependencies:
       '@docusaurus/core': 2.2.0(@docusaurus/types@2.2.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)
       '@docusaurus/types': 2.2.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
@@ -11642,7 +11553,7 @@ snapshots:
       fs-extra: 10.1.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      react-json-view: 1.21.3(@types/react@17.0.87)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      react-json-view: 1.21.3(@types/react@17.0.52)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@parcel/css'
@@ -11735,19 +11646,19 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/preset-classic@2.2.0(@algolia/client-search@4.24.0)(@types/react@17.0.87)(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)':
+  '@docusaurus/preset-classic@2.2.0(@algolia/client-search@4.24.0)(@types/react@17.0.52)(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)':
     dependencies:
       '@docusaurus/core': 2.2.0(@docusaurus/types@2.2.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)
       '@docusaurus/plugin-content-blog': 2.2.0(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)
       '@docusaurus/plugin-content-docs': 2.2.0(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)
       '@docusaurus/plugin-content-pages': 2.2.0(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)
-      '@docusaurus/plugin-debug': 2.2.0(@types/react@17.0.87)(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)
+      '@docusaurus/plugin-debug': 2.2.0(@types/react@17.0.52)(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)
       '@docusaurus/plugin-google-analytics': 2.2.0(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)
       '@docusaurus/plugin-google-gtag': 2.2.0(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)
       '@docusaurus/plugin-sitemap': 2.2.0(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)
       '@docusaurus/theme-classic': 2.2.0(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)
       '@docusaurus/theme-common': 2.2.0(@docusaurus/types@2.2.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)
-      '@docusaurus/theme-search-algolia': 2.2.0(@algolia/client-search@4.24.0)(@docusaurus/types@2.2.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(@types/react@17.0.87)(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)
+      '@docusaurus/theme-search-algolia': 2.2.0(@algolia/client-search@4.24.0)(@docusaurus/types@2.2.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(@types/react@17.0.52)(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)
       '@docusaurus/types': 2.2.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -11771,7 +11682,7 @@ snapshots:
 
   '@docusaurus/react-loadable@5.5.2(react@17.0.2)':
     dependencies:
-      '@types/react': 17.0.87
+      '@types/react': 17.0.52
       prop-types: 15.8.1
       react: 17.0.2
 
@@ -11875,7 +11786,7 @@ snapshots:
       '@docusaurus/plugin-content-pages': 2.2.0(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)
       '@docusaurus/utils': 2.2.0(@docusaurus/types@2.2.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))
       '@types/history': 4.7.11
-      '@types/react': 17.0.87
+      '@types/react': 17.0.52
       '@types/react-router-config': 5.0.6
       clsx: 1.2.1
       parse-numeric-range: 1.3.0
@@ -11910,7 +11821,7 @@ snapshots:
       '@docusaurus/utils': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))
       '@docusaurus/utils-common': 2.4.3(@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2))
       '@types/history': 4.7.11
-      '@types/react': 17.0.87
+      '@types/react': 17.0.52
       '@types/react-router-config': 5.0.11
       clsx: 1.2.1
       parse-numeric-range: 1.3.0
@@ -11939,9 +11850,9 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@2.2.0(@algolia/client-search@4.24.0)(@docusaurus/types@2.2.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(@types/react@17.0.87)(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)':
+  '@docusaurus/theme-search-algolia@2.2.0(@algolia/client-search@4.24.0)(@docusaurus/types@2.2.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(@types/react@17.0.52)(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)':
     dependencies:
-      '@docsearch/react': 3.3.0(@algolia/client-search@4.24.0)(@types/react@17.0.87)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
+      '@docsearch/react': 3.3.0(@algolia/client-search@4.24.0)(@types/react@17.0.52)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@docusaurus/core': 2.2.0(@docusaurus/types@2.2.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)
       '@docusaurus/logger': 2.2.0
       '@docusaurus/plugin-content-docs': 2.2.0(eslint@8.43.0)(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@4.9.5)
@@ -11990,7 +11901,7 @@ snapshots:
   '@docusaurus/types@2.2.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 17.0.87
+      '@types/react': 17.0.52
       commander: 5.1.0
       joi: 17.6.0
       react: 17.0.2
@@ -12008,7 +11919,7 @@ snapshots:
   '@docusaurus/types@2.4.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 17.0.87
+      '@types/react': 17.0.52
       commander: 5.1.0
       joi: 17.13.3
       react: 17.0.2
@@ -12316,13 +12227,6 @@ snapshots:
     dependencies:
       eslint: 8.43.0
       eslint-visitor-keys: 3.4.1
-
-  '@eslint-community/eslint-utils@4.7.0(eslint@8.43.0)':
-    dependencies:
-      eslint: 8.43.0
-      eslint-visitor-keys: 3.4.3
-
-  '@eslint-community/regexpp@4.12.1': {}
 
   '@eslint-community/regexpp@4.5.1': {}
 
@@ -13433,45 +13337,35 @@ snapshots:
     dependencies:
       '@types/react': 17.0.52
 
-  '@types/react-dom@17.0.26(@types/react@17.0.87)':
-    dependencies:
-      '@types/react': 17.0.87
-
   '@types/react-router-config@5.0.11':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 17.0.87
+      '@types/react': 17.0.52
       '@types/react-router': 5.1.20
 
   '@types/react-router-config@5.0.6':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 17.0.87
+      '@types/react': 17.0.52
       '@types/react-router': 5.1.18
 
   '@types/react-router-dom@5.3.3':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 17.0.87
+      '@types/react': 17.0.52
       '@types/react-router': 5.1.18
 
   '@types/react-router@5.1.18':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 17.0.87
+      '@types/react': 17.0.52
 
   '@types/react-router@5.1.20':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 17.0.87
+      '@types/react': 17.0.52
 
   '@types/react@17.0.52':
-    dependencies:
-      '@types/prop-types': 15.7.5
-      '@types/scheduler': 0.16.2
-      csstype: 3.0.11
-
-  '@types/react@17.0.87':
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
@@ -13494,8 +13388,6 @@ snapshots:
   '@types/scheduler@0.16.2': {}
 
   '@types/semver@7.3.13': {}
-
-  '@types/semver@7.7.0': {}
 
   '@types/send@0.17.4':
     dependencies:
@@ -13586,25 +13478,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.43.0)(typescript@4.9.5))(eslint@8.43.0)(typescript@4.9.5)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 5.62.0(eslint@8.43.0)(typescript@4.9.5)
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@8.43.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.43.0)(typescript@4.9.5)
-      debug: 4.4.1
-      eslint: 8.43.0
-      graphemer: 1.4.0
-      ignore: 5.2.0
-      natural-compare-lite: 1.4.0
-      semver: 7.3.7
-      tsutils: 3.21.0(typescript@4.9.5)
-    optionalDependencies:
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/parser@5.41.0(eslint@8.43.0)(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/scope-manager': 5.41.0
@@ -13617,27 +13490,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@5.62.0(eslint@8.43.0)(typescript@4.9.5)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
-      debug: 4.4.1
-      eslint: 8.43.0
-    optionalDependencies:
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/scope-manager@5.41.0':
     dependencies:
       '@typescript-eslint/types': 5.41.0
       '@typescript-eslint/visitor-keys': 5.41.0
-
-  '@typescript-eslint/scope-manager@5.62.0':
-    dependencies:
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/visitor-keys': 5.62.0
 
   '@typescript-eslint/type-utils@5.41.0(eslint@8.43.0)(typescript@4.9.5)':
     dependencies:
@@ -13651,21 +13507,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@5.62.0(eslint@8.43.0)(typescript@4.9.5)':
-    dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.43.0)(typescript@4.9.5)
-      debug: 4.4.1
-      eslint: 8.43.0
-      tsutils: 3.21.0(typescript@4.9.5)
-    optionalDependencies:
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/types@5.41.0': {}
-
-  '@typescript-eslint/types@5.62.0': {}
 
   '@typescript-eslint/typescript-estree@5.41.0(typescript@4.9.5)':
     dependencies:
@@ -13675,20 +13517,6 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.7
-      tsutils: 3.21.0(typescript@4.9.5)
-    optionalDependencies:
-      typescript: 4.9.5
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/typescript-estree@5.62.0(typescript@4.9.5)':
-    dependencies:
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.1
-      globby: 11.1.0
-      is-glob: 4.0.3
-      semver: 7.7.2
       tsutils: 3.21.0(typescript@4.9.5)
     optionalDependencies:
       typescript: 4.9.5
@@ -13710,30 +13538,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@5.62.0(eslint@8.43.0)(typescript@4.9.5)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@8.43.0)
-      '@types/json-schema': 7.0.15
-      '@types/semver': 7.7.0
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
-      eslint: 8.43.0
-      eslint-scope: 5.1.1
-      semver: 7.3.7
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   '@typescript-eslint/visitor-keys@5.41.0':
     dependencies:
       '@typescript-eslint/types': 5.41.0
       eslint-visitor-keys: 3.4.1
-
-  '@typescript-eslint/visitor-keys@5.62.0':
-    dependencies:
-      '@typescript-eslint/types': 5.62.0
-      eslint-visitor-keys: 3.4.3
 
   '@vitejs/plugin-react@2.2.0(vite@3.2.11(@types/node@17.0.18)(terser@5.40.0))':
     dependencies:
@@ -14771,10 +14579,10 @@ snapshots:
       cheerio-select: 2.1.0
       dom-serializer: 2.0.0
       domhandler: 5.0.3
-      domutils: 3.0.1
+      domutils: 3.2.2
       htmlparser2: 8.0.1
-      parse5: 7.0.0
-      parse5-htmlparser2-tree-adapter: 7.0.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
       tslib: 2.8.1
 
   chokidar@3.6.0:
@@ -15558,12 +15366,6 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 4.3.1
 
-  domutils@3.0.1:
-    dependencies:
-      dom-serializer: 2.0.0
-      domelementtype: 2.3.0
-      domhandler: 5.0.3
-
   domutils@3.2.2:
     dependencies:
       dom-serializer: 2.0.0
@@ -15640,8 +15442,6 @@ snapshots:
   entities@2.2.0: {}
 
   entities@3.0.1: {}
-
-  entities@4.3.0: {}
 
   entities@4.5.0: {}
 
@@ -16000,8 +15800,6 @@ snapshots:
   eslint-visitor-keys@2.1.0: {}
 
   eslint-visitor-keys@3.4.1: {}
-
-  eslint-visitor-keys@3.4.3: {}
 
   eslint@8.43.0:
     dependencies:
@@ -16955,8 +16753,8 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
       domhandler: 5.0.3
-      domutils: 3.0.1
-      entities: 4.3.0
+      domutils: 3.2.2
+      entities: 4.5.0
 
   htmlparser2@9.1.0:
     dependencies:
@@ -18826,8 +18624,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  natural-compare-lite@1.4.0: {}
-
   natural-compare@1.4.0: {}
 
   negotiator@0.6.3: {}
@@ -19123,11 +18919,6 @@ snapshots:
 
   parse-numeric-range@1.3.0: {}
 
-  parse5-htmlparser2-tree-adapter@7.0.0:
-    dependencies:
-      domhandler: 5.0.3
-      parse5: 7.0.0
-
   parse5-htmlparser2-tree-adapter@7.1.0:
     dependencies:
       domhandler: 5.0.3
@@ -19138,10 +18929,6 @@ snapshots:
       parse5: 7.3.0
 
   parse5@6.0.1: {}
-
-  parse5@7.0.0:
-    dependencies:
-      entities: 4.3.0
 
   parse5@7.3.0:
     dependencies:
@@ -19232,7 +19019,13 @@ snapshots:
     dependencies:
       playwright-core: 1.33.0
 
+  playwright-chromium@1.52.0:
+    dependencies:
+      playwright-core: 1.52.0
+
   playwright-core@1.33.0: {}
+
+  playwright-core@1.52.0: {}
 
   pngjs@3.4.0: {}
 
@@ -19937,14 +19730,14 @@ snapshots:
 
   react-is@17.0.2: {}
 
-  react-json-view@1.21.3(@types/react@17.0.87)(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
+  react-json-view@1.21.3(@types/react@17.0.52)(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
     dependencies:
       flux: 4.0.3(react@17.0.2)
       react: 17.0.2
       react-base16-styling: 0.6.0
       react-dom: 17.0.2(react@17.0.2)
       react-lifecycles-compat: 3.0.4
-      react-textarea-autosize: 8.3.3(@types/react@17.0.87)(react@17.0.2)
+      react-textarea-autosize: 8.3.3(@types/react@17.0.52)(react@17.0.2)
     transitivePeerDependencies:
       - '@types/react'
       - encoding
@@ -20028,12 +19821,12 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  react-textarea-autosize@8.3.3(@types/react@17.0.87)(react@17.0.2):
+  react-textarea-autosize@8.3.3(@types/react@17.0.52)(react@17.0.2):
     dependencies:
       '@babel/runtime': 7.27.4
       react: 17.0.2
       use-composed-ref: 1.3.0(react@17.0.2)
-      use-latest: 1.2.1(@types/react@17.0.87)(react@17.0.2)
+      use-latest: 1.2.1(@types/react@17.0.52)(react@17.0.2)
     transitivePeerDependencies:
       - '@types/react'
 
@@ -21469,18 +21262,18 @@ snapshots:
     dependencies:
       react: 17.0.2
 
-  use-isomorphic-layout-effect@1.1.2(@types/react@17.0.87)(react@17.0.2):
+  use-isomorphic-layout-effect@1.1.2(@types/react@17.0.52)(react@17.0.2):
     dependencies:
       react: 17.0.2
     optionalDependencies:
-      '@types/react': 17.0.87
+      '@types/react': 17.0.52
 
-  use-latest@1.2.1(@types/react@17.0.87)(react@17.0.2):
+  use-latest@1.2.1(@types/react@17.0.52)(react@17.0.2):
     dependencies:
       react: 17.0.2
-      use-isomorphic-layout-effect: 1.1.2(@types/react@17.0.87)(react@17.0.2)
+      use-isomorphic-layout-effect: 1.1.2(@types/react@17.0.52)(react@17.0.2)
     optionalDependencies:
-      '@types/react': 17.0.87
+      '@types/react': 17.0.52
 
   use-sync-external-store@1.5.0(react@17.0.2):
     dependencies:


### PR DESCRIPTION
**goal**
update chrome to 136 (latest)

**problems solved**
when upgrading i've found out that the chrome 134+ wont load extensions when developer mode is not enabled. It needs to be enabled the whole time for user to load the unpacked extension, and for the cli usage --load-extension this is not required until you need to reload the extension - the tests are doing exactly that. 

two tests were failing because of this reason:
```
$env:DEBUG='crx:*';$env:TIMEOUT='999999'; pnpm run test:run:e2e tests/e2e/mv3-vite-vanilla-content-script-hmr/vite-serve.test.ts
$env:DEBUG='crx:*';$env:TIMEOUT='999999'; pnpm run test:run:e2e tests/e2e/mv3-vite-dynamic-content-script-hmr/vite-serve.test.tsclear
```
the `mv3-vite-vanilla-content-script-hmr/vite-serve.test.ts` is skipped in CI for some reason but maybe we could enable it in the next PR

**references**
https://underpassapp.com/news/2025/3/3.html
https://github.com/microsoft/playwright/issues/34711#issuecomment-2797778673

**improvements for next PRs**
* run rollup-plugin e2e tests in ci - currently ci ignores the test by running `jest --runInBand --testPathIgnorePatterns="/node_modules/|playwright" --testPathPattern=mv3`
* fix the mv3-playwright test because it does not work at all. The content script does not load