### PR TITLE
feat: add Discord notifications after changeset publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,48 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+  # Test Discord notification (no production environment required)
+  test-discord:
+    name: Test Discord Notification
+    if: inputs.test_discord == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send test Discord notification
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          # Check if webhook URL is configured
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "::error::DISCORD_WEBHOOK_URL secret is not configured."
+            exit 1
+          fi
+          
+          # Create the Discord webhook payload
+          PAYLOAD=$(jq -n \
+            '{
+              "username": "CRXJS Release Bot",
+              "avatar_url": "https://crxjs.dev/logo.svg",
+              "embeds": [{
+                "title": "[TEST] Test Discord Notification",
+                "description": "• This is a test notification to verify Discord webhook integration",
+                "color": 2105893,
+                "footer": {
+                  "text": "[TEST] CRXJS Chrome Extension Tools"
+                },
+                "timestamp": (now | strftime("%Y-%m-%dT%H:%M:%SZ"))
+              }]
+            }')
+          
+          # Send to Discord
+          curl -X POST "$DISCORD_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD"
+          
+          echo "Discord test notification sent successfully!"
+
   release:
     name: Release
+    if: inputs.test_discord != true
     runs-on: ubuntu-latest
     environment: production
     steps:
@@ -50,11 +90,9 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ env.cache-name }}-
 
       - name: Install dependencies
-        if: inputs.test_discord != true
         run: pnpm install
 
       - name: Create Release Pull Request or Publish to npm
-        if: inputs.test_discord != true
         id: changesets
         uses: changesets/action@v1
         with:
@@ -64,12 +102,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - if: steps.changesets.outputs.published == 'true' || inputs.test_discord == true
+      - if: steps.changesets.outputs.published == 'true'
         name: Notify Discord about new release
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
-          IS_TEST: ${{ inputs.test_discord == true }}
         run: |
           # Check if webhook URL is configured
           if [ -z "$DISCORD_WEBHOOK_URL" ]; then
@@ -77,32 +114,21 @@ jobs:
             exit 0
           fi
           
-          # Determine if this is a test run
-          if [ "$IS_TEST" = "true" ]; then
-            TEST_PREFIX="[TEST] "
-            TITLE="${TEST_PREFIX}Test Discord Notification"
-            PACKAGES="• This is a test notification to verify Discord webhook integration"
-          else
-            TEST_PREFIX=""
-            TITLE="New packages have been published to npm"
-            # Parse the published packages and create a Discord message
-            PACKAGES=$(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | "• \(.name)@\(.version)"' 2>/dev/null || echo "• New packages published")
-          fi
+          # Parse the published packages and create a Discord message
+          PACKAGES=$(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | "• \(.name)@\(.version)"' 2>/dev/null || echo "• New packages published")
           
           # Create the Discord webhook payload
           PAYLOAD=$(jq -n \
-            --arg title "$TITLE" \
             --arg description "$PACKAGES" \
-            --arg test_prefix "$TEST_PREFIX" \
             '{
               "username": "CRXJS Release Bot",
               "avatar_url": "https://crxjs.dev/logo.svg",
               "embeds": [{
-                "title": $title,
+                "title": "New packages have been published to npm",
                 "description": $description,
                 "color": 2105893,
                 "footer": {
-                  "text": ($test_prefix + "CRXJS Chrome Extension Tools")
+                  "text": "CRXJS Chrome Extension Tools"
                 },
                 "timestamp": (now | strftime("%Y-%m-%dT%H:%M:%SZ"))
               }]


### PR DESCRIPTION
## Summary

- Replaces the broken `sillyangel/releases-to-discord` action with a working Discord notification
- Sends rich embed messages to Discord after each successful changeset publish
- Lists all published packages with their versions

## Required Setup

Add `DISCORD_WEBHOOK_URL` secret to the repository (Settings → Secrets → Actions → New repository secret) with your Discord webhook URL.

## How it works

When `changesets/action` publishes packages (`published == 'true'`), this step:
1. Parses the published packages from changesets output
2. Creates a Discord embed with package names and versions
3. Sends it via `curl` to the Discord webhook

Fixes the FIXME from https://github.com/crxjs/chrome-extension-tools/actions/runs/13581366932/job/37967884502