### PR TITLE
Fix flaky vite-plugin tests

### DIFF
--- a/packages/vite-plugin/tests/e2e/mv3-dynamic-script/manifest.json
+++ b/packages/vite-plugin/tests/e2e/mv3-dynamic-script/manifest.json
@@ -8,5 +8,10 @@
   "name": "test extension",
   "options_page": "src/options.html",
   "permissions": ["storage", "scripting"],
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "web_accessible_resources": [{
+    "matches": [ "<all_urls>" ],
+    "resources": [ "src/redirect.html" ],
+    "use_dynamic_url": false
+  }]
 }

--- a/packages/vite-plugin/tests/e2e/mv3-dynamic-script/src/options.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-dynamic-script/src/options.ts
@@ -21,7 +21,11 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
   }
 })
 
-chrome.tabs.create({ url: 'https://example.com' }).then((tab) => {
+// https://github.com/microsoft/playwright/issues/32865
+// Network mocking does not work for initial request when page opened via extension API chrome.tabs.create()
+// Network mocking _does_ work for the redirect request.
+const url = chrome.runtime.getURL('src/redirect.html')
+chrome.tabs.create({ url }).then((tab) => {
   newTab = tab
 })
 

--- a/packages/vite-plugin/tests/e2e/mv3-dynamic-script/src/redirect.html
+++ b/packages/vite-plugin/tests/e2e/mv3-dynamic-script/src/redirect.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1000, initial-scale=1.0" />
+    <meta http-equiv="refresh" content="0; URL=https://example.com" />
+    <title>Redirect</title>
+  </head>
+  <body>
+  </body>
+</html>

--- a/packages/vite-plugin/tests/e2e/mv3-vanilla-favicon-test/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vanilla-favicon-test/vite-serve.test.ts
@@ -7,9 +7,6 @@ test(
     const { browser } = await serve(__dirname)
 
     const contentPage = await browser.newPage()
-    // make sure the browser loads the github favicon
-    await contentPage.goto('https://github.com')
-    // then test loading it in the content script
     await contentPage.goto('https://example.com')
 
     await contentPage.waitForSelector('#favicon-test-container', {

--- a/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/manifest.json
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/manifest.json
@@ -5,5 +5,10 @@
   "background": { "service_worker": "src/background.ts" },
   "version": "1.0.0",
   "host_permissions": ["<all_urls>"],
-  "permissions": ["scripting"]
+  "permissions": ["scripting"],
+  "web_accessible_resources": [{
+    "matches": [ "<all_urls>" ],
+    "resources": [ "src/redirect.html" ],
+    "use_dynamic_url": false
+  }]
 }

--- a/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/src1/background.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/src1/background.ts
@@ -12,8 +12,11 @@ chrome.runtime.onInstalled.addListener(async ({ reason }) => {
       .then(() => {
         console.log('Content script registered successfully.')
         
+        // https://github.com/microsoft/playwright/issues/32865
+        // Network mocking does not work for initial request when page opened via extension API chrome.tabs.create()
+        // Network mocking _does_ work for the redirect request.
         chrome.tabs.create({
-          url: 'https://example.com'
+          url: chrome.runtime.getURL('src/redirect.html')
         }).catch(console.error);
       })
   }

--- a/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/src1/redirect.html
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-hmr/src1/redirect.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1000, initial-scale=1.0" />
+    <meta http-equiv="refresh" content="0; URL=https://example.com" />
+    <title>Redirect</title>
+  </head>
+  <body>
+  </body>
+</html>

--- a/packages/vite-plugin/tests/e2e/runners.ts
+++ b/packages/vite-plugin/tests/e2e/runners.ts
@@ -68,10 +68,10 @@ export async function serve(dirname: string) {
     routes.next(route)
   })
 
-  await browser
-    .pages()
-    .find((p) => p.url() === 'about:blank')
-    ?.goto('chrome://extensions')
+  // await browser
+  //   .pages()
+  //   .find((p) => p.url() === 'about:blank')
+  //   ?.goto('chrome://extensions')
 
   return {
     browser,

--- a/packages/vite-plugin/tests/e2e/runners.ts
+++ b/packages/vite-plugin/tests/e2e/runners.ts
@@ -1,3 +1,4 @@
+import { promises as fs } from 'fs'
 import path from 'pathe'
 import { chromium, ChromiumBrowserContext, Route } from 'playwright-chromium'
 import { Subject } from 'rxjs'
@@ -29,6 +30,7 @@ export async function build(dirname: string) {
   const { outDir, config } = await _build(dirname)
 
   const dataDir = path.join(config.cacheDir!, '.chromium')
+  await fs.rm(dataDir, { recursive: true, force: true, maxRetries: 5 });
   browser = (await chromium.launchPersistentContext(dataDir, {
     headless: false,
     slowMo: 100,
@@ -51,6 +53,7 @@ export async function serve(dirname: string) {
   await allFilesSuccess()
 
   const dataDir = path.join(config.cacheDir!, '.chromium')
+  await fs.rm(dataDir, { recursive: true, force: true, maxRetries: 5 });
   browser = (await chromium.launchPersistentContext(dataDir, {
     headless: false,
     slowMo: 100,

--- a/packages/vite-plugin/tests/runners.ts
+++ b/packages/vite-plugin/tests/runners.ts
@@ -117,11 +117,6 @@ export async function serve(dirname: string): Promise<ServeTestResult> {
   ]
   if (process.env.DEBUG) plugins.push(inspect())
 
-  const minPort = 5200
-  const maxPort = 5500
-  const randomPort =
-    Math.floor(Math.random() * (maxPort - minPort + 1)) + minPort
-
   const inlineConfig: InlineConfig = {
     root: dirname,
     configFile: join(dirname, 'vite.config.ts'),
@@ -132,11 +127,8 @@ export async function serve(dirname: string): Promise<ServeTestResult> {
     clearScreen: false,
     logLevel: 'error',
     server: {
-      port: randomPort,
-      strictPort: true,
-      hmr: {
-        port: randomPort,
-      },
+      port: 5200,
+      hmr: true,
       watch: {
         // cache dir should not trigger update in these tests
         ignored: [cacheDir],


### PR DESCRIPTION
Fixes a number of issues that cause tests to randomly fail.

Still doesn't always work locally when running tests in parallel — need more investigation there.