### PR TITLE
chore: exit pre-release mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "rollup-plugin-chrome-extension": "3.6.10",


### PR DESCRIPTION
just ran
```
pnpm changeset pre exit
```

as the task says https://github.com/crxjs/chrome-extension-tools/issues/991