### PR TITLE
fix: usage of newer picocolor api when using old dependency #1038

### DIFF
--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -76,7 +76,7 @@
     "jsesc": "^3.0.2",
     "magic-string": "^0.30.12",
     "pathe": "^2.0.1",
-    "picocolors": "^1.0.0",
+    "picocolors": "^1.1.1",
     "react-refresh": "^0.13.0",
     "rollup": "2.79.2",
     "rxjs": "7.5.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,7 +269,7 @@ importers:
         specifier: ^2.0.1
         version: 2.0.3
       picocolors:
-        specifier: ^1.0.0
+        specifier: ^1.1.1
         version: 1.1.1
       react-refresh:
         specifier: ^0.13.0
@@ -18448,7 +18448,11 @@ snapshots:
       pretty-format: 26.6.2
       throat: 5.0.0
     transitivePeerDependencies:
+      - bufferutil
+      - canvas
       - supports-color
+      - ts-node
+      - utf-8-validate
 
   jest-jasmine2@27.5.1:
     dependencies:


### PR DESCRIPTION
closes #1038