### PR TITLE
feat: run build steps on build definition changes

### DIFF
--- a/.github/workflows/rollup-plugin.yml
+++ b/.github/workflows/rollup-plugin.yml
@@ -9,11 +9,13 @@ on:
     branches: [main]
     paths:
       - "packages/rollup-plugin/**"
+      - ".github/workflows/rollup-plugin.yml"
       - "!**.md"
   pull_request:
     branches: [main]
     paths:
       - "packages/rollup-plugin/**"
+      - ".github/workflows/rollup-plugin.yml"
       - "!**.md"
 
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/vite-plugin.yml
+++ b/.github/workflows/vite-plugin.yml
@@ -7,11 +7,13 @@ on:
     branches: [main]
     paths:
       - "packages/vite-plugin/**"
+      - ".github/workflows/vite-plugin.yml"
       - "!**.md"
   pull_request:
     branches: [main]
     paths:
       - "packages/vite-plugin/**"
+      - ".github/workflows/vite-plugin.yml"
       - "!**.md"
 
   # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
In #1024 i've encountered a problem:
i wanted to update `.github/workflows/vite-plugin.yaml` file and check if it works.
Original issue created by https://github.com/crxjs/chrome-extension-tools/pull/1019/commits/9c1aca9a980372425a921b8e08b48066b4506dcc
It was not checked, because the CI didnt run

This PR fixes that so that the ci runs whenever a ci definition changes