### PR TITLE
Remove Windows lint job from Vite plugin CI

### DIFF
--- a/.github/workflows/vite-plugin.yml
+++ b/.github/workflows/vite-plugin.yml
@@ -17,11 +17,8 @@ on:
 
 jobs:
   lint:
-    name: Lint (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
+    name: Lint
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: packages/vite-plugin


### PR DESCRIPTION
## What changed

- Removed the Windows matrix entry from the Vite plugin `lint` job.
- The lint job now runs once on `ubuntu-latest`; unit/output and e2e test jobs still keep Windows coverage.

## Why

Running the same lint command on Windows does not add useful signal for this workflow and adds avoidable CI cost/time.