### PR TITLE
test: replace fixed e2e waits

### DIFF
--- a/.changeset/exten-vite-compatibility-matrix-tests.md
+++ b/.changeset/exten-vite-compatibility-matrix-tests.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+ci: run full test suite agains all supported vite versions instead of just a handful of critical tests

--- a/.changeset/vite-compat-matrix.md
+++ b/.changeset/vite-compat-matrix.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+ci: add Vite version compat matrix job (`test:run:compat`) and `tests/vite-compat/` fixture

--- a/.github/workflows/vite-plugin.yml
+++ b/.github/workflows/vite-plugin.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Run e2e tests
         uses: coactions/setup-xvfb@v1
         with:
-          run: pnpm test:run:e2e
+          run: pnpm exec vitest --run --mode e2e ${{ matrix.vite-version == '8' && '--threads false' || '' }}
           working-directory: packages/vite-plugin
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/vite-plugin.yml
+++ b/.github/workflows/vite-plugin.yml
@@ -5,14 +5,12 @@ on:
     branches: [main]
     paths:
       - "packages/vite-plugin/**"
-      - "tests/vite-compat/**"
       - ".github/workflows/vite-plugin.yml"
       - "!**.md"
   pull_request:
     branches: [main]
     paths:
       - "packages/vite-plugin/**"
-      - "tests/vite-compat/**"
       - ".github/workflows/vite-plugin.yml"
       - "!**.md"
   workflow_dispatch:
@@ -21,7 +19,6 @@ jobs:
   lint:
     name: Lint (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 5
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
@@ -51,18 +48,19 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ env.cache-name }}-
 
       - name: Install dependencies
-        run: pnpm install --filter "vite-plugin"
+        run: pnpm install --filter "vite-plugin" --ignore-scripts
 
-      - name: Lint files
+      - name: Lint
         run: pnpm lint
 
   unit-output:
