### PR TITLE
ci: migrate release workflow to npm trusted publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,10 @@ jobs:
     if: inputs.test_discord != true
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
@@ -67,6 +71,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Setup PNPM
         # You may pin to the exact commit or the version.
@@ -100,7 +105,7 @@ jobs:
           publish: pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
 
       - if: steps.changesets.outputs.published == 'true'
         name: Notify Discord about new release


### PR DESCRIPTION
Replace static NPM_TOKEN with OIDC-based trusted publisher authentication. Adds id-token: write permission, configures npm registry via setup-node, and enables provenance attestations via NPM_CONFIG_PROVENANCE.