### PR TITLE
ci: add timeout limits to CI jobs

### DIFF
--- a/.github/workflows/vite-plugin.yml
+++ b/.github/workflows/vite-plugin.yml
@@ -21,6 +21,7 @@ jobs:
   lint:
     name: Lint (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
@@ -58,6 +59,7 @@ jobs:
   unit-output:
     name: Unit & Output Tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
@@ -95,6 +97,7 @@ jobs:
   e2e:
     name: E2E Tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
@@ -141,6 +144,7 @@ jobs:
   compat:
     name: Compat Tests (${{ matrix.os }}, Vite ${{ matrix.vite-version }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Add `timeout-minutes` to all CI jobs to prevent them from running indefinitely if something hangs.

## Changes

| Job | Timeout |
|-----|---------|
| Lint | 5 minutes |
| Unit & Output Tests | 10 minutes |
| E2E Tests | 15 minutes |
| Compat Tests | 15 minutes |

This ensures that stuck jobs are automatically cancelled, saving CI resources and providing faster feedback when something goes wrong.