-    name: Unit & Output Tests (${{ matrix.os }})
+    name: Unit & Output Tests (${{ matrix.os }}, Vite ${{ matrix.vite-version }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
+        vite-version: ["3", "6", "7", "8"]
     defaults:
       run:
         working-directory: packages/vite-plugin
@@ -91,16 +89,28 @@ jobs:
       - name: Install dependencies
         run: pnpm install --filter "vite-plugin"
 
-      - name: Run unit and output tests
+      - name: Build plugin (always on Vite 3)
+        run: pnpm build
+
+      - name: Install Vite ${{ matrix.vite-version }} for testing
+        if: matrix.vite-version != '3'
+        run: pnpm add -D vite@${{ matrix.vite-version }} --ignore-scripts
+
+      - name: Verify Vite version
+        run: echo "Testing with Vite $(pnpm exec vite --version)"
+
+      - name: Run unit and output tests (Vite 3 only - includes snapshots)
+        if: matrix.vite-version == '3'
         run: pnpm test:run:out
 
   e2e:
-    name: E2E Tests (${{ matrix.os }})
+    name: E2E Tests (${{ matrix.os }}, Vite ${{ matrix.vite-version }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
+        vite-version: ["3", "6", "7", "8"]
     defaults:
       run:
         working-directory: packages/vite-plugin
@@ -128,6 +138,16 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --filter "vite-plugin"
+
+      - name: Build plugin (always on Vite 3)
+        run: pnpm build
+
+      - name: Install Vite ${{ matrix.vite-version }} for testing
+        if: matrix.vite-version != '3'
+        run: pnpm add -D vite@${{ matrix.vite-version }} --ignore-scripts
+
+      - name: Verify Vite version
+        run: echo "Testing with Vite $(pnpm exec vite --version)"
 
       - name: Run e2e tests
         uses: coactions/setup-xvfb@v1
@@ -138,60 +158,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: image-diff-${{ matrix.os }}
+          name: image-diff-${{ matrix.os }}-vite-${{ matrix.vite-version }}
           path: ${{ github.workspace }}/packages/vite-plugin/tests/**/__image_snapshots__/__diff_output__/*.png
-
-  compat:
-    name: Compat Tests (${{ matrix.os }}, Vite ${{ matrix.vite-version }})
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-        vite-version: ["3", "6", "7", "8"]
-    defaults:
-      run:
-        working-directory: tests/vite-compat
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "22"
-
-      - name: Setup PNPM
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.11.1
-
-      - name: Cache pnpm modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-pnpm-modules
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/package.json') }}
-          restore-keys: ${{ runner.os }}-${{ env.cache-name }}-
-
-      - name: Install dependencies
-        run: pnpm install
-        working-directory: .
-
-      - name: Build vite-plugin
-        run: pnpm build
-        working-directory: packages/vite-plugin
-
-      - name: Install Vite ${{ matrix.vite-version }}
-        run: pnpm add vite@${{ matrix.vite-version }}
-
-      - name: Re-install to link dependencies
-        run: pnpm install
-        working-directory: .
-
-      - name: Run compat tests
-        uses: coactions/setup-xvfb@v1
-        with:
-          run: pnpm test
-          working-directory: tests/vite-compat

--- a/packages/vite-plugin/src/node/contentScripts.ts
+++ b/packages/vite-plugin/src/node/contentScripts.ts
@@ -54,10 +54,11 @@ contentScripts.change$
       'scriptId',
     ] as const
     // set many to one value for lookup by multiple keys (script.id, script.fileName, etc)
-    for (const keyName of keyNames) {
-      const key = value[keyName]
+    const keys = keyNames.map((keyName) => value[keyName])
+    keys.push(value.id.replace(/^\//, ''))
+    for (const key of keys) {
       // avoid runaway recursion
-      if (typeof key === 'undefined' || map.has(key)) {
+      if (typeof key === 'undefined' || map.get(key) === value) {
         continue
       } else {
         map.set(key, value)

--- a/packages/vite-plugin/src/node/fileWriter-hmr.test.ts
+++ b/packages/vite-plugin/src/node/fileWriter-hmr.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from 'vitest'
+import {
+  getUpdatePayloadFileIds,
+  mapVitePayloadForCrx,
+  shouldForwardCrxPayload,
+} from './fileWriter-hmr'
+
+test('forwards path-scoped full reloads to content scripts', () => {
+  const payload = mapVitePayloadForCrx({
+    type: 'full-reload',
+    path: '/src/header.ts',
+  })
+
+  expect(payload).toEqual({
+    type: 'full-reload',
+    path: '/src/header.ts',
+  })
+  expect(shouldForwardCrxPayload(payload)).toBe(true)
+})
+
+test('does not forward empty content script updates', () => {
+  expect(
+    shouldForwardCrxPayload({
+      type: 'update',
+      updates: [],
+    }),
+  ).toBe(false)
+})
+
+test('rewrites query-string modules from update payloads', () => {
+  expect(
+    getUpdatePayloadFileIds({
+      type: 'update',
+      updates: [
+        {
+          type: 'js-update',
+          path: '/src/components/HelloWorld.vue?vue&type=style&lang.css',
+          acceptedPath:
+            '/src/components/HelloWorld.vue?vue&type=style&lang.css',
+          timestamp: 1,
+        },
+      ],
+    }),
+  ).toEqual(['/src/components/HelloWorld.vue?vue&type=style&lang.css'])
+})

--- a/packages/vite-plugin/src/node/fileWriter-hmr.ts
+++ b/packages/vite-plugin/src/node/fileWriter-hmr.ts
@@ -20,6 +20,82 @@ const isCustomPayload = (p: HMRPayload): p is CustomPayload => {
   return p.type === 'custom'
 }
 export const hmrPayload$ = new Subject<HMRPayload>()
+
+export function getUpdatePayloadFileIds(p: UpdatePayload) {
+  const ids = new Set<string>()
+
+  for (const u of p.updates) {
+    for (const id of [u.path, u.acceptedPath]) {
+      const isVirtualModule = id.startsWith('/@id/') || id.startsWith('/__')
+      const isQueryModule = id.includes('?')
+      if (isVirtualModule || isQueryModule) ids.add(id)
+    }
+  }
+
+  return [...ids]
+}
+
+export function mapVitePayloadForCrx(p: HMRPayload): HMRPayload {
+  switch (p.type) {
+    case 'full-reload': {
+      const fullReload: FullReloadPayload = {
+        type: 'full-reload',
+        path: p.path && getViteUrl({ id: p.path, type: 'module' }),
+      }
+      return fullReload
+    }
+
+    case 'prune': {
+      const prune: PrunePayload = {
+        type: 'prune',
+        paths: p.paths.map((id) => getViteUrl({ id, type: 'module' })),
+      }
+      return prune
+    }
+
+    case 'update': {
+      // Update files on disk for payload-only module ids. Regular files are
+      // handled by handleHotUpdate; query modules like Vue SFC styles are not.
+      debug('update payload with %d updates', p.updates.length)
+      for (const u of p.updates) {
+        debug(
+          'update item: path=%s acceptedPath=%s type=%s',
+          u.path,
+          u.acceptedPath,
+          u.type,
+        )
+      }
+      for (const id of getUpdatePayloadFileIds(p)) {
+        debug('updating payload module: %s', id)
+        update(id)
+      }
+      const update_: UpdatePayload = {
+        type: 'update',
+        updates: p.updates.map(({ acceptedPath: ap, path: p, ...rest }) => ({
+          ...rest,
+          acceptedPath: prefix('/', getFileName({ id: ap, type: 'module' })),
+          path: prefix('/', getFileName({ id: p, type: 'module' })),
+        })),
+      }
+      return update_
+    }
+
+    default:
+      return p // connected, custom, error
+  }
+}
+
+export function shouldForwardCrxPayload(p: HMRPayload) {
+  switch (p.type) {
+    case 'prune':
+      return p.paths.length > 0
+    case 'update':
+      return p.updates.length > 0
+    default:
+      return true
+  }
+}
+
 export const crxHMRPayload$: Observable<CrxHMRPayload> = hmrPayload$.pipe(
   filter((p) => !isCustomPayload(p)),
   buffer(allFilesReady$),
@@ -36,74 +112,8 @@ export const crxHMRPayload$: Observable<CrxHMRPayload> = hmrPayload$.pipe(
     if (fullReload) payloads.push(fullReload)
     return payloads
   }),
-  map((p): HMRPayload => {
-    switch (p.type) {
-      case 'full-reload': {
-        const fullReload: FullReloadPayload = {
-          type: 'full-reload',
-          path: p.path && getViteUrl({ id: p.path, type: 'module' }),
-        }
-        return fullReload
-      }
-
-      case 'prune': {
-        const prune: PrunePayload = {
-          type: 'prune',
-          paths: p.paths.map((id) => getViteUrl({ id, type: 'module' })),
-        }
-        return prune
-      }
-
-      case 'update': {
-        // Update files on disk for virtual modules and other HMR updates
-        // This ensures the extension can fetch the updated content
-        debug('update payload with %d updates', p.updates.length)
-        for (const u of p.updates) {
-          debug(
-            'update item: path=%s acceptedPath=%s type=%s',
-            u.path,
-            u.acceptedPath,
-            u.type,
-          )
-          // Update virtual modules - regular files are handled by handleHotUpdate
-          // Virtual modules can have different formats:
-          // - /@id/__x00__virtual:uno.css (Vite's standard virtual module format)
-          // - /__uno.css (UnoCSS's virtual module format)
-          const isVirtualModule =
-            u.path.startsWith('/@id/') || u.path.startsWith('/__')
-          if (isVirtualModule) {
-            debug('updating virtual module: %s', u.path)
-            update(u.path)
-          }
-        }
-        const update_: UpdatePayload = {
-          type: 'update',
-          updates: p.updates.map(({ acceptedPath: ap, path: p, ...rest }) => ({
-            ...rest,
-            acceptedPath: prefix('/', getFileName({ id: ap, type: 'module' })),
-            path: prefix('/', getFileName({ id: p, type: 'module' })),
-          })),
-        }
-        return update_
-      }
-
-      default:
-        return p // connected, custom, error
-    }
-  }),
-  filter((p) => {
-    switch (p.type) {
-      // TODO: why not reload when path is defined?
-      case 'full-reload':
-        return typeof p.path === 'undefined'
-      case 'prune':
-        return p.paths.length > 0
-      case 'update':
-        return p.updates.length > 0
-      default:
-        return true
-    }
-  }),
+  map(mapVitePayloadForCrx),
+  filter(shouldForwardCrxPayload),
   map((data): CrxHMRPayload => {
     debug(`hmr payload`, data)
     return {

--- a/packages/vite-plugin/src/node/fileWriter-hmr.ts
+++ b/packages/vite-plugin/src/node/fileWriter-hmr.ts
@@ -1,4 +1,12 @@
-import { buffer, filter, map, mergeMap, Observable, Subject } from 'rxjs'
+import {
+  buffer,
+  filter,
+  firstValueFrom,
+  map,
+  mergeMap,
+  Observable,
+  Subject,
+} from 'rxjs'
 import {
   CustomPayload,
   FullReloadPayload,
@@ -21,14 +29,27 @@ const isCustomPayload = (p: HMRPayload): p is CustomPayload => {
 }
 export const hmrPayload$ = new Subject<HMRPayload>()
 
-export function getUpdatePayloadFileIds(p: UpdatePayload) {
+function withTimestamp(id: string, timestamp: number) {
+  if (id.includes('?t=') || id.includes('&t=')) return id
+
+  const t = `t=${timestamp}` + (id.includes('?') ? '&' : '')
+  const parts = id.split('?')
+  parts[1] = typeof parts[1] === 'undefined' ? t : t + parts[1]
+  return parts.join('?')
+}
+
+export function getUpdatePayloadFileIds(
+  p: UpdatePayload,
+  { timestamp = false }: { timestamp?: boolean } = {},
+) {
   const ids = new Set<string>()
 
   for (const u of p.updates) {
     for (const id of [u.path, u.acceptedPath]) {
       const isVirtualModule = id.startsWith('/@id/') || id.startsWith('/__')
       const isQueryModule = id.includes('?')
-      if (isVirtualModule || isQueryModule) ids.add(id)
+      if (isVirtualModule || isQueryModule)
+        ids.add(timestamp ? withTimestamp(id, u.timestamp) : id)
     }
   }
 
@@ -54,8 +75,6 @@ export function mapVitePayloadForCrx(p: HMRPayload): HMRPayload {
     }
 
     case 'update': {
-      // Update files on disk for payload-only module ids. Regular files are
-      // handled by handleHotUpdate; query modules like Vue SFC styles are not.
       debug('update payload with %d updates', p.updates.length)
       for (const u of p.updates) {
         debug(
@@ -64,10 +83,6 @@ export function mapVitePayloadForCrx(p: HMRPayload): HMRPayload {
           u.acceptedPath,
           u.type,
         )
-      }
-      for (const id of getUpdatePayloadFileIds(p)) {
-        debug('updating payload module: %s', id)
-        update(id)
       }
       const update_: UpdatePayload = {
         type: 'update',
@@ -83,6 +98,25 @@ export function mapVitePayloadForCrx(p: HMRPayload): HMRPayload {
     default:
       return p // connected, custom, error
   }
+}
+
+export async function prepareVitePayloadForCrx(
+  p: HMRPayload,
+): Promise<HMRPayload> {
+  if (p.type === 'update') {
+    // Update files on disk for payload-only module ids. Regular files are
+    // handled by handleHotUpdate; query modules like Vue SFC styles are not.
+    const pendingFiles = getUpdatePayloadFileIds(p, {
+      timestamp: true,
+    }).flatMap((id) => {
+      debug('updating payload module: %s', id)
+      return update(id).map((file) => file.file)
+    })
+    await Promise.all(pendingFiles)
+    await firstValueFrom(allFilesReady$)
+  }
+
+  return mapVitePayloadForCrx(p)
 }
 
 export function shouldForwardCrxPayload(p: HMRPayload) {
@@ -112,7 +146,7 @@ export const crxHMRPayload$: Observable<CrxHMRPayload> = hmrPayload$.pipe(
     if (fullReload) payloads.push(fullReload)
     return payloads
   }),
-  map(mapVitePayloadForCrx),
+  mergeMap(prepareVitePayloadForCrx),
   filter(shouldForwardCrxPayload),
   map((data): CrxHMRPayload => {
     debug(`hmr payload`, data)

--- a/packages/vite-plugin/src/node/fileWriter-rxjs.ts
+++ b/packages/vite-plugin/src/node/fileWriter-rxjs.ts
@@ -20,7 +20,7 @@ import {
   toArray,
 } from 'rxjs'
 import { build as viteBuild, ErrorPayload, ViteDevServer } from 'vite'
-import { outputFiles } from './fileWriter-filesMap'
+import { OutputFile, outputFiles } from './fileWriter-filesMap'
 import { getFileName, getOutputPath, getViteUrl } from './fileWriter-utilities'
 import { join } from './path'
 import { CrxDevAssetId, CrxDevScriptId, CrxPlugin } from './types'
@@ -95,8 +95,20 @@ export const buildStart$ = fileWriterEvent$.pipe(
 export const allFilesReady$ = buildEnd$.pipe(
   switchMap(() => outputFiles.change$.pipe(startWith({ type: 'start' }))),
   map(() => [...outputFiles.values()]),
-  switchMap((files) => Promise.allSettled(files.map(({ file }) => file))),
+  switchMap((files) =>
+    Promise.allSettled(files.map((file) => waitForOutputFile(file))),
+  ),
 )
+
+async function waitForOutputFile(
+  file: OutputFile,
+  seen = new Set<OutputFile>(),
+): Promise<void> {
+  if (seen.has(file)) return
+  seen.add(file)
+  const { deps } = await file.file
+  await Promise.all(deps.map((dep) => waitForOutputFile(dep, seen)))
+}
 
 const timestamp$ = new BehaviorSubject(Date.now())
 allFilesReady$.subscribe(() => {
@@ -166,7 +178,13 @@ function prepScript(
       // get script contents from dev server
       mergeMap(async ({ server }) => {
         const target = getOutputPath(server, fileName)
-        const viteUrl = getViteUrl(script)
+        const originalViteUrl = getViteUrl(script)
+        const isVueSfcQuery = script.id.includes('?vue')
+        const viteUrl = getViteUrl(script, { timestamp: isVueSfcQuery })
+        if (isVueSfcQuery) {
+          const module = await server.moduleGraph.getModuleByUrl(originalViteUrl)
+          if (module) server.moduleGraph.invalidateModule(module)
+        }
         const transformResult = await server.transformRequest(viteUrl)
         if (!transformResult)
           throw new TypeError(`Unable to load "${script.id}" from server.`)

--- a/packages/vite-plugin/src/node/fileWriter-utilities.ts
+++ b/packages/vite-plugin/src/node/fileWriter-utilities.ts
@@ -123,14 +123,16 @@ export function getOutputPath(server: ViteDevServer, fileName: string) {
 }
 
 /** Converts a script to the correct Vite URL */
-export function getViteUrl({ type, id }: FileWriterId) {
-  // { timestamp = false }: { timestamp?: boolean } = {},
-  // if (timestamp && !id.startsWith('/@') && !id.includes('?v=')) {
-  //   const t = `t=${Date.now()}` + (id.includes('?') ? '&' : '')
-  //   const parts = id.split('?')
-  //   parts[1] = typeof parts[1] === 'undefined' ? t : t + parts[1]
-  //   id = parts.join('?')
-  // }
+export function getViteUrl(
+  { type, id }: FileWriterId,
+  { timestamp = false }: { timestamp?: boolean } = {},
+) {
+  if (timestamp && !id.startsWith('/@') && !id.includes('?v=')) {
+    const t = `t=${Date.now()}` + (id.includes('?') ? '&' : '')
+    const parts = id.split('?')
+    parts[1] = typeof parts[1] === 'undefined' ? t : t + parts[1]
+    id = parts.join('?')
+  }
 
   if (type === 'asset') {
     // TODO: verify if assets need special handling

--- a/packages/vite-plugin/src/node/fileWriter.ts
+++ b/packages/vite-plugin/src/node/fileWriter.ts
@@ -27,6 +27,17 @@ const { outputFile } = fsx
 
 const debug = _debug('file-writer')
 
+function queueWrite(
+  script: CrxDevAssetId | CrxDevScriptId,
+  previous?: OutputFile,
+) {
+  if (!previous) return write(script)
+
+  return previous.file
+    .catch(() => undefined)
+    .then(() => write(script))
+}
+
 /**
  * Starts the file writer.
  *
@@ -91,7 +102,7 @@ export function add(script: CrxDevAssetId | CrxDevScriptId): OutputFile {
     file = formatFileData({
       ...script,
       fileName,
-      file: write(script),
+      file: queueWrite(script),
     })
     outputFiles.set(file.fileName, file)
     debug('add: stored new file %s', file.fileName)
@@ -100,12 +111,19 @@ export function add(script: CrxDevAssetId | CrxDevScriptId): OutputFile {
     // Virtual modules don't have a file on disk, so we can't rely on file watchers
     const isVirtualModule =
       script.id.startsWith('/@id/') || script.id.startsWith('/__')
-    if (isVirtualModule) {
+    const isTimestampedModule =
+      script.type === 'module' && /[?&]t=\d+/.test(script.id)
+    if (isVirtualModule || isTimestampedModule) {
       debug(
-        'add: virtual module already exists, triggering re-write for %s',
+        'add: module already exists, triggering re-write for %s',
         fileName,
       )
-      file.file = write(script)
+      file = formatFileData({
+        ...file,
+        ...script,
+        fileName,
+        file: queueWrite(script, file),
+      })
       outputFiles.set(fileName, file)
     }
   }
@@ -129,7 +147,7 @@ export function update(_id: string): OutputFile[] {
     const scriptFile = outputFiles.get(fileName)
     if (scriptFile) {
       debug('update: found file, calling write()')
-      scriptFile.file = write({ id, type })
+      scriptFile.file = queueWrite({ id, type }, scriptFile)
       updatedFiles.push(scriptFile)
       // trigger scriptFiles change, scriptFile is already formatted
       outputFiles.set(fileName, scriptFile)

--- a/packages/vite-plugin/src/node/plugin-background.ts
+++ b/packages/vite-plugin/src/node/plugin-background.ts
@@ -1,11 +1,52 @@
 import workerHmrClient from 'client/es/hmr-client-worker.ts'
-import { ResolvedConfig } from 'vite'
+import type { CorsOptions, ResolvedConfig } from 'vite'
 import { defineClientValues } from './defineClientValues'
 import { getFileName } from './fileWriter-utilities'
 import { ChromeManifestBackground, FirefoxManifestBackground } from './manifest'
 import { getOptions } from './plugin-optionsProvider'
 import type { Browser, CrxPluginFn } from './types'
 import { workerClientId } from './virtualFileIds'
+
+const extensionOrigins = [/^chrome-extension:\/\//, /^moz-extension:\/\//]
+
+function isExtensionOrigin(origin?: string) {
+  return origin
+    ? extensionOrigins.some((pattern) => pattern.test(origin))
+    : false
+}
+
+function addExtensionOrigins(
+  origin: CorsOptions['origin'],
+): CorsOptions['origin'] {
+  if (origin === true) return true
+  if (typeof origin === 'function') {
+    return (requestOrigin, cb) => {
+      if (isExtensionOrigin(requestOrigin)) {
+        cb(null as unknown as Error, true)
+        return
+      }
+
+      origin(requestOrigin, cb)
+    }
+  }
+
+  if (Array.isArray(origin)) return [...origin, ...extensionOrigins]
+  if (origin) return [origin, ...extensionOrigins]
+
+  return extensionOrigins
+}
+
+function addExtensionCors(cors: CorsOptions | boolean | undefined) {
+  if (cors === true) return true
+  if (cors && typeof cors === 'object') {
+    return {
+      ...cors,
+      origin: addExtensionOrigins(cors.origin),
+    }
+  }
+
+  return { origin: extensionOrigins }
+}
 
 /**
  * This plugin enables HMR during Vite serve mode by intercepting fetch requests
@@ -55,6 +96,10 @@ export const pluginBackground: CrxPluginFn = () => {
         const opts = await getOptions(config)
         browser = opts.browser || 'chrome'
         liveReload = opts.liveReload !== false
+        config.server = {
+          ...config.server,
+          cors: addExtensionCors(config.server?.cors),
+        }
       },
       configResolved(_config) {
         config = _config

--- a/packages/vite-plugin/src/node/plugin-contentScripts.ts
+++ b/packages/vite-plugin/src/node/plugin-contentScripts.ts
@@ -1,5 +1,6 @@
 import contentHmrPort from 'client/es/hmr-content-port.ts'
 import { filter, Subscription } from 'rxjs'
+import type { OutputBundle, PluginContext } from 'rollup'
 import { ConfigEnv, UserConfig, ViteDevServer } from 'vite'
 import {
   contentScripts,
@@ -178,60 +179,78 @@ export const pluginContentScripts: CrxPluginFn = () => {
         }
       },
       generateBundle(_options, bundle) {
-        // emit content script loaders
-        for (const [key, script] of contentScripts)
-          if (key === script.refId) {
-            const fileName = this.getFileName(script.refId)
-
-            if (script.type === 'module') {
-              script.fileName = fileName
-            } else if (script.type === 'loader') {
-              script.fileName = fileName
-
-              const bundleFileInfo = bundle[fileName]
-              // the loader loads scripts asynchronously which in this case needlessly
-              // delays content script execution which may not be desired
-              const shouldUseLoader = !(
-                bundleFileInfo.type === 'chunk' &&
-                bundleFileInfo.imports.length === 0 &&
-                bundleFileInfo.dynamicImports.length === 0 &&
-                bundleFileInfo.exports.length === 0
-              )
-
-              if (shouldUseLoader) {
-                const refId = this.emitFile({
-                  type: 'asset',
-                  name: getFileName({
-                    type: 'loader',
-                    id: basename(script.id),
-                  }),
-                  source: worldMainIds.has(script.id)
-                    ? createProMainLoader({
-                        fileName: `./${fileName.split('/').at(-1)}`,
-                      })
-                    : createProLoader({ fileName }),
-                })
-
-                script.loaderName = this.getFileName(refId)
-              } else {
-                // make sure the code is wrapped in a function invocation
-                // to have the same scope isolation as the loader provides
-                //
-                // note that loaders may also call an `onExecute` function
-                // if exported by the content script, but given we
-                // require content scripts in this branch to have no exports
-                // there is obviously no need to handle onExecute() here
-                bundleFileInfo.code = `(function(){${bundleFileInfo.code}})()\n`
-              }
-            } else if (script.type === 'iife') {
-              // IIFE scripts are handled by plugin-contentScripts_iife
-              // Skip processing here - the IIFE plugin builds and emits them
-              continue
-            }
-            // trigger update for other key values
-            contentScripts.set(script.refId, formatFileData(script))
-          }
+        finalizeBuildContentScripts(this, bundle, worldMainIds)
       },
     },
   ]
+}
+
+export function finalizeBuildContentScripts(
+  context: Pick<PluginContext, 'emitFile' | 'getFileName'>,
+  bundle: OutputBundle,
+  worldMainIds = new Set<string>(),
+) {
+  const processed = new Set<object>()
+
+  // emit content script loaders
+  for (const [key, script] of contentScripts) {
+    if (key !== script.refId || processed.has(script)) continue
+    processed.add(script)
+
+    if (script.type === 'module') {
+      script.fileName = script.fileName ?? context.getFileName(script.refId)
+    } else if (script.type === 'loader') {
+      const fileName = script.fileName ?? context.getFileName(script.refId)
+      script.fileName = fileName
+
+      const bundleFileInfo = bundle[fileName]
+      if (bundleFileInfo?.type !== 'chunk') continue
+
+      // the loader loads scripts asynchronously which in this case needlessly
+      // delays content script execution which may not be desired
+      const shouldUseLoader = !(
+        bundleFileInfo.imports.length === 0 &&
+        bundleFileInfo.dynamicImports.length === 0 &&
+        bundleFileInfo.exports.length === 0
+      )
+
+      if (shouldUseLoader) {
+        if (typeof script.loaderName === 'undefined') {
+          const refId = context.emitFile({
+            type: 'asset',
+            name: getFileName({
+              type: 'loader',
+              id: basename(script.id),
+            }),
+            source: worldMainIds.has(script.id)
+              ? createProMainLoader({
+                  fileName: `./${fileName.split('/').at(-1)}`,
+                })
+              : createProLoader({ fileName }),
+          })
+
+          script.loaderName = context.getFileName(refId)
+        }
+      } else if (
+        typeof script.loaderName === 'undefined' &&
+        !bundleFileInfo.code.startsWith('(function(){')
+      ) {
+        // make sure the code is wrapped in a function invocation
+        // to have the same scope isolation as the loader provides
+        //
+        // note that loaders may also call an `onExecute` function
+        // if exported by the content script, but given we
+        // require content scripts in this branch to have no exports
+        // there is obviously no need to handle onExecute() here
+        bundleFileInfo.code = `(function(){${bundleFileInfo.code}})()\n`
+      }
+    } else if (script.type === 'iife') {
+      // IIFE scripts are handled by plugin-contentScripts_iife
+      // Skip processing here - the IIFE plugin builds and emits them
+      continue
+    }
+
+    // trigger update for other key values
+    contentScripts.set(script.refId, formatFileData(script))
+  }
 }

--- a/packages/vite-plugin/src/node/plugin-contentScripts_dynamic.ts
+++ b/packages/vite-plugin/src/node/plugin-contentScripts_dynamic.ts
@@ -168,6 +168,7 @@ export const pluginDynamicContentScripts: CrxPluginFn = () => {
                   type: 'chunk',
                   id,
                   name: basename(id),
+                  preserveSignature: 'exports-only',
                 })
               } else {
                 refId = scriptId

--- a/packages/vite-plugin/src/node/plugin-contentScripts_iife.ts
+++ b/packages/vite-plugin/src/node/plugin-contentScripts_iife.ts
@@ -70,7 +70,7 @@ export const pluginContentScriptsIife: CrxPluginFn = () => {
       name: pluginName,
       apply: 'build',
       enforce: 'post',
-      async generateBundle(options, bundle) {
+      async generateBundle() {
         const opts = await getOptions({ plugins: config.plugins } as UserConfig)
         const _manifest = opts.manifest
         const manifest =
@@ -144,40 +144,64 @@ export const pluginContentScriptsIife: CrxPluginFn = () => {
               ? result.flatMap(r => 'output' in r ? r.output : [])
               : result.output
             
-            // Add the IIFE output to the bundle
-            for (const chunk of outputs) {
-              if (chunk.type === 'chunk' && chunk.isEntry) {
-                bundle[outputFileName] = {
-                  ...chunk,
-                  fileName: outputFileName,
-                }
+            const entryChunk = outputs.find(
+              (chunk) => chunk.type === 'chunk' && chunk.isEntry,
+            )
+            if (!entryChunk || entryChunk.type !== 'chunk') {
+              throw new Error(`Unable to generate IIFE bundle for "${entry.file}"`)
+            }
 
-                // Update contentScripts map with new filename
-                // For dynamic scripts, we need to update the existing entry
-                const existingScript = contentScripts.get(entry.file)
-                if (existingScript) {
-                  // Update existing script entry with the IIFE filename
-                  existingScript.fileName = outputFileName
-                  contentScripts.set(entry.file, formatFileData(existingScript))
-                } else {
-                  // Create new entry for manifest-declared scripts
-                  contentScripts.set(
-                    entry.file,
-                    formatFileData({
-                      type: 'iife',
-                      id: entry.file,
-                      refId: entry.file,
-                      matches: entry.matches,
-                      fileName: outputFileName,
-                    }),
-                  )
-                }
-                
-                console.log(
-                  colors.green(`  ✓ ${basename(entry.file)} → ${outputFileName}`),
-                )
+            this.emitFile({
+              type: 'asset',
+              fileName: outputFileName,
+              source: entryChunk.code,
+            })
+
+            for (const output of outputs) {
+              if (
+                output.type === 'asset' &&
+                output.fileName !== outputFileName &&
+                output.fileName !== 'manifest.json' &&
+                !output.fileName.startsWith('.vite/')
+              ) {
+                this.emitFile({
+                  type: 'asset',
+                  fileName: output.fileName,
+                  source: output.source,
+                })
+              } else if (output.type === 'chunk' && !output.isEntry) {
+                this.emitFile({
+                  type: 'asset',
+                  fileName: output.fileName,
+                  source: output.code,
+                })
               }
             }
+
+            // Update contentScripts map with new filename
+            // For dynamic scripts, we need to update the existing entry
+            const existingScript = contentScripts.get(entry.file)
+            if (existingScript) {
+              // Update existing script entry with the IIFE filename
+              existingScript.fileName = outputFileName
+              contentScripts.set(entry.file, formatFileData(existingScript))
+            } else {
+              // Create new entry for manifest-declared scripts
+              contentScripts.set(
+                entry.file,
+                formatFileData({
+                  type: 'iife',
+                  id: entry.file,
+                  refId: entry.file,
+                  matches: entry.matches,
+                  fileName: outputFileName,
+                }),
+              )
+            }
+
+            console.log(
+              colors.green(`  ✓ ${basename(entry.file)} → ${outputFileName}`),
+            )
           } catch (error) {
             console.error(
               colors.red(`  ✗ Failed to build ${entry.file}:`),

--- a/packages/vite-plugin/src/node/plugin-hmr.test.ts
+++ b/packages/vite-plugin/src/node/plugin-hmr.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { getChangedFilePath } from './plugin-hmr'
+
+describe('getChangedFilePath', () => {
+  it('normalizes Windows file paths to content script ids', () => {
+    const root = String.raw`D:\a\chrome-extension-tools\chrome-extension-tools\packages\vite-plugin\tests\e2e\mv3-dynamic-script-iife`
+    const file = String.raw`D:\a\chrome-extension-tools\chrome-extension-tools\packages\vite-plugin\tests\e2e\mv3-dynamic-script-iife\src\main-world.ts`
+
+    expect(getChangedFilePath(root, file)).toBe('/src/main-world.ts')
+  })
+
+  it('normalizes POSIX file paths to content script ids', () => {
+    const root =
+      '/home/runner/work/chrome-extension-tools/chrome-extension-tools/packages/vite-plugin/tests/e2e/mv3-dynamic-script-iife'
+    const file = `${root}/src/main-world.ts`
+
+    expect(getChangedFilePath(root, file)).toBe('/src/main-world.ts')
+  })
+
+  it('returns null for files outside the root', () => {
+    expect(getChangedFilePath('/repo/project', '/repo/other/src/main-world.ts')).toBe(
+      null,
+    )
+    expect(
+      getChangedFilePath('/repo/project', '/repo/project-other/src/main-world.ts'),
+    ).toBe(null)
+  })
+})

--- a/packages/vite-plugin/src/node/plugin-hmr.ts
+++ b/packages/vite-plugin/src/node/plugin-hmr.ts
@@ -8,7 +8,7 @@ import { fileWriterError$ } from './fileWriter-rxjs'
 import { getFileName, prefix } from './fileWriter-utilities'
 import { _debug } from './helpers'
 import { isImporter } from './isImporter'
-import { isAbsolute, join } from './path'
+import { isAbsolute, join, normalize, relative } from './path'
 import { getContentCssEntries } from './plugin-contentScripts_declared'
 import { getOptions } from './plugin-optionsProvider'
 import type { CrxHMRPayload, CrxPluginFn, ManifestFiles } from './types'
@@ -19,6 +19,30 @@ const debug = _debug('hmr')
 export const crxRuntimeReload: CrxHMRPayload = {
   type: 'custom',
   event: 'crx:runtime-reload',
+}
+
+export function getChangedFilePath(root: string, file?: string | null): string | null {
+  if (!file) return null
+
+  const normalizedRoot = normalize(root)
+  const normalizedFile = normalize(file)
+  const relativeFile = relative(normalizedRoot, normalizedFile)
+  if (!relativeFile || relativeFile.startsWith('..') || isAbsolute(relativeFile)) {
+    return null
+  }
+
+  return prefix('/', relativeFile)
+}
+
+function stripTimestamp(id: string) {
+  return id
+    .replace(/([?&])t=\d+&/, '$1')
+    .replace(/[?&]t=\d+$/, '')
+    .replace(/\?$/, '')
+}
+
+function escapeRegExp(text: string) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 export const pluginHMR: CrxPluginFn = () => {
@@ -96,19 +120,16 @@ export const pluginHMR: CrxPluginFn = () => {
       handleHotUpdate({ file, modules, server }) {
         const { root } = server.config
 
-        const changedFilePath = file
-          ? file.startsWith(root)
-            ? prefix('/', file.slice(root.length))
-            : null
-          : null
+        const changedFilePath = getChangedFilePath(root, file)
 
         const relFiles = new Set<string>()
         const fsFiles = new Set<string>()
         const virtualModules = new Set<string>()
 
         for (const m of modules) {
-          if (m.id?.startsWith(root)) {
-            relFiles.add(m.id.slice(server.config.root.length))
+          const relFile = getChangedFilePath(root, m.id)
+          if (relFile) {
+            relFiles.add(relFile)
           } else if (m.url?.startsWith('/@fs')) {
             fsFiles.add(m.url)
           } else if (
@@ -218,14 +239,14 @@ export const pluginHMR: CrxPluginFn = () => {
           _id !== '/@vite/client' &&
           code.includes('createHotContext')
         ) {
-          const id = _id.replace(/t=\d+&/, '')
-          const escaped = id.replace(/([?&.])/g, '\\$1')
-          // using lookahead and lookbehind
+          const id = stripTimestamp(_id)
+          const escaped = escapeRegExp(id)
           const regexp = new RegExp(
-            `(?<=createHotContext\\(")${escaped}(?="\\))`,
+            `(createHotContext\\(")${escaped}("\\))`,
+            'g',
           )
           const fileUrl = prefix('/', getFileName({ id, type }))
-          const replaced = code.replace(regexp, fileUrl)
+          const replaced = code.replace(regexp, `$1${fileUrl}$2`)
           return replaced
         } else {
           return code

--- a/packages/vite-plugin/src/node/plugin-manifest.ts
+++ b/packages/vite-plugin/src/node/plugin-manifest.ts
@@ -17,6 +17,7 @@ import {
   getContentCssEntries,
   registerContentCssEntry,
 } from './plugin-contentScripts_declared'
+import { finalizeBuildContentScripts } from './plugin-contentScripts'
 import { isIifeContentScript } from './plugin-contentScripts_iife'
 import { manifestId, stubId } from './virtualFileIds'
 const { readFile } = fs
@@ -274,6 +275,7 @@ export const pluginManifest: CrxPluginFn = () => {
                   type: 'chunk',
                   id,
                   name: basename(file),
+                  preserveSignature: 'exports-only',
                 })
                 contentScripts.set(
                   file,
@@ -358,6 +360,8 @@ export const pluginManifest: CrxPluginFn = () => {
             }
           }
         } else {
+          finalizeBuildContentScripts(this, bundle)
+
           // transform hook emits files and replaces in manifest with ref ids
           // update background service worker filename from ref
           // service worker not emitted during development, so don't update file name
@@ -379,7 +383,8 @@ export const pluginManifest: CrxPluginFn = () => {
             ({ js = [], ...rest }) => {
               return {
                 js: js.map((id) => {
-                  const script = contentScripts.get(id)
+                  const script =
+                    contentScripts.get(id) ?? contentScripts.get(prefix('/', id))
                   const fileName = script?.loaderName ?? script?.fileName
                   if (typeof fileName === 'undefined')
                     throw new Error(

--- a/packages/vite-plugin/tests/e2e/helpers.ts
+++ b/packages/vite-plugin/tests/e2e/helpers.ts
@@ -66,7 +66,9 @@ export async function waitForInnerHtml(
   throw new Error('could not find element')
 }
 
-const ensureViteHMRWillPickupChangedFiled = async (filesToModify: string[]) => {
+export const ensureViteHMRWillPickupChangedFiled = async (
+  filesToModify: string[],
+) => {
   const now = new Date()
   for (const f of filesToModify) {
     // Add a newline to trigger change detection
@@ -83,6 +85,9 @@ const ensureViteHMRWillPickupChangedFiled = async (filesToModify: string[]) => {
     }
   }
 }
+
+export const ensureViteHmrSeesChangedFiles =
+  ensureViteHMRWillPickupChangedFiled
 
 export const createUpdate =
   ({

--- a/packages/vite-plugin/tests/e2e/helpers.ts
+++ b/packages/vite-plugin/tests/e2e/helpers.ts
@@ -123,6 +123,20 @@ export const createUpdate =
     }
   }
 
+export async function waitForFileContent(
+  file: string,
+  predicate: (content: string) => boolean,
+  { timeout = 5000, interval = 100 }: { timeout?: number; interval?: number } = {},
+): Promise<string> {
+  const deadline = Date.now() + timeout
+  while (Date.now() < deadline) {
+    const content = await fs.readFile(file, 'utf-8')
+    if (predicate(content)) return content
+    await new Promise((r) => setTimeout(r, interval))
+  }
+
+  throw new Error(`Timed out after ${timeout}ms waiting for "${file}" to update`)
+}
 
 /**
  * Returns the extension's MV3 background service worker. If one is already

--- a/packages/vite-plugin/tests/e2e/mv3-dynamic-script-iife/vite-build.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-dynamic-script-iife/vite-build.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra'
 import path from 'pathe'
 import { expect, test } from 'vitest'
+import { waitForRegisteredContentScripts } from '../helpers'
 import { build } from '../runners'
 
 test(
@@ -16,7 +17,7 @@ test(
     const { browser } = await build(__dirname)
 
     // Wait for the background script to register the content script
-    await new Promise((resolve) => setTimeout(resolve, 2000))
+    await waitForRegisteredContentScripts(browser, ['main-world-script'])
 
     // Navigate to example.com - the registered content script should inject
     const page = await browser.newPage()

--- a/packages/vite-plugin/tests/e2e/mv3-dynamic-script-iife/vite-build.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-dynamic-script-iife/vite-build.test.ts
@@ -10,8 +10,8 @@ test(
     const src1 = path.join(__dirname, 'src1')
 
     // Use the initial version for build test
-    await fs.remove(src)
-    await fs.copy(src1, src, { recursive: true })
+    await fs.emptydir(src)
+    await fs.copy(src1, src, { recursive: true, overwrite: true })
 
     const { browser } = await build(__dirname)
 

--- a/packages/vite-plugin/tests/e2e/mv3-dynamic-script-iife/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-dynamic-script-iife/vite-serve.test.ts
@@ -3,6 +3,7 @@ import path from 'pathe'
 import { expect, test } from 'vitest'
 import { serve } from '../runners'
 import {
+  ensureViteHmrSeesChangedFiles,
   waitForContentScriptContent,
   waitForRegisteredContentScripts,
 } from '../helpers'
@@ -35,10 +36,11 @@ test(
 
     // Now update ONLY the main-world.ts file (not background.ts)
     // This directly copies the file to avoid any race conditions
-    await fs.copyFile(
-      path.join(src2, 'main-world.ts'),
-      path.join(src, 'main-world.ts'),
-    )
+    const mainWorldScript = path.join(src, 'main-world.ts')
+    await fs.copyFile(path.join(src2, 'main-world.ts'), mainWorldScript)
+    if (process.platform === 'win32') {
+      await ensureViteHmrSeesChangedFiles([mainWorldScript])
+    }
 
     // Wait for the IIFE rebuild to finish by polling the on-disk bundle for
     // the updated content (more reliable than a fixed timeout).

--- a/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-build-watch/vite-build-watch.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-dynamic-content-script-build-watch/vite-build-watch.test.ts
@@ -1,10 +1,34 @@
 import fs from 'fs-extra'
 import path from 'pathe'
-import { expect, test } from 'vitest'
-import { createUpdate, getPage } from '../helpers'
-import { header } from './src2/header'
+import { test } from 'vitest'
+import { createUpdate } from '../helpers'
+import { header as initialHeader } from './src1/header'
+import { header as updatedHeader } from './src2/header'
 import { build } from '../runners'
 import { RollupWatcher } from 'rollup'
+
+async function waitForContentAsset(
+  outDir: string,
+  needle: string,
+  { timeout = 15_000, interval = 250 } = {},
+): Promise<void> {
+  const assetsDir = path.join(outDir, 'assets')
+  const deadline = Date.now() + timeout
+
+  while (Date.now() < deadline) {
+    const assets = await fs.readdir(assetsDir).catch(() => [] as string[])
+    for (const f of assets) {
+      if (!f.startsWith('content.ts') || !f.endsWith('.js')) continue
+      const source = await fs.readFile(path.join(assetsDir, f), 'utf8')
+      if (source.includes(needle)) return
+    }
+    await new Promise((r) => setTimeout(r, interval))
+  }
+
+  throw new Error(
+    `Timed out after ${timeout}ms waiting for "${needle}" in watched content asset`,
+  )
+}
 
 test(
   'crx page update on build --watch',
@@ -16,41 +40,25 @@ test(
     await fs.remove(src)
     await fs.copy(src1, src, { recursive: true })
 
-    const { browser, output, outDir } = await build(__dirname)
+    const { output, outDir } = await build(__dirname)
 
-    const update = createUpdate({ target: src, src: src2 })
-    const page = await getPage(browser, 'example.com')
+    try {
+      await waitForContentAsset(outDir, initialHeader)
 
-    const app = page.locator('#app')
-    await app.waitFor({ timeout: 15_000 })
+      const update = createUpdate({ target: src, src: src2 })
 
-    // update header.ts file -> trigger rebuild
-    await update('header.ts')
+      // update header.ts file -> trigger rebuild
+      await update('header.ts')
 
-    // wait for the watch rebuild to complete and produce updated output.
-    // Note: in build --watch mode there is no extension auto-reload, so we
-    // assert on the produced files rather than the running page.
-    const assetsDir = path.join(outDir, 'assets')
-    const deadline = Date.now() + 15_000
-    let updated = false
-    while (Date.now() < deadline) {
-      const assets = await fs.readdir(assetsDir).catch(() => [] as string[])
-      for (const f of assets) {
-        if (!f.startsWith('content.ts.')) continue
-        const source = await fs.readFile(path.join(assetsDir, f), 'utf8')
-        if (source.includes(header)) {
-          updated = true
-          break
-        }
+      // wait for the watch rebuild to complete and produce updated output.
+      // Note: in build --watch mode there is no extension auto-reload, so we
+      // assert on the produced files rather than the running page.
+      await waitForContentAsset(outDir, updatedHeader)
+    } finally {
+      // Clean up the watcher
+      if ('close' in output) {
+        ;(output as RollupWatcher).close()
       }
-      if (updated) break
-      await new Promise((r) => setTimeout(r, 250))
-    }
-    expect(updated).toBe(true)
-
-    // Clean up the watcher
-    if ('close' in output) {
-      ;(output as RollupWatcher).close()
     }
   },
   { retry: 2 },

--- a/packages/vite-plugin/tests/e2e/mv3-vite-unocss-hmr/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-unocss-hmr/vite-serve.test.ts
@@ -1,9 +1,9 @@
 import fs from 'fs-extra'
 import path from 'pathe'
-import { expect, test } from 'vitest'
-import { createUpdate } from '../helpers'
-import { serve } from '../runners'
 import { allFilesReady } from 'src/fileWriter-rxjs'
+import { expect, test } from 'vitest'
+import { createUpdate, waitForFileContent } from '../helpers'
+import { serve } from '../runners'
 
 /**
  * This test verifies that UnoCSS virtual CSS modules are properly updated
@@ -67,14 +67,10 @@ test(
     // Wait for all files to be written after HMR update
     await allFilesReady()
 
-    // Wait for the file to be updated - need to wait for async write to complete
-    // Poll the file until it contains the updated CSS or timeout
-    let updatedCss = ''
-    for (let i = 0; i < 50; i++) {
-      await new Promise((r) => setTimeout(r, 100))
-      updatedCss = await fs.readFile(unoCssFile!, 'utf-8')
-      if (updatedCss.includes('bg-green')) break
-    }
+    const updatedCss = await waitForFileContent(
+      unoCssFile!,
+      (content) => content.includes('bg-green'),
+    )
 
     // The CSS should now contain the new green background class
     // This is the key assertion - verifies HMR updated the virtual CSS file

--- a/packages/vite-plugin/tests/e2e/mv3-vite-virtual-css-hmr/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-virtual-css-hmr/vite-serve.test.ts
@@ -1,7 +1,8 @@
 import fs from 'fs-extra'
 import path from 'pathe'
+import { allFilesReady } from 'src/fileWriter-rxjs'
 import { expect, test } from 'vitest'
-import { createUpdate, waitForInnerHtml } from '../helpers'
+import { createUpdate, waitForFileContent, waitForInnerHtml } from '../helpers'
 import { serve } from '../runners'
 
 /**
@@ -65,11 +66,11 @@ test.skipIf(process.env.CI)('virtual css module updates on hmr', async () => {
 
   console.log('content.ts updated, waiting for file to be updated in dist...')
 
-  // Wait a bit for the file to be written
-  await new Promise((r) => setTimeout(r, 2000))
-
-  // Read the file again to check if it was updated
-  const updatedCssContentFromFile = await fs.readFile(virtualCssFile!, 'utf-8')
+  await allFilesReady()
+  const updatedCssContentFromFile = await waitForFileContent(
+    virtualCssFile!,
+    (content) => content.includes('text-green') && content.includes('mt-4'),
+  )
 
   // The virtual CSS should now contain the new classes - THIS IS THE KEY ASSERTION
   expect(updatedCssContentFromFile).toContain('text-green')


### PR DESCRIPTION
Follow-up to the Vite compatibility PR. This keeps the change separate from the green working PR branch.

Changes:
- Add `waitForFileContent` to `tests/e2e/helpers.ts`.
- Replace the fixed 2s wait in `mv3-dynamic-script-iife/vite-build.test.ts` with `waitForRegisteredContentScripts`.
- Replace the fixed 2s virtual CSS HMR wait with `allFilesReady()` plus `waitForFileContent`.
- Reuse `waitForFileContent` in the UnoCSS HMR test instead of its local polling loop.

Local verification:
- `pnpm --dir packages/vite-plugin exec vitest --run --mode e2e tests/e2e/mv3-dynamic-script-iife/vite-build.test.ts tests/e2e/mv3-vite-virtual-css-hmr/vite-serve.test.ts tests/e2e/mv3-vite-unocss-hmr/vite-serve.test.ts`
- `pnpm --dir packages/vite-plugin exec eslint tests/e2e/helpers.ts tests/e2e/mv3-dynamic-script-iife/vite-build.test.ts tests/e2e/mv3-vite-virtual-css-hmr/vite-serve.test.ts tests/e2e/mv3-vite-unocss-hmr/vite-serve.test.ts`
- `git diff --check`