### PR TITLE
test: replace fixed e2e waits

### DIFF
--- a/packages/vite-plugin/tests/e2e/helpers.ts
+++ b/packages/vite-plugin/tests/e2e/helpers.ts
@@ -123,6 +123,20 @@ export const createUpdate =
     }
   }
 
+export async function waitForFileContent(
+  file: string,
+  predicate: (content: string) => boolean,
+  { timeout = 5000, interval = 100 }: { timeout?: number; interval?: number } = {},
+): Promise<string> {
+  const deadline = Date.now() + timeout
+  while (Date.now() < deadline) {
+    const content = await fs.readFile(file, 'utf-8')
+    if (predicate(content)) return content
+    await new Promise((r) => setTimeout(r, interval))
+  }
+
+  throw new Error(`Timed out after ${timeout}ms waiting for "${file}" to update`)
+}
 
 /**
  * Returns the extension's MV3 background service worker. If one is already

--- a/packages/vite-plugin/tests/e2e/mv3-dynamic-script-iife/vite-build.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-dynamic-script-iife/vite-build.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra'
 import path from 'pathe'
 import { expect, test } from 'vitest'
+import { waitForRegisteredContentScripts } from '../helpers'
 import { build } from '../runners'
 
 test(
@@ -16,7 +17,7 @@ test(
     const { browser } = await build(__dirname)
 
     // Wait for the background script to register the content script
-    await new Promise((resolve) => setTimeout(resolve, 2000))
+    await waitForRegisteredContentScripts(browser, ['main-world-script'])
 
     // Navigate to example.com - the registered content script should inject
     const page = await browser.newPage()

--- a/packages/vite-plugin/tests/e2e/mv3-vite-unocss-hmr/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-unocss-hmr/vite-serve.test.ts
@@ -1,9 +1,9 @@
 import fs from 'fs-extra'
 import path from 'pathe'
-import { expect, test } from 'vitest'
-import { createUpdate } from '../helpers'
-import { serve } from '../runners'
 import { allFilesReady } from 'src/fileWriter-rxjs'
+import { expect, test } from 'vitest'
+import { createUpdate, waitForFileContent } from '../helpers'
+import { serve } from '../runners'
 
 /**
  * This test verifies that UnoCSS virtual CSS modules are properly updated
@@ -67,14 +67,10 @@ test(
     // Wait for all files to be written after HMR update
     await allFilesReady()
 
-    // Wait for the file to be updated - need to wait for async write to complete
-    // Poll the file until it contains the updated CSS or timeout
-    let updatedCss = ''
-    for (let i = 0; i < 50; i++) {
-      await new Promise((r) => setTimeout(r, 100))
-      updatedCss = await fs.readFile(unoCssFile!, 'utf-8')
-      if (updatedCss.includes('bg-green')) break
-    }
+    const updatedCss = await waitForFileContent(
+      unoCssFile!,
+      (content) => content.includes('bg-green'),
+    )
 
     // The CSS should now contain the new green background class
     // This is the key assertion - verifies HMR updated the virtual CSS file

--- a/packages/vite-plugin/tests/e2e/mv3-vite-virtual-css-hmr/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-virtual-css-hmr/vite-serve.test.ts
@@ -1,7 +1,8 @@
 import fs from 'fs-extra'
 import path from 'pathe'
+import { allFilesReady } from 'src/fileWriter-rxjs'
 import { expect, test } from 'vitest'
-import { createUpdate, waitForInnerHtml } from '../helpers'
+import { createUpdate, waitForFileContent, waitForInnerHtml } from '../helpers'
 import { serve } from '../runners'
 
 /**
@@ -65,11 +66,11 @@ test.skipIf(process.env.CI)('virtual css module updates on hmr', async () => {
 
   console.log('content.ts updated, waiting for file to be updated in dist...')
 
-  // Wait a bit for the file to be written
-  await new Promise((r) => setTimeout(r, 2000))
-
-  // Read the file again to check if it was updated
-  const updatedCssContentFromFile = await fs.readFile(virtualCssFile!, 'utf-8')
+  await allFilesReady()
+  const updatedCssContentFromFile = await waitForFileContent(
+    virtualCssFile!,
+    (content) => content.includes('text-green') && content.includes('mt-4'),
+  )
 
   // The virtual CSS should now contain the new classes - THIS IS THE KEY ASSERTION
   expect(updatedCssContentFromFile).toContain('text-green')


### PR DESCRIPTION
Follow-up to the Vite compatibility PR. This keeps the change separate from the green working PR branch.

Changes:
- Add `waitForFileContent` to `tests/e2e/helpers.ts`.
- Replace the fixed 2s wait in `mv3-dynamic-script-iife/vite-build.test.ts` with `waitForRegisteredContentScripts`.
- Replace the fixed 2s virtual CSS HMR wait with `allFilesReady()` plus `waitForFileContent`.
- Reuse `waitForFileContent` in the UnoCSS HMR test instead of its local polling loop.
