### PR TITLE
fix: sanitize colons from output filenames on Windows

### DIFF
--- a/.changeset/five-impalas-turn.md
+++ b/.changeset/five-impalas-turn.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+fix: sanitize colons from output filenames on Windows

--- a/packages/vite-plugin/src/node/fileWriter-utilities.test.ts
+++ b/packages/vite-plugin/src/node/fileWriter-utilities.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'vitest'
+import { getFileName } from './fileWriter-utilities'
+
+// Characters that are illegal in Windows filenames
+const WINDOWS_ILLEGAL_CHARS = /[<>:"|?*]/
+
+describe('getFileName', () => {
+  test('strips leading slash from id', () => {
+    expect(getFileName({ type: 'module', id: '/src/main.ts' })).toBe(
+      'src/main.ts.js',
+    )
+  })
+
+  test('converts url query characters', () => {
+    const result = getFileName({
+      type: 'module',
+      id: '/src/App.vue?vue&type=script&setup=true&lang.ts',
+    })
+    expect(result).not.toContain('?')
+    expect(result).not.toContain('&')
+    expect(result).not.toContain('=')
+  })
+
+  test('strips timestamps', () => {
+    expect(getFileName({ type: 'module', id: '/src/main.ts?t=12345' })).toBe(
+      'src/main.ts.js',
+    )
+  })
+
+  test('moves node_modules to vendor/', () => {
+    const result = getFileName({
+      type: 'module',
+      id: '/node_modules/vue/dist/vue.runtime.esm-bundler.js',
+    })
+    expect(result).toMatch(/^vendor\//)
+    expect(result).not.toContain('node_modules')
+  })
+
+  test('moves @-scoped packages to vendor/', () => {
+    const result = getFileName({
+      type: 'module',
+      id: '/@id/__x00__plugin-vue:export-helper',
+    })
+    expect(result).toMatch(/^vendor\//)
+  })
+
+  test('sanitizes colons for Windows compatibility', () => {
+    const result = getFileName({
+      type: 'module',
+      id: '/@id/__x00__plugin-vue:export-helper',
+    })
+    expect(result).not.toMatch(WINDOWS_ILLEGAL_CHARS)
+    expect(result).toBe('vendor/id-__x00__plugin-vue-export-helper.js')
+  })
+
+  test('produces Windows-safe filenames for all types', () => {
+    const ids = [
+      '/@id/__x00__plugin-vue:export-helper',
+      '/src/App.vue?vue&type=style&index=0&scoped=abc&lang.css',
+      '/node_modules/.vite/deps/vue.js?v=e5500e05',
+    ]
+    for (const id of ids) {
+      for (const type of ['module', 'iife', 'loader', 'asset'] as const) {
+        const result = getFileName({ type, id })
+        expect(result).not.toMatch(WINDOWS_ILLEGAL_CHARS)
+      }
+    }
+  })
+
+  test('appends correct extension per type', () => {
+    const id = '/src/main.ts'
+    expect(getFileName({ type: 'module', id })).toBe('src/main.ts.js')
+    expect(getFileName({ type: 'iife', id })).toBe('src/main.ts.iife.js')
+    expect(getFileName({ type: 'loader', id })).toBe('src/main.ts-loader.js')
+    expect(getFileName({ type: 'asset', id })).toBe('src/main.ts')
+  })
+
+  test('sanitizes leading underscores from basename', () => {
+    const result = getFileName({ type: 'asset', id: '/__uno.css' })
+    expect(result).toBe('uno.css')
+  })
+})

--- a/packages/vite-plugin/src/node/fileWriter-utilities.ts
+++ b/packages/vite-plugin/src/node/fileWriter-utilities.ts
@@ -76,6 +76,7 @@ export function getFileName({ type, id }: FileWriterId): string {
     .replace(/\?/g, '__') // convert url queries
     .replace(/&/g, '_')
     .replace(/=/g, '--')
+    .replace(/:/g, '-') // colons are illegal on Windows
   if (fileName.includes('node_modules/')) {
     fileName = `vendor/${fileName
       .split('node_modules/')

--- a/packages/vite-plugin/tests/e2e/mv3-vite-vue-content-script/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-vue-content-script/vite-serve.test.ts
@@ -1,3 +1,5 @@
+import { basename } from 'path'
+import { glob } from 'tinyglobby'
 import { test, expect } from 'vitest'
 import { getCustomId } from '../helpers'
 import { serve } from '../runners'
@@ -18,3 +20,17 @@ test(
   },
   { retry: process.env.CI ? 5 : 0 },
 )
+
+test('no output files contain Windows-illegal characters', async () => {
+  const { outDir } = await serve(__dirname)
+  const files = await glob('**/*', { cwd: outDir })
+
+  // Colons, angle brackets, double quotes, pipes, question marks, and
+  // asterisks are all forbidden in Windows filenames.
+  const windowsIllegal = /[<>:"|?*]/
+  const invalidFiles = files.filter((file) =>
+    file.split('/').some((segment) => windowsIllegal.test(segment)),
+  )
+
+  expect(invalidFiles).toEqual([])
+})


### PR DESCRIPTION
## Summary

Fixes #1153

- Sanitize colons (`:`) from output filenames in `getFileName()`, preventing Windows filesystem errors during dev mode
- Add unit tests for `getFileName()` which previously had zero test coverage
- Add e2e test asserting Vue content script output filenames contain no Windows-illegal characters

## Problem

Vite virtual modules (e.g. `\0plugin-vue:export-helper` from `@vitejs/plugin-vue`) get encoded as `/@id/__x00__plugin-vue:export-helper` in URLs. The `getFileName()` function converts these to disk filenames but did not sanitize the colon (`:`) character, which is **illegal on Windows filesystems**. This caused content scripts to fail to load during `npm run dev` on Windows.

The generated filename was: `vendor/id-__x00__plugin-vue:export-helper.js`
After this fix: `vendor/id-__x00__plugin-vue-export-helper.js`

## Changes

| File | Change |
|------|--------|
| `packages/vite-plugin/src/node/fileWriter-utilities.ts` | Added `.replace(/:/g, '-')` to the sanitization chain in `getFileName()` |
| `packages/vite-plugin/src/node/fileWriter-utilities.test.ts` | New: 9 unit tests covering colon sanitization, Windows-illegal characters, extension types, and existing behaviors |
| `tests/e2e/mv3-vite-vue-content-script/vite-serve.test.ts` | New: e2e test asserting no output files contain Windows-illegal characters |

## Testing

- All unit tests pass (9 new ones for `getFileName()`)
- All e2e tests pass including the new filename safety assertion
- Verified tests go **red** without the fix (both unit and e2e correctly catch the colon in the filename)