### PR TITLE
feat(vite-plugin): add liveReload option to disable automatic extension reload and HMR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 **/tests/artifacts
 .vscode
 **/chromium-data-dir-*
-**/tests/e2e/mv3-*-hmr/src
+**/tests/e2e/mv3-*/src
 **/__diff_output__
 TODO
 pnpm-global

--- a/packages/vite-plugin/src/client/es/hmr-client-worker.ts
+++ b/packages/vite-plugin/src/client/es/hmr-client-worker.ts
@@ -16,6 +16,7 @@ declare const __HMR_PORT__: string
 declare const __HMR_TIMEOUT__: number
 declare const __SERVER_PROTO__: string
 declare const __SERVER_PORT__: string
+declare const __LIVE_RELOAD__: boolean
 
 /* -------- REDIRECT FETCH TO THE DEV SERVER ------- */
 
@@ -130,6 +131,15 @@ function handleSocketMessage(payload: HMRPayload) {
 }
 
 function handleCrxHmrPayload(payload: CrxHMRPayload) {
+  if (!__LIVE_RELOAD__) {
+    // when liveReload is disabled, don't relay any CRX payloads to content
+    // scripts and don't reload the extension
+    if (payload.event === 'crx:runtime-reload') {
+      console.log('[crx] runtime reload suppressed (liveReload disabled)')
+    }
+    return
+  }
+
   // everything goes to the content scripts
   notifyContentScripts(payload)
 
@@ -162,8 +172,14 @@ socket.addEventListener('close', async ({ wasClean }) => {
   if (wasClean) return
   console.log(`[vite] server connection lost. polling for restart...`)
   await waitForSuccessfulPing()
-  handleCrxHmrPayload({
-    type: 'custom',
-    event: 'crx:runtime-reload',
-  })
+  if (__LIVE_RELOAD__) {
+    handleCrxHmrPayload({
+      type: 'custom',
+      event: 'crx:runtime-reload',
+    })
+  } else {
+    console.log(
+      '[crx] server reconnected, skipping reload (liveReload disabled)',
+    )
+  }
 })

--- a/packages/vite-plugin/src/client/es/hmr-content-port.ts
+++ b/packages/vite-plugin/src/client/es/hmr-content-port.ts
@@ -4,6 +4,7 @@ import type { CrxHMRPayload } from 'src/types'
 import type { HMRPayload } from 'vite'
 
 declare const __CRX_HMR_TIMEOUT__: number
+declare const __CRX_LIVE_RELOAD__: boolean
 
 function isCrxHMRPayload(x: HMRPayload): x is CrxHMRPayload {
   return x.type === 'custom' && x.event.startsWith('crx:')
@@ -63,9 +64,13 @@ export class HMRPort {
     const payload: HMRPayload | CrxHMRPayload = JSON.parse(message.data)
     if (isCrxHMRPayload(payload)) {
       if (payload.event === 'crx:runtime-reload') {
-        // delayed page reload; let background finish restart
-        console.log('[crx] runtime reload')
-        setTimeout(() => location.reload(), 500)
+        if (__CRX_LIVE_RELOAD__) {
+          // delayed page reload; let background finish restart
+          console.log('[crx] runtime reload')
+          setTimeout(() => location.reload(), 500)
+        } else {
+          console.log('[crx] runtime reload suppressed (liveReload disabled)')
+        }
       } else {
         // unpack hmr payloads; forward to vite client
         // console.log('[crx] content payload', payload)

--- a/packages/vite-plugin/src/node/plugin-background.ts
+++ b/packages/vite-plugin/src/node/plugin-background.ts
@@ -24,6 +24,7 @@ import { workerClientId } from './virtualFileIds'
 export const pluginBackground: CrxPluginFn = () => {
   let config: ResolvedConfig
   let browser: Browser
+  let liveReload = true
 
   return [
     {
@@ -34,9 +35,13 @@ export const pluginBackground: CrxPluginFn = () => {
       },
       load(id) {
         if (id === workerClientId) {
-          const base = `${config.server.https ? 'https' : 'http'}://localhost:${config.server.port}/`
+          const base = `${config.server.https ? 'https' : 'http'}://localhost:${
+            config.server.port
+          }/`
           return defineClientValues(
-            workerHmrClient.replace('__BASE__', JSON.stringify(base)),
+            workerHmrClient
+              .replace('__BASE__', JSON.stringify(base))
+              .replace('__LIVE_RELOAD__', JSON.stringify(liveReload)),
             config,
           )
         }
@@ -49,6 +54,7 @@ export const pluginBackground: CrxPluginFn = () => {
       async config(config) {
         const opts = await getOptions(config)
         browser = opts.browser || 'chrome'
+        liveReload = opts.liveReload !== false
       },
       configResolved(_config) {
         config = _config
@@ -61,7 +67,7 @@ export const pluginBackground: CrxPluginFn = () => {
 
         let loader: string
         if (config.command === 'serve') {
-          const proto = config.server.https ? 'https' : 'http';
+          const proto = config.server.https ? 'https' : 'http'
           const port = config.server.port?.toString()
           if (typeof port === 'undefined')
             throw new Error('server port is undefined in watch mode')

--- a/packages/vite-plugin/src/node/plugin-contentScripts.ts
+++ b/packages/vite-plugin/src/node/plugin-contentScripts.ts
@@ -35,6 +35,7 @@ export const pluginContentScripts: CrxPluginFn = () => {
   let server: ViteDevServer
   let preambleCode: string | false | undefined
   let hmrTimeout: number | undefined
+  let liveReload = true
   let sub = new Subscription()
 
   const worldMainIds = new Set<string>()
@@ -70,9 +71,11 @@ export const pluginContentScripts: CrxPluginFn = () => {
       apply: 'serve',
       async config(config, env) {
         await findWorldMainIds(config, env)
-        const { contentScripts = {} } = await getOptions(config)
+        const opts = await getOptions(config)
+        const { contentScripts = {} } = opts
         hmrTimeout = contentScripts.hmrTimeout ?? 5000
         preambleCode = preambleCode ?? contentScripts.preambleCode
+        liveReload = opts.liveReload !== false
       },
       async configureServer(_server) {
         server = _server
@@ -141,10 +144,9 @@ export const pluginContentScripts: CrxPluginFn = () => {
         }
 
         if (id === contentHmrPortId) {
-          const defined = contentHmrPort.replace(
-            '__CRX_HMR_TIMEOUT__',
-            JSON.stringify(hmrTimeout),
-          )
+          const defined = contentHmrPort
+            .replace('__CRX_HMR_TIMEOUT__', JSON.stringify(hmrTimeout))
+            .replace('__CRX_LIVE_RELOAD__', JSON.stringify(liveReload))
           return defined
         }
       },

--- a/packages/vite-plugin/src/node/plugin-hmr.ts
+++ b/packages/vite-plugin/src/node/plugin-hmr.ts
@@ -10,6 +10,7 @@ import { _debug } from './helpers'
 import { isImporter } from './isImporter'
 import { isAbsolute, join } from './path'
 import { getContentCssEntries } from './plugin-contentScripts_declared'
+import { getOptions } from './plugin-optionsProvider'
 import type { CrxHMRPayload, CrxPluginFn, ManifestFiles } from './types'
 import { isContentCssId } from './virtualFileIds'
 
@@ -25,6 +26,7 @@ export const pluginHMR: CrxPluginFn = () => {
   let decoratedSend: ((payload: HMRPayload) => void) | undefined
   let config: ResolvedConfig
   let subs: Subscription
+  let liveReload = true
 
   return [
     {
@@ -33,6 +35,8 @@ export const pluginHMR: CrxPluginFn = () => {
       enforce: 'pre',
       // server hmr host should be localhost
       async config({ server = {}, ...config }) {
+        const opts = await getOptions({ ...config, server })
+        liveReload = opts.liveReload !== false
         if (server.hmr === false) return
         if (server.hmr === true) server.hmr = {}
         server.hmr = server.hmr ?? {}
@@ -76,7 +80,11 @@ export const pluginHMR: CrxPluginFn = () => {
           subs.add(fileWriterError$.subscribe(send))
           subs.add(
             crxHMRPayload$.subscribe((payload) => {
-              send(payload) // send crx hmr and error events
+              // keep subscription alive for file writer side effects,
+              // but skip sending HMR payloads when liveReload is disabled
+              if (liveReload) {
+                send(payload) // send crx hmr and error events
+              }
             }),
           )
         }
@@ -125,8 +133,12 @@ export const pluginHMR: CrxPluginFn = () => {
             relFiles.has(background) ||
             modules.some(isImporter(join(server.config.root, background)))
           ) {
-            debug('sending runtime reload')
-            server.ws.send(crxRuntimeReload)
+            if (liveReload) {
+              debug('sending runtime reload')
+              server.ws.send(crxRuntimeReload)
+            } else {
+              debug('skipping runtime reload (liveReload disabled)')
+            }
           }
         }
 

--- a/packages/vite-plugin/src/node/types.ts
+++ b/packages/vite-plugin/src/node/types.ts
@@ -91,6 +91,20 @@ export interface CrxOptions {
    * Default is "chrome".
    */
   browser?: Browser
+  /**
+   * Enable automatic extension reload and HMR during development. When false:
+   *
+   * - The extension will not call `chrome.runtime.reload()` on background changes
+   *   or dev server reconnection.
+   * - Content scripts will not receive HMR updates or reload their host pages.
+   * - Files are still rebuilt and written to the output directory on change.
+   *
+   * Use this when content scripts have side effects on injection and you want
+   * to manually reload the extension in the browser.
+   *
+   * Default is `true`.
+   */
+  liveReload?: boolean
 }
 
 export type Browser = 'firefox' | 'chrome'

--- a/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-default/manifest.json
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-default/manifest.json
@@ -1,0 +1,14 @@
+{
+  "description": "test extension",
+  "manifest_version": 3,
+  "name": "test extension",
+  "background": { "service_worker": "src/background.ts" },
+  "content_scripts": [
+    {
+      "matches": ["https://example.com/*"],
+      "js": ["src/content.ts"]
+    }
+  ],
+  "options_page": "src/options.html",
+  "version": "1.0.0"
+}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-default/src1/background.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-default/src1/background.ts
@@ -1,0 +1,3 @@
+import { onLoad } from './bg-onload'
+
+chrome.runtime.onMessage.addListener(onLoad)

--- a/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-default/src1/bg-onload.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-default/src1/bg-onload.ts
@@ -1,0 +1,6 @@
+export const onLoad = () => {
+  chrome.runtime.openOptionsPage()
+  console.log('opened options page')
+}
+
+export {}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-default/src1/content.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-default/src1/content.ts
@@ -1,0 +1,8 @@
+const app = document.createElement('div')
+app.id = 'app'
+app.innerHTML = `<h1>Hello from content script</h1>`
+document.body.append(app)
+
+chrome.runtime.sendMessage({ type: 'content-script-load' })
+
+export {}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-default/src1/options.html
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-default/src1/options.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Options</title>
+  </head>
+  <body>
+    <h1>Options</h1>
+  </body>
+</html>

--- a/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-default/src2/bg-onload.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-default/src2/bg-onload.ts
@@ -1,0 +1,5 @@
+export const onLoad = () => {
+  console.log('post runtime reload')
+}
+
+export {}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-default/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-default/vite-serve.test.ts
@@ -1,0 +1,43 @@
+import fs from 'fs-extra'
+import path from 'pathe'
+import { firstValueFrom } from 'rxjs'
+import { expect, test } from 'vitest'
+import { createUpdate, getPage } from '../helpers'
+import { serve } from '../runners'
+
+test('liveReload default: background change triggers runtime reload', async () => {
+  const src = path.join(__dirname, 'src')
+  const src1 = path.join(__dirname, 'src1')
+  const src2 = path.join(__dirname, 'src2')
+
+  await fs.remove(src)
+  await fs.copy(src1, src, { recursive: true })
+
+  const { browser, routes } = await serve(__dirname)
+
+  const page = await browser.newPage()
+  const update = createUpdate({ target: src, src: src2 })
+  const app = page.locator('#app')
+
+  await page.goto('https://example.com')
+  await app.waitFor()
+
+  let reloads = 0
+  routes.subscribe(() => {
+    reloads++
+  })
+
+  const optionsPage = await getPage(browser, /options.html$/)
+  expect(optionsPage.isClosed()).toBe(false)
+
+  // update background dependency -> should trigger runtime reload
+  const closeEvent = optionsPage.waitForEvent('close', { timeout: 5000 })
+  await update('bg-onload.ts')
+  await firstValueFrom(routes)
+  await closeEvent
+
+  // runtime reload happened: options page closed, content script page reloaded
+  expect(optionsPage.isClosed()).toBe(true)
+  expect(reloads).toBeGreaterThanOrEqual(1)
+  await app.waitFor({ timeout: 15_000 })
+})

--- a/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-default/vite.config.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-default/vite.config.ts
@@ -1,0 +1,10 @@
+import { crx } from '../../plugin-testOptionsProvider'
+import { defineConfig } from 'vite'
+import manifest from './manifest.json'
+
+export default defineConfig({
+  build: { minify: false },
+  clearScreen: false,
+  logLevel: 'error',
+  plugins: [crx({ manifest })],
+})

--- a/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-disabled/manifest.json
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-disabled/manifest.json
@@ -1,0 +1,14 @@
+{
+  "description": "test extension",
+  "manifest_version": 3,
+  "name": "test extension",
+  "background": { "service_worker": "src/background.ts" },
+  "content_scripts": [
+    {
+      "matches": ["https://example.com/*"],
+      "js": ["src/content.ts"]
+    }
+  ],
+  "options_page": "src/options.html",
+  "version": "1.0.0"
+}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-disabled/src1/background.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-disabled/src1/background.ts
@@ -1,0 +1,3 @@
+import { onLoad } from './bg-onload'
+
+chrome.runtime.onMessage.addListener(onLoad)

--- a/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-disabled/src1/bg-onload.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-disabled/src1/bg-onload.ts
@@ -1,0 +1,6 @@
+export const onLoad = () => {
+  chrome.runtime.openOptionsPage()
+  console.log('opened options page')
+}
+
+export {}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-disabled/src1/content.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-disabled/src1/content.ts
@@ -1,0 +1,8 @@
+const app = document.createElement('div')
+app.id = 'app'
+app.innerHTML = `<h1>Hello from content script</h1>`
+document.body.append(app)
+
+chrome.runtime.sendMessage({ type: 'content-script-load' })
+
+export {}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-disabled/src1/options.html
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-disabled/src1/options.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Options</title>
+  </head>
+  <body>
+    <h1>Options</h1>
+  </body>
+</html>

--- a/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-disabled/src2/bg-onload.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-disabled/src2/bg-onload.ts
@@ -1,0 +1,5 @@
+export const onLoad = () => {
+  console.log('post runtime reload')
+}
+
+export {}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-disabled/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-disabled/vite-serve.test.ts
@@ -1,0 +1,41 @@
+import fs from 'fs-extra'
+import path from 'pathe'
+import { expect, test } from 'vitest'
+import { createUpdate, getPage } from '../helpers'
+import { serve } from '../runners'
+
+test('liveReload false: background change does not trigger runtime reload', async () => {
+  const src = path.join(__dirname, 'src')
+  const src1 = path.join(__dirname, 'src1')
+  const src2 = path.join(__dirname, 'src2')
+
+  await fs.remove(src)
+  await fs.copy(src1, src, { recursive: true })
+
+  const { browser, routes } = await serve(__dirname)
+
+  const page = await browser.newPage()
+  const update = createUpdate({ target: src, src: src2 })
+  const app = page.locator('#app')
+
+  await page.goto('https://example.com')
+  await app.waitFor()
+
+  let reloads = 0
+  routes.subscribe(() => {
+    reloads++
+  })
+
+  const optionsPage = await getPage(browser, /options.html$/)
+  expect(optionsPage.isClosed()).toBe(false)
+
+  // update background dependency -> should NOT trigger runtime reload
+  await update('bg-onload.ts')
+
+  // wait enough time for a reload to have happened if it was going to
+  await new Promise((r) => setTimeout(r, 3000))
+
+  // runtime reload did NOT happen: options page still open, no page reloads
+  expect(optionsPage.isClosed()).toBe(false)
+  expect(reloads).toBe(0)
+})

--- a/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-disabled/vite.config.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-live-reload-disabled/vite.config.ts
@@ -1,0 +1,10 @@
+import { crx } from '../../plugin-testOptionsProvider'
+import { defineConfig } from 'vite'
+import manifest from './manifest.json'
+
+export default defineConfig({
+  build: { minify: false },
+  clearScreen: false,
+  logLevel: 'error',
+  plugins: [crx({ manifest, liveReload: false })],
+})


### PR DESCRIPTION
## Summary

Adds a `liveReload` option to `CrxOptions` that allows users to disable automatic extension reload and HMR during development. When `liveReload: false`, file changes still update the `outDir` on disk, but the extension does not automatically call `chrome.runtime.reload()`, push HMR updates to content scripts, or trigger `location.reload()` on host pages. Users can then manually reload the extension in Chrome when ready.

Closes https://github.com/crxjs/chrome-extension-tools/discussions/1146

## Usage

```ts
// vite.config.ts
import { crx } from '@crxjs/vite-plugin'

export default defineConfig({
  plugins: [
    crx({
      manifest,
      liveReload: false, // disable automatic reload/HMR
    }),
  ],
})
```

## Implementation

Three layers are gated by the option:

1. **Server side** (`plugin-hmr.ts`) — skips sending `crx:runtime-reload` and `crx:content-script-payload` WebSocket messages. The RxJS `crxHMRPayload$` subscription (which writes files to `outDir`) stays alive.
2. **Service worker client** (`hmr-client-worker.ts`) — `__LIVE_RELOAD__` build-time constant gates `chrome.runtime.reload()`, `notifyContentScripts()`, and reconnection-triggered reload.
3. **Content script client** (`hmr-content-port.ts`) — `__CRX_LIVE_RELOAD__` build-time constant gates `location.reload()`.

The option defaults to `true` (existing behavior preserved).

## Changes

- `src/node/types.ts` — Added `liveReload?: boolean` to `CrxOptions` with JSDoc
- `src/node/plugin-hmr.ts` — Gates WebSocket `send()` calls based on option
- `src/node/plugin-background.ts` — Injects `__LIVE_RELOAD__` into service worker client
- `src/node/plugin-contentScripts.ts` — Injects `__CRX_LIVE_RELOAD__` into content port client
- `src/client/es/hmr-client-worker.ts` — Guards reload calls with `__LIVE_RELOAD__`
- `src/client/es/hmr-content-port.ts` — Guards `location.reload()` with `__CRX_LIVE_RELOAD__`
- `.gitignore` — Broadened e2e test `src/` ignore pattern

## Tests

Two new e2e test fixtures:
- `mv3-vite-live-reload-default` — verifies default behavior: background change triggers runtime reload (options page closes, content page reloads)
- `mv3-vite-live-reload-disabled` — verifies `liveReload: false`: background change does NOT trigger reload (options page stays open, zero page reloads)