### PR TITLE
feat(vite-plugin): support https dev server

### DIFF
--- a/packages/vite-plugin/rollup.config.ts
+++ b/packages/vite-plugin/rollup.config.ts
@@ -29,6 +29,7 @@ const external: (string | RegExp)[] = [
   'node:fs',
   'node:path',
 
+  /%PROTO%/,
   /%PORT%/,
   /%PATH%/,
 ]

--- a/packages/vite-plugin/src/client/es/loading-page-script.ts
+++ b/packages/vite-plugin/src/client/es/loading-page-script.ts
@@ -3,7 +3,7 @@
  * service worker takes control of fetch (e.g., in the onInstalled event).
  */
 
-const VITE_URL = 'http://localhost:%PORT%'
+const VITE_URL = '%PROTO%://localhost:%PORT%'
 
 document.body.innerHTML = `
 <div

--- a/packages/vite-plugin/src/node/plugin-background.ts
+++ b/packages/vite-plugin/src/node/plugin-background.ts
@@ -34,7 +34,7 @@ export const pluginBackground: CrxPluginFn = () => {
       },
       load(id) {
         if (id === workerClientId) {
-          const base = `http://localhost:${config.server.port}/`
+          const base = `${config.server.https ? 'https' : 'http'}://localhost:${config.server.port}/`
           return defineClientValues(
             workerHmrClient.replace('__BASE__', JSON.stringify(base)),
             config,
@@ -61,6 +61,7 @@ export const pluginBackground: CrxPluginFn = () => {
 
         let loader: string
         if (config.command === 'serve') {
+          const proto = config.server.https ? 'https' : 'http';
           const port = config.server.port?.toString()
           if (typeof port === 'undefined')
             throw new Error('server port is undefined in watch mode')
@@ -70,20 +71,20 @@ export const pluginBackground: CrxPluginFn = () => {
             // can't use import statements
 
             // development, required to define env vars
-            loader = `import('http://localhost:${port}/@vite/env');\n`
+            loader = `import('${proto}://localhost:${port}/@vite/env');\n`
             // development, required hmr client
-            loader += `import('http://localhost:${port}${workerClientId}');\n`
+            loader += `import('${proto}://localhost:${port}${workerClientId}');\n`
             // development, optional service worker
             if (worker)
-              loader += `import('http://localhost:${port}/${worker}');\n`
+              loader += `import('${proto}://localhost:${port}/${worker}');\n`
           } else {
             // development, required to define env vars
-            loader = `import 'http://localhost:${port}/@vite/env';\n`
+            loader = `import '${proto}://localhost:${port}/@vite/env';\n`
             // development, required hmr client
-            loader += `import 'http://localhost:${port}${workerClientId}';\n`
+            loader += `import '${proto}://localhost:${port}${workerClientId}';\n`
             // development, optional service worker
             if (worker)
-              loader += `import 'http://localhost:${port}/${worker}';\n`
+              loader += `import '${proto}://localhost:${port}/${worker}';\n`
           }
         } else if (worker) {
           // production w/ service worker loader at root, see comment at top of file.

--- a/packages/vite-plugin/src/node/plugin-manifest.ts
+++ b/packages/vite-plugin/src/node/plugin-manifest.ts
@@ -378,10 +378,9 @@ Public dir: "${config.publicDir}"`,
           const refId = this.emitFile({
             type: 'asset',
             name: 'loading-page.js',
-            source: loadingPageScript.replace(
-              '%PORT%',
-              `${config.server.port ?? 0}`,
-            ),
+            source: loadingPageScript
+              .replace('%PROTO%', config.server.https ? 'https' : 'http')
+              .replace('%PORT%', `${config.server.port ?? 0}`),
           })
           const loadingPageScriptName = this.getFileName(refId)
           files.html.map((f) =>

--- a/packages/vite-plugin/tests/out/with-https-server/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-https-server/__snapshots__/build.test.ts.snap
@@ -1,0 +1,141 @@
+// Vitest Snapshot v1
+
+exports[`build fs output > _00 manifest.json 1`] = `
+Object {
+  "action": Object {
+    "default_popup": "src/popup.html",
+  },
+  "background": Object {
+    "service_worker": "service-worker-loader.js",
+    "type": "module",
+  },
+  "content_scripts": Array [
+    Object {
+      "js": Array [
+        "assets/content.js.hash0.js",
+      ],
+      "matches": Array [
+        "https://a.com/*",
+        "http://b.com/*",
+      ],
+    },
+  ],
+  "description": "test extension",
+  "host_permissions": Array [
+    "https://c.com/*",
+  ],
+  "manifest_version": 3,
+  "name": "Test Extension",
+  "version": "1.0.0",
+  "web_accessible_resources": Array [
+    Object {
+      "matches": Array [
+        "http://b.com/*",
+        "https://a.com/*",
+      ],
+      "resources": Array [
+        "assets/content.js.hash0.js",
+      ],
+      "use_dynamic_url": false,
+    },
+  ],
+}
+`;
+
+exports[`build fs output > _01 output files 1`] = `
+Array [
+  "assets/background.js.hash1.js",
+  "assets/content.js.hash0.js",
+  "assets/popup.html.hash2.js",
+  "assets/vendor.hash3.js",
+  "manifest.json",
+  "service-worker-loader.js",
+  "src/popup.html",
+]
+`;
+
+exports[`build fs output > assets/background.js.hash1.js 1`] = `
+"console.log(\\"service_worker.js\\");
+"
+`;
+
+exports[`build fs output > assets/content.js.hash0.js 1`] = `
+"(function(){console.log(\\"content script\\");
+})()
+"
+`;
+
+exports[`build fs output > assets/popup.html.hash2.js 1`] = `
+"import { R as React, a as ReactDOM } from \\"./vendor.hash3.js\\";
+(function polyfill() {
+  const relList = document.createElement(\\"link\\").relList;
+  if (relList && relList.supports && relList.supports(\\"modulepreload\\")) {
+    return;
+  }
+  for (const link of document.querySelectorAll('link[rel=\\"modulepreload\\"]')) {
+    processPreload(link);
+  }
+  new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      if (mutation.type !== \\"childList\\") {
+        continue;
+      }
+      for (const node of mutation.addedNodes) {
+        if (node.tagName === \\"LINK\\" && node.rel === \\"modulepreload\\")
+          processPreload(node);
+      }
+    }
+  }).observe(document, { childList: true, subtree: true });
+  function getFetchOpts(script) {
+    const fetchOpts = {};
+    if (script.integrity)
+      fetchOpts.integrity = script.integrity;
+    if (script.referrerpolicy)
+      fetchOpts.referrerPolicy = script.referrerpolicy;
+    if (script.crossorigin === \\"use-credentials\\")
+      fetchOpts.credentials = \\"include\\";
+    else if (script.crossorigin === \\"anonymous\\")
+      fetchOpts.credentials = \\"omit\\";
+    else
+      fetchOpts.credentials = \\"same-origin\\";
+    return fetchOpts;
+  }
+  function processPreload(link) {
+    if (link.ep)
+      return;
+    link.ep = true;
+    const fetchOpts = getFetchOpts(link);
+    fetch(link.href, fetchOpts);
+  }
+})();
+const App = () => {
+  return /* @__PURE__ */ React.createElement(\\"div\\", null, /* @__PURE__ */ React.createElement(\\"h1\\", null, \\"Popup Page\\"), /* @__PURE__ */ React.createElement(\\"p\\", null, \\"If you are seeing this, React is working!\\"));
+};
+console.log(\\"popup script\\");
+const root = document.querySelector(\\"#root\\");
+ReactDOM.render(/* @__PURE__ */ React.createElement(App, null), root);
+"
+`;
+
+exports[`build fs output > service-worker-loader.js 1`] = `
+"import './assets/background.js.hash1.js';
+"
+`;
+
+exports[`build fs output > src/popup.html 1`] = `
+"<!DOCTYPE html>
+<html lang=\\"en\\">
+  <head>
+    <meta charset=\\"UTF-8\\" />
+    <meta name=\\"viewport\\" content=\\"width=1000, initial-scale=1.0\\" />
+    <title>Popup Page</title>
+    <script type=\\"module\\" crossorigin src=\\"/assets/popup.html.hash2.js\\"></script>
+    <link rel=\\"modulepreload\\" crossorigin href=\\"/assets/vendor.hash3.js\\">
+  </head>
+  <body>
+    <div id=\\"root\\"></div>
+    
+  </body>
+</html>
+"
+`;

--- a/packages/vite-plugin/tests/out/with-https-server/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-https-server/__snapshots__/serve.test.ts.snap
@@ -1,0 +1,175 @@
+// Vitest Snapshot v1
+
+exports[`serve fs output > _00 manifest.json 1`] = `
+Object {
+  "action": Object {
+    "default_popup": "src/popup.html",
+  },
+  "background": Object {
+    "service_worker": "service-worker-loader.js",
+    "type": "module",
+  },
+  "content_scripts": Array [
+    Object {
+      "js": Array [
+        "src/content.js-loader.js",
+      ],
+      "matches": Array [
+        "https://a.com/*",
+        "http://b.com/*",
+      ],
+    },
+  ],
+  "description": "test extension",
+  "host_permissions": Array [
+    "https://c.com/*",
+  ],
+  "manifest_version": 3,
+  "name": "Test Extension",
+  "version": "1.0.0",
+  "web_accessible_resources": Array [
+    Object {
+      "matches": Array [
+        "<all_urls>",
+      ],
+      "resources": Array [
+        "*",
+        "**/*",
+      ],
+      "use_dynamic_url": false,
+    },
+  ],
+}
+`;
+
+exports[`serve fs output > _01 output files 1`] = `
+Array [
+  "assets/loading-page.hash0.js",
+  "manifest.json",
+  "service-worker-loader.js",
+  "src/content.js-loader.js",
+  "src/content.js.js",
+  "src/popup.html",
+  "vendor/crx-client-port.js",
+  "vendor/vite-client.js",
+  "vendor/vite-dist-client-env.mjs.js",
+  "vendor/webcomponents-custom-elements.js",
+]
+`;
+
+exports[`serve fs output > _02 optimized deps 1`] = `
+Set {
+  "src/content.js",
+  "src/background.js",
+  "src/popup.html",
+}
+`;
+
+exports[`serve fs output > assets/loading-page.hash0.js 1`] = `
+"const VITE_URL = \\"https://localhost:3000\\";
+document.body.innerHTML = \`
+<div
+      id=\\"app\\"
+      style=\\"
+        border: 1px solid #ddd;
+        padding: 20px;
+        border-radius: 5px;
+        box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+      \\"
+    >
+      <h1 style=\\"color: #333\\">Vite Dev Mode</h1>
+      <p style=\\"color: #666\\">
+        Cannot connect to the Vite Dev Server on <a href=\\"\${VITE_URL}\\">\${VITE_URL}</a>
+      </p>
+      <p style=\\"color: #666\\">
+        Double-check that Vite is working and reload the extension.
+      </p>
+      <p style=\\"color: #666\\">
+        This page will close when the extension reloads.
+      </p>
+      <button
+        style=\\"
+          padding: 10px 20px;
+          border: none;
+          background-color: #007bff;
+          color: #fff;
+          border-radius: 5px;
+          cursor: pointer;
+        \\"
+      >
+        Reload Extension
+      </button>
+    </div>\`;
+document.body.querySelector(\\"button\\")?.addEventListener(\\"click\\", () => {
+  chrome.runtime.reload();
+});
+let tries = 0;
+let ready = false;
+do {
+  try {
+    await fetch(VITE_URL);
+    ready = true;
+  } catch {
+    const timeout = Math.min(100 * Math.pow(2, ++tries), 5e3);
+    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_URL}\`);
+    console.log(\`[CRXJS] Retrying in \${timeout}ms...\`);
+    await new Promise((resolve) => setTimeout(resolve, timeout));
+  }
+} while (!ready);
+location.reload();
+"
+`;
+
+exports[`serve fs output > service-worker-loader.js 1`] = `
+"import 'https://localhost:3000/@vite/env';
+import 'https://localhost:3000/@crx/client-worker';
+import 'https://localhost:3000/src/background.js';
+"
+`;
+
+exports[`serve fs output > src/content.js.js 1`] = `
+"console.log('content script')
+"
+`;
+
+exports[`serve fs output > src/content.js-loader.js 1`] = `
+"(function () {
+  'use strict';
+
+  const injectTime = performance.now();
+  (async () => {
+    if (\\"\\")
+      await import(
+        /* @vite-ignore */
+        chrome.runtime.getURL(\\"\\")
+      );
+    await import(
+      /* @vite-ignore */
+      chrome.runtime.getURL(\\"vendor/vite-client.js\\")
+    );
+    const { onExecute } = await import(
+      /* @vite-ignore */
+      chrome.runtime.getURL(\\"src/content.js.js\\")
+    );
+    onExecute?.({ perf: { injectTime, loadTime: performance.now() - injectTime } });
+  })().catch(console.error);
+
+})();
+"
+`;
+
+exports[`serve fs output > src/popup.html 1`] = `
+"<!DOCTYPE html>
+<html lang=\\"en\\">
+  <head>
+    <title>Vite Dev Mode</title>
+    <script src=\\"/assets/loading-page.hash0.js\\" type=\\"module\\"></script>
+  </head>
+  <body
+    style=\\"font-family: Arial, sans-serif; padding: 20px; text-align: center\\"
+  >
+    <h1>Vite Dev Mode</h1>
+  </body>
+</html>
+"
+`;

