### PR TITLE
fix: update repository url

### DIFF
--- a/.changeset/heavy-sheep-wave.md
+++ b/.changeset/heavy-sheep-wave.md
@@ -1,0 +1,6 @@
+---
+"rollup-plugin-chrome-extension": patch
+"@crxjs/vite-plugin": patch
+---
+
+fix: update repository url

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: RPCE Community Support
-    url: https://github.com/crxjs/rollup-plugin-chrome-extension/discussions/new
+    url: https://github.com/crxjs/chrome-extension-tools/discussions/new
     about: Need help? Start a community discussion!

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -14,7 +14,8 @@
     "browser-extension"
   ],
   "repository": {
-    "url": "https://github.com/crxjs/rollup-plugin-chrome-extension.git"
+    "type": "git",
+    "url": "https://github.com/crxjs/chrome-extension-tools.git"
   },
   "license": "MIT",
   "author": "Jack and Amy Steam <jacksteamdev@gmail.com>",

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -13,9 +13,11 @@
     "browser",
     "browser-extension"
   ],
+  "homepage": "https://www.extend-chrome.dev/rollup-plugin",
   "repository": {
     "type": "git",
-    "url": "https://github.com/crxjs/chrome-extension-tools.git"
+    "url": "git+https://github.com/crxjs/chrome-extension-tools",
+    "directory": "packages/rollup-plugin"
   },
   "license": "MIT",
   "author": "Jack and Amy Steam <jacksteamdev@gmail.com>",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -13,13 +13,14 @@
     "browser",
     "browser-extension"
   ],
-  "homepage": "https://github.com/crxjs/chrome-extension-tools",
+  "homepage": "https://crxjs.dev/vite-plugin",
   "bugs": {
     "url": "https://github.com/crxjs/chrome-extension-tools/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/crxjs/chrome-extension-tools.git"
+    "url": "git+https://github.com/crxjs/chrome-extension-tools",
+    "directory": "packages/vite-plugin"
   },
   "license": "MIT",
   "author": "Jack and Amy Steam <jacksteamdev@gmail.com>",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -13,13 +13,13 @@
     "browser",
     "browser-extension"
   ],
-  "homepage": "https://github.com/crxjs/rollup-plugin-chrome-extension",
+  "homepage": "https://github.com/crxjs/chrome-extension-tools",
   "bugs": {
-    "url": "https://github.com/crxjs/rollup-plugin-chrome-extension/issues"
+    "url": "https://github.com/crxjs/chrome-extension-tools/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/crxjs/rollup-plugin-chrome-extension.git"
+    "url": "https://github.com/crxjs/chrome-extension-tools.git"
   },
   "license": "MIT",
   "author": "Jack and Amy Steam <jacksteamdev@gmail.com>",


### PR DESCRIPTION
Normally, GitHub tracks public projects using the `repository`, but `CRXJS` hasn't been correctly tracked (as shown below).
![image](https://github.com/user-attachments/assets/1f47d0ca-a2f7-45fd-9991-8d3cb502dda0)

This is because the repository field in the original package.json incorrectly pointed to the old repository name. I've now updated the address correctly.
I believe we should immediately release a new version to trigger GitHub's tracking, including the Rollup version.