### PR TITLE
poll for file changes instead of wait a fixed amount of time

### DIFF
--- a/.changeset/silver-rockets-cross.md
+++ b/.changeset/silver-rockets-cross.md
@@ -1,5 +1,0 @@
----
-"@crxjs/vite-plugin": patch
----
-
-poll for file changes instead of wait a fixed amount of time

--- a/.changeset/silver-rockets-cross.md
+++ b/.changeset/silver-rockets-cross.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+poll for file changes instead of wait a fixed amount of time

--- a/packages/vite-plugin/tests/e2e/helpers.ts
+++ b/packages/vite-plugin/tests/e2e/helpers.ts
@@ -168,3 +168,46 @@ export async function waitForRegisteredContentScripts(
     `Timed out after ${timeout}ms waiting for content scripts to register: ${expectedIds.join(', ')}`,
   )
 }
+
+/**
+ * Wait until the IIFE bundle for a registered content script has been rebuilt
+ * to contain `needle`. Discovers the on-disk filename by asking the SW which
+ * `js` paths are currently registered for `scriptId`, then polls those files
+ * under `outDir` until one matches.
+ *
+ * Use this instead of a fixed sleep after editing a source file: the HMR plugin
+ * only signals runtime-reload once the IIFE rebuild promise resolves, so the
+ * output file's content is the most direct "rebuild finished" signal.
+ */
+export async function waitForContentScriptContent(
+  browser: BrowserContext,
+  outDir: string,
+  scriptId: string,
+  needle: string,
+  { timeout = 15000, interval = 100 }: { timeout?: number; interval?: number } = {},
+): Promise<void> {
+  const deadline = Date.now() + timeout
+  while (Date.now() < deadline) {
+    const sw = await getServiceWorker(browser)
+    if (sw) {
+      try {
+        const jsPaths: string[] = await sw.evaluate(async (id) => {
+          if (typeof chrome === 'undefined' || !chrome.scripting) return []
+          const r = await chrome.scripting.getRegisteredContentScripts({ ids: [id] })
+          return r.flatMap((s) => s.js ?? [])
+        }, scriptId)
+        for (const p of jsPaths) {
+          const file = join(outDir, p.replace(/^\//, ''))
+          try {
+            const content = await fs.readFile(file, 'utf8')
+            if (content.includes(needle)) return
+          } catch { /* file may not exist mid-rebuild */ }
+        }
+      } catch { /* SW restarted mid-evaluate — loop and retry */ }
+    }
+    await new Promise((r) => setTimeout(r, interval))
+  }
+  throw new Error(
+    `Timed out after ${timeout}ms waiting for "${needle}" in content script bundle for "${scriptId}"`,
+  )
+}

--- a/packages/vite-plugin/tests/e2e/mv3-dynamic-script-iife/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-dynamic-script-iife/vite-serve.test.ts
@@ -2,7 +2,10 @@ import fs from 'fs-extra'
 import path from 'pathe'
 import { expect, test } from 'vitest'
 import { serve } from '../runners'
-import { waitForRegisteredContentScripts } from '../helpers'
+import {
+  waitForContentScriptContent,
+  waitForRegisteredContentScripts,
+} from '../helpers'
 
 test(
   'iife content script rebuilds on change and works after page reload',
@@ -16,7 +19,7 @@ test(
     await fs.emptyDir(src)
     await fs.copy(src1, src, { overwrite: true, recursive: true })
 
-    const { browser } = await serve(__dirname)
+    const { browser, outDir } = await serve(__dirname)
 
     // Wait for the background script to register the content script
     await waitForRegisteredContentScripts(browser, ['main-world-script'])
@@ -37,9 +40,14 @@ test(
       path.join(src, 'main-world.ts'),
     )
 
-    // Wait for the file watcher to pick up changes and rebuild the IIFE
-    // Note: IIFE scripts don't have HMR, but they should rebuild on file change
-    await new Promise((resolve) => setTimeout(resolve, 5000))
+    // Wait for the IIFE rebuild to finish by polling the on-disk bundle for
+    // the updated content (more reliable than a fixed timeout).
+    await waitForContentScriptContent(
+      browser,
+      outDir,
+      'main-world-script',
+      'src2',
+    )
 
     // Reload the page - the updated script should now inject
     // Navigate to a different page first to clear any cache


### PR DESCRIPTION
This PR only touches tests, so it's low risk.

Introduced a helper util that can check for file changes (useful for IIFE files).

Before:
```
 ✓ tests/e2e/mv3-dynamic-script-iife/vite-serve.test.ts (1) 8029ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  13:25:57
   Duration  8.82s (transform 185ms, setup 70ms, collect 526ms, tests 8.03s)
```

After:
```
 ✓ tests/e2e/mv3-dynamic-script-iife/vite-serve.test.ts (1) 3634ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  13:26:25
   Duration  4.25s (transform 182ms, setup 46ms, collect 404ms, tests 3.63s)
```