--- a/packages/vite-plugin/tests/out/with-https-server/build.test.ts
+++ b/packages/vite-plugin/tests/out/with-https-server/build.test.ts
@@ -1,0 +1,8 @@
+import { build } from 'tests/runners'
+import { testOutput } from 'tests/testOutput'
+import { test } from 'vitest'
+
+test('build fs output', async () => {
+  const result = await build(__dirname)
+  await testOutput(result)
+})

--- a/packages/vite-plugin/tests/out/with-https-server/manifest.json
+++ b/packages/vite-plugin/tests/out/with-https-server/manifest.json
@@ -1,0 +1,19 @@
+{
+  "action": {
+    "default_popup": "src/popup.html"
+  },
+  "background": {
+    "service_worker": "src/background.js"
+  },
+  "content_scripts": [
+    {
+      "js": ["src/content.js"],
+      "matches": ["https://a.com/*", "http://b.com/*"]
+    }
+  ],
+  "description": "test extension",
+  "host_permissions": ["https://c.com/*"],
+  "manifest_version": 3,
+  "name": "Test Extension",
+  "version": "1.0.0"
+}

--- a/packages/vite-plugin/tests/out/with-https-server/serve.test.ts
+++ b/packages/vite-plugin/tests/out/with-https-server/serve.test.ts
@@ -1,0 +1,16 @@
+import { serve } from 'tests/runners'
+import { testOutput } from 'tests/testOutput'
+import { afterAll, test } from 'vitest'
+
+let result: Awaited<ReturnType<typeof serve>> | undefined
+
+afterAll(async () => {
+  try {
+    await result?.server.close()
+  } catch (error) {}
+})
+
+test('serve fs output', async () => {
+  result = await serve(__dirname)
+  await testOutput(result)
+})

