### PR TITLE
add: browser_specific_settings.gecko properties

### DIFF
--- a/.changeset/curvy-rockets-relate.md
+++ b/.changeset/curvy-rockets-relate.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": minor
+---
+
+add: browser_specific_settings.gecko properties

--- a/packages/vite-plugin/src/node/manifest.ts
+++ b/packages/vite-plugin/src/node/manifest.ts
@@ -279,4 +279,29 @@ export interface ManifestV3 {
   web_accessible_resources?:
     | (WebAccessibleResourceById | WebAccessibleResourceByMatch)[]
     | undefined
+  browser_specific_settings?:
+    | {
+        gecko: {
+            id: string;
+            strict_min_version?: string | undefined
+            strict_max_version?: string | undefined
+            update_url?: string | undefined
+            data_collection_permissions: {
+              /**
+               * available value: "personallyIdentifyingInfo" | "healthInfo" | "financialAndPaymentInfo" | "authenticationInfo" | "personalCommunications" | "locationInfo" | "browsingActivity" | "websiteContent" | "websiteActivity" | "searchTerms" | "bookmarksInfo" | "none".
+               * see also: https://extensionworkshop.com/documentation/develop/firefox-builtin-data-consent/
+              */
+              required: GeckoPermissionsRequired[]
+              /**
+               * available value: "personallyIdentifyingInfo" | "healthInfo" | "financialAndPaymentInfo" | "authenticationInfo" | "personalCommunications" | "locationInfo" | "browsingActivity" | "websiteContent" | "websiteActivity" | "searchTerms" | "bookmarksInfo" | "technicalAndInteraction".
+               * see also: https://extensionworkshop.com/documentation/develop/firefox-builtin-data-consent/
+              */
+              optional?: GeckoPermissionsOptional[] | undefined
+            }
+        }
+      }
+    | undefined
 }
+type GeckoPermissionsRequired = "personallyIdentifyingInfo" | "healthInfo" | "financialAndPaymentInfo" | "authenticationInfo" | "personalCommunications" | "locationInfo" | "browsingActivity" | "websiteContent" | "websiteActivity" | "searchTerms" | "bookmarksInfo" | "none"
+type GeckoPermissionsOptional = "personallyIdentifyingInfo" | "healthInfo" | "financialAndPaymentInfo" | "authenticationInfo" | "personalCommunications" | "locationInfo" | "browsingActivity" | "websiteContent" | "websiteActivity" | "searchTerms" | "bookmarksInfo" | "technicalAndInteraction"
+


### PR DESCRIPTION
add browser_specific_settings.gecko optional properties for interface ManifestV3. If we register add-on on addons.mozilla.org, must define browser_specific_settings.gecko.data_collection_permissions.