### PR TITLE
chore: ignore @crxjs/vite-compat-test in changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["play-*"]
+  "ignore": ["play-*", "@crxjs/vite-compat-test"]
 }


### PR DESCRIPTION
## Summary
Add `@crxjs/vite-compat-test` to the changeset ignore list.

This package is a private test package (`"private": true`) used for compatibility testing and should not be tracked by changesets or included in version bumps.