--- a/packages/vite-plugin/tests/out/with-https-server/src/App.jsx
+++ b/packages/vite-plugin/tests/out/with-https-server/src/App.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const App = () => {
+  return (
+    <div>
+      <h1>Popup Page</h1>
+      <p>If you are seeing this, React is working!</p>
+    </div>
+  )
+}
+
+export default App

--- a/packages/vite-plugin/tests/out/with-https-server/src/background.js
+++ b/packages/vite-plugin/tests/out/with-https-server/src/background.js
@@ -1,0 +1,1 @@
+console.log('service_worker.js')

--- a/packages/vite-plugin/tests/out/with-https-server/src/content.js
+++ b/packages/vite-plugin/tests/out/with-https-server/src/content.js
@@ -1,0 +1,1 @@
+console.log('content script')

--- a/packages/vite-plugin/tests/out/with-https-server/src/popup.html
+++ b/packages/vite-plugin/tests/out/with-https-server/src/popup.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1000, initial-scale=1.0" />
+    <title>Popup Page</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="./popup.jsx" type="module"></script>
+  </body>
+</html>

--- a/packages/vite-plugin/tests/out/with-https-server/src/popup.jsx
+++ b/packages/vite-plugin/tests/out/with-https-server/src/popup.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import App from './App'
+
+console.log('popup script')
+
+const root = document.querySelector('#root')
+
+ReactDOM.render(<App />, root)

--- a/packages/vite-plugin/tests/out/with-https-server/vite.config.ts
+++ b/packages/vite-plugin/tests/out/with-https-server/vite.config.ts
@@ -1,0 +1,23 @@
+import { crx } from '../../plugin-testOptionsProvider'
+import { defineConfig } from 'vite'
+import manifest from './manifest.json'
+
+export default defineConfig({
+  build: {
+    minify: false,
+    rollupOptions: {
+      output: {
+        // the hash randomly changes between environments
+        assetFileNames: 'assets/[name].hash[hash].[ext]',
+        chunkFileNames: 'assets/[name].hash[hash].js',
+        entryFileNames: 'assets/[name].hash[hash].js',
+      },
+    },
+  },
+  clearScreen: false,
+  logLevel: 'error',
+  plugins: [crx({ manifest })],
+  server: {
+    https: true,
+  },
+})


### PR DESCRIPTION
Fixes #852 

Added support for the Vite config option `config.server.https`. When it is true, the plugin emit `https://localhost:{port}/...` for `service-worker-loader.js` and other locations.