### PR TITLE
feat: beautiful terminal

### DIFF
--- a/.github/workflows/rollup-plugin.yml
+++ b/.github/workflows/rollup-plugin.yml
@@ -97,7 +97,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           # Version of PNPM to install
-          version: 9.15.2
+          version: 10.11.1
           # Where to store PNPM files
           # dest: # optional, default is ~/setup-pnpm
           # If specified, run `pnpm install`

--- a/.github/workflows/vite-plugin.yml
+++ b/.github/workflows/vite-plugin.yml
@@ -97,7 +97,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           # Version of PNPM to install
-          version: 9.15.2
+          version: 10.11.1
           # Where to store PNPM files
           # dest: # optional, default is ~/setup-pnpm
           # If specified, run `pnpm install`
@@ -155,7 +155,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           # Version of PNPM to install
-          version: 9.15.2
+          version: 10.11.1
           # Where to store PNPM files
           # dest: # optional, default is ~/setup-pnpm
           # If specified, run `pnpm install`

--- a/packages/vite-plugin/src/node/index.ts
+++ b/packages/vite-plugin/src/node/index.ts
@@ -10,6 +10,7 @@ import { pluginFileWriter } from './plugin-fileWriter'
 import { pluginFileWriterPolyfill } from './plugin-fileWriter-polyfill'
 import { pluginFileWriterPublic } from './plugin-fileWriter_public'
 import { pluginHMR } from './plugin-hmr'
+import { pluginPrint } from './plugin-print'
 import { pluginHtmlInlineScripts } from './plugin-htmlInlineScripts'
 import { pluginManifest } from './plugin-manifest'
 import { pluginWebAccessibleResources } from './plugin-webAccessibleResources'
@@ -36,6 +37,7 @@ export const crx = (
     pluginContentScriptsCss(),
     pluginHMR(),
     pluginManifest(),
+    pluginPrint(),
   ].flat()
 }
 

--- a/packages/vite-plugin/src/node/plugin-print.ts
+++ b/packages/vite-plugin/src/node/plugin-print.ts
@@ -1,0 +1,33 @@
+import { CrxPluginFn } from "./types"
+import pc from 'picocolors'
+
+/**
+ * terminal font design form https://github.com/nyaggah/bedframe
+ * MIT
+ * https://github.com/nyaggah/bedframe/blob/main/packages/core/src/lib/get-manifest.ts#L66
+ */
+function printStr(dir:string) {
+  return `  ${pc.magentaBright('C H R O M E')}
+  ${pc.greenBright('E X T E N S I O N')}
+  ${pc.blueBright('T O O L S')}
+  
+  ${pc.green('➜')}  ${pc.bold('CRXJS')}: ${pc.green(`Load ${pc.cyan(dir)} as unpacked extension`)}`
+} 
+
+export const pluginPrint:CrxPluginFn = () => {
+  let outDir = 'dist';
+  return [
+    {
+      name: 'crx:print',
+      enforce: 'pre',
+      configResolved(resolvedConfig) {
+        outDir = resolvedConfig.build.outDir;
+      },
+      configureServer(server) {
+        server.printUrls = () => {
+          console.log(printStr(outDir))
+        }
+      },
+    },
+  ]
+}

--- a/packages/vite-plugin/src/node/plugin-print.ts
+++ b/packages/vite-plugin/src/node/plugin-print.ts
@@ -7,7 +7,7 @@ import pc from 'picocolors'
  * https://github.com/nyaggah/bedframe/blob/main/packages/core/src/lib/get-manifest.ts#L66
  */
 function printStr(dir:string) {
-  return `  ${pc.magentaBright('C H R O M E')}
+  return `  ${pc.magentaBright('B R O W S E R')}
   ${pc.greenBright('E X T E N S I O N')}
   ${pc.blueBright('T O O L S')}
   


### PR DESCRIPTION
### Changes  
This PR modifies Vite's default terminal output.  

### Motivation  
The original terminal output displayed a URL which is **less meaningful** and **potentially misleading** in CRXJS-based projects.  

### Solution  
Adjusted the default terminal output as shown below:  
<img width="661" alt="截屏2025-06-13 22 54 48" src="https://github.com/user-attachments/assets/28eece49-c05e-4781-bd97-c1be06a44158" />
