### PR TITLE
upgrade Vitest to 0.34.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "bumpp": "^11.0.1",
-    "vitest": "0.24.3"
+    "vitest": "0.34.6"
   },
   "pnpm": {
     "peerDependencyRules": {

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -131,7 +131,7 @@
     "unocss": "^66.5.12",
     "vite": "^3.2.11",
     "vite-plugin-inspect": "0.7.25",
-    "vitest": "0.28.5",
+    "vitest": "0.34.6",
     "vue": "3.2.47"
   },
   "peerDependencies": {

--- a/packages/vite-plugin/tests/out/basic-js-optional-host-permissions/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/basic-js-optional-host-permissions/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/basic-js-optional-host-permissions/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/basic-js-optional-host-permissions/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/basic-js/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/basic-js/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/basic-js/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/basic-js/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/basic-ts/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/basic-ts/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/basic-ts/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/basic-ts/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/content-script-module-api/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/content-script-module-api/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/content-script-module-api/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/content-script-module-api/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/content-script-world-main/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/content-script-world-main/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/content-script-world-main/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/content-script-world-main/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/dynamic-script-iife/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/dynamic-script-iife/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/dynamic-script-iife/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/dynamic-script-iife/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/dynamic-script/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/dynamic-script/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/dynamic-script/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/dynamic-script/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/vite-content-script-css-imports-2/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-content-script-css-imports-2/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/vite-content-script-css-imports-2/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-content-script-css-imports-2/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/vite-content-script-css-imports-3/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-content-script-css-imports-3/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/vite-content-script-css-imports-3/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-content-script-css-imports-3/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/vite-content-script-css-imports/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-content-script-css-imports/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/vite-content-script-css-imports/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-content-script-css-imports/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/vite-content-script-manifest-css/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-content-script-manifest-css/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/vite-content-script-manifest-css/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-content-script-manifest-css/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/vite-declared-script-resources/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-declared-script-resources/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/vite-declared-script-resources/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-declared-script-resources/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/vite-dynamic-script-resources-minify/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-dynamic-script-resources-minify/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/vite-dynamic-script-resources-minify/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-dynamic-script-resources-minify/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/vite-dynamic-script-resources/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-dynamic-script-resources/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/vite-dynamic-script-resources/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-dynamic-script-resources/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/vite-react-fast-refresh/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-react-fast-refresh/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/vite-react-fast-refresh/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-react-fast-refresh/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/vite-self-directive-in-csp/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-self-directive-in-csp/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`works with 'self' directive > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/vite-self-directive-in-csp/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-self-directive-in-csp/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`works with 'self' directive > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/vite-svelte/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-svelte/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/vite-svelte/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-svelte/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/vite-underscore-css-filename/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-underscore-css-filename/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/vite-underscore-css-filename/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-underscore-css-filename/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`no output files start with underscore (except _locales) > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/with-circular-deps/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-circular-deps/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/with-circular-deps/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-circular-deps/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/with-copied-assets/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-copied-assets/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/with-copied-assets/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-copied-assets/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/with-https-server/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-https-server/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/with-https-server/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-https-server/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/with-manifest-url-fragment/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-manifest-url-fragment/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/with-manifest-url-fragment/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-manifest-url-fragment/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/with-manifest-url-query-string/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-manifest-url-query-string/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/with-manifest-url-query-string/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-manifest-url-query-string/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/with-public-dir/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-public-dir/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/with-public-dir/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-public-dir/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/with-sourcemaps-inline/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-sourcemaps-inline/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/with-sourcemaps-inline/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-sourcemaps-inline/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/with-sourcemaps-separate/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-sourcemaps-separate/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/with-sourcemaps-separate/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-sourcemaps-separate/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/with-web-accessible-html/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-web-accessible-html/__snapshots__/build.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`build fs output > _00 manifest.json 1`] = `
 Object {

--- a/packages/vite-plugin/tests/out/with-web-accessible-html/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-web-accessible-html/__snapshots__/serve.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`serve fs output > _00 manifest.json 1`] = `
 Object {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,8 +44,8 @@ importers:
         specifier: ^11.0.1
         version: 11.0.1
       vitest:
-        specifier: 0.24.3
-        version: 0.24.3(jsdom@16.7.0)(terser@5.44.1)
+        specifier: 0.34.6
+        version: 0.34.6(jsdom@16.7.0)(terser@5.44.1)
 
   packages/rollup-plugin:
     dependencies:
@@ -406,8 +406,8 @@ importers:
         specifier: 0.7.25
         version: 0.7.25(rollup@2.80.0)(vite@3.2.11(@types/node@17.0.18)(terser@5.44.1))
       vitest:
-        specifier: 0.28.5
-        version: 0.28.5(jsdom@16.7.0)(terser@5.44.1)
+        specifier: 0.34.6
+        version: 0.34.6(jsdom@16.7.0)(terser@5.44.1)
       vue:
         specifier: 3.2.47
         version: 3.2.47
@@ -3157,17 +3157,20 @@ packages:
       vite: ^5.0.0 || ^6.0.0
       vue: ^3.2.25
 
-  '@vitest/expect@0.28.5':
-    resolution: {integrity: sha512-gqTZwoUTwepwGIatnw4UKpQfnoyV0Z9Czn9+Lo2/jLIt4/AXLTn+oVZxlQ7Ng8bzcNkR+3DqLJ08kNr8jRmdNQ==}
+  '@vitest/expect@0.34.6':
+    resolution: {integrity: sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==}
 
-  '@vitest/runner@0.28.5':
-    resolution: {integrity: sha512-NKkHtLB+FGjpp5KmneQjTcPLWPTDfB7ie+MmF1PnUBf/tGe2OjGxWyB62ySYZ25EYp9krR5Bw0YPLS/VWh1QiA==}
+  '@vitest/runner@0.34.6':
+    resolution: {integrity: sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==}
 
-  '@vitest/spy@0.28.5':
-    resolution: {integrity: sha512-7if6rsHQr9zbmvxN7h+gGh2L9eIIErgf8nSKYDlg07HHimCxp4H6I/X/DPXktVPPLQfiZ1Cw2cbDIx9fSqDjGw==}
+  '@vitest/snapshot@0.34.6':
+    resolution: {integrity: sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==}
 
-  '@vitest/utils@0.28.5':
-    resolution: {integrity: sha512-UyZdYwdULlOa4LTUSwZ+Paz7nBHGTT72jKwdFSV4IjHF1xsokp+CabMdhjvVhYwkLfO88ylJT46YMilnkSARZA==}
+  '@vitest/spy@0.34.6':
+    resolution: {integrity: sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==}
+
+  '@vitest/utils@0.34.6':
+    resolution: {integrity: sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==}
 
   '@volar/language-core@2.4.15':
     resolution: {integrity: sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==}
@@ -3953,10 +3956,6 @@ packages:
     resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
     engines: {node: 10.* || >= 12.*}
 
-  cli-truncate@3.1.0:
-    resolution: {integrity: sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
@@ -4456,6 +4455,10 @@ packages:
   diff-sequences@27.5.1:
     resolution: {integrity: sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   diff@5.2.0:
     resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
@@ -5724,10 +5727,6 @@ packages:
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
-
-  is-fullwidth-code-point@4.0.0:
-    resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
-    engines: {node: '>=12'}
 
   is-generator-fn@2.1.0:
     resolution: {integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==}
@@ -7417,6 +7416,10 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   pretty-time@1.1.0:
     resolution: {integrity: sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA==}
     engines: {node: '>=4'}
@@ -7550,6 +7553,9 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   react-json-view@1.21.3:
     resolution: {integrity: sha512-13p8IREj9/x/Ye4WI/JpjhoIwuzEgUAtgJZNBJckfzJt1qyh24BdTm6UQNGnyTq9dapQdrqvquZTo3dz1X6Cjw==}
@@ -8101,10 +8107,6 @@ packages:
     resolution: {integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==}
     engines: {node: '>=12'}
 
-  slice-ansi@5.0.0:
-    resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
-    engines: {node: '>=12'}
-
   snapdragon-node@2.1.1:
     resolution: {integrity: sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==}
     engines: {node: '>=0.10.0'}
@@ -8320,9 +8322,6 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  strip-literal@0.4.2:
-    resolution: {integrity: sha512-pv48ybn4iE1O9RLgCAN0iU4Xv7RlBTiit6DKmMiErbs9x1wH6vXBs45tWc0H5wUIF6TLTrKweqkmYF/iraQKNw==}
-
   strip-literal@1.3.0:
     resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
 
@@ -8474,12 +8473,12 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@0.3.1:
-    resolution: {integrity: sha512-zLA1ZXlstbU2rlpA4CIeVaqvWq41MTWqLY3FfsAXgC8+f7Pk7zroaJQxDgxn1xNudKW6Kmj4808rPFShUlIRmQ==}
+  tinypool@0.7.0:
+    resolution: {integrity: sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==}
     engines: {node: '>=14.0.0'}
 
-  tinyspy@1.1.1:
-    resolution: {integrity: sha512-UVq5AXt/gQlti7oxoIg5oi/9r0WpF7DGEVwXgqWSMmyN16+e3tl5lIvTaOpJ3TAtu5xFzWccFRM4R5NaWHF+4g==}
+  tinyspy@2.2.1:
+    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
     engines: {node: '>=14.0.0'}
 
   tmpl@1.0.5:
@@ -8898,9 +8897,9 @@ packages:
   vfile@4.2.1:
     resolution: {integrity: sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==}
 
-  vite-node@0.28.5:
-    resolution: {integrity: sha512-LmXb9saMGlrMZbXTvOveJKwMTBTNUH66c8rJnQ0ZPNX+myPEol64+szRzXtV5ORb0Hb/91yq+/D3oERoyAt6LA==}
-    engines: {node: '>=v14.16.0'}
+  vite-node@0.34.6:
+    resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
+    engines: {node: '>=v14.18.0'}
     hasBin: true
 
   vite-plugin-inspect@0.7.25:
@@ -9005,9 +9004,9 @@ packages:
       vite:
         optional: true
 
-  vitest@0.24.3:
-    resolution: {integrity: sha512-aM0auuPPgMSstWvr851hB74g/LKaKBzSxcG3da7ejfZbx08Y21JpZmbmDYrMTCGhVZKqTGwzcnLMwyfz2WzkhQ==}
-    engines: {node: '>=v14.16.0'}
+  vitest@0.34.6:
+    resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}
+    engines: {node: '>=v14.18.0'}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
@@ -9015,6 +9014,9 @@ packages:
       '@vitest/ui': '*'
       happy-dom: '*'
       jsdom: '*'
+      playwright: '*'
+      safaridriver: '*'
+      webdriverio: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -9026,27 +9028,11 @@ packages:
         optional: true
       jsdom:
         optional: true
-
-  vitest@0.28.5:
-    resolution: {integrity: sha512-pyCQ+wcAOX7mKMcBNkzDwEHRGqQvHUl0XnoHR+3Pb1hytAHISgSxv9h0gUiSiYtISXUU3rMrKiKzFYDrI6ZIHA==}
-    engines: {node: '>=v14.16.0'}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@vitest/browser': '*'
-      '@vitest/ui': '*'
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
+      playwright:
         optional: true
-      '@vitest/browser':
+      safaridriver:
         optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
+      webdriverio:
         optional: true
 
   vscode-uri@3.1.0:
@@ -13460,29 +13446,33 @@ snapshots:
       vite: 6.4.1(@types/node@22.19.5)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
       vue: 3.5.26(typescript@5.7.3)
 
-  '@vitest/expect@0.28.5':
+  '@vitest/expect@0.34.6':
     dependencies:
-      '@vitest/spy': 0.28.5
-      '@vitest/utils': 0.28.5
+      '@vitest/spy': 0.34.6
+      '@vitest/utils': 0.34.6
       chai: 4.5.0
 
-  '@vitest/runner@0.28.5':
+  '@vitest/runner@0.34.6':
     dependencies:
-      '@vitest/utils': 0.28.5
+      '@vitest/utils': 0.34.6
       p-limit: 4.0.0
       pathe: 1.1.2
 
-  '@vitest/spy@0.28.5':
+  '@vitest/snapshot@0.34.6':
     dependencies:
-      tinyspy: 1.1.1
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      pretty-format: 29.7.0
 
-  '@vitest/utils@0.28.5':
+  '@vitest/spy@0.34.6':
     dependencies:
-      cli-truncate: 3.1.0
-      diff: 5.2.0
+      tinyspy: 2.2.1
+
+  '@vitest/utils@0.34.6':
+    dependencies:
+      diff-sequences: 29.6.3
       loupe: 2.3.7
-      picocolors: 1.1.1
-      pretty-format: 27.5.1
+      pretty-format: 29.7.0
 
   '@volar/language-core@2.4.15':
     dependencies:
@@ -14503,11 +14493,6 @@ snapshots:
     optionalDependencies:
       '@colors/colors': 1.5.0
 
-  cli-truncate@3.1.0:
-    dependencies:
-      slice-ansi: 5.0.0
-      string-width: 5.1.2
-
   cliui@6.0.0:
     dependencies:
       string-width: 4.2.3
@@ -14993,6 +14978,8 @@ snapshots:
   diff-sequences@26.6.2: {}
 
   diff-sequences@27.5.1: {}
+
+  diff-sequences@29.6.3: {}
 
   diff@5.2.0: {}
 
@@ -16532,8 +16519,6 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
-  is-fullwidth-code-point@4.0.0: {}
-
   is-generator-fn@2.1.0: {}
 
   is-generator-function@1.1.2:
@@ -17029,11 +17014,7 @@ snapshots:
       pretty-format: 26.6.2
       throat: 5.0.0
     transitivePeerDependencies:
-      - bufferutil
-      - canvas
       - supports-color
-      - ts-node
-      - utf-8-validate
 
   jest-jasmine2@27.5.1:
     dependencies:
@@ -18696,6 +18677,12 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  pretty-format@29.7.0:
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+
   pretty-time@1.1.0: {}
 
   prism-react-renderer@1.3.5(react@17.0.2):
@@ -18862,6 +18849,8 @@ snapshots:
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
+
+  react-is@18.3.1: {}
 
   react-json-view@1.21.3(@types/react@17.0.52)(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
     dependencies:
@@ -19554,11 +19543,6 @@ snapshots:
 
   slash@4.0.0: {}
 
-  slice-ansi@5.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 4.0.0
-
   snapdragon-node@2.1.1:
     dependencies:
       define-property: 1.0.0
@@ -19818,10 +19802,6 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strip-literal@0.4.2:
-    dependencies:
-      acorn: 8.15.0
-
   strip-literal@1.3.0:
     dependencies:
       acorn: 8.15.0
@@ -19971,9 +19951,9 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
-  tinypool@0.3.1: {}
+  tinypool@0.7.0: {}
 
-  tinyspy@1.1.1: {}
+  tinyspy@2.2.1: {}
 
   tmpl@1.0.5: {}
 
@@ -20418,15 +20398,13 @@ snapshots:
       unist-util-stringify-position: 2.0.3
       vfile-message: 2.0.4
 
-  vite-node@0.28.5(@types/node@22.19.5)(terser@5.44.1):
+  vite-node@0.34.6(@types/node@22.19.5)(terser@5.44.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       mlly: 1.8.0
       pathe: 1.1.2
       picocolors: 1.1.1
-      source-map: 0.6.1
-      source-map-support: 0.5.21
       vite: 3.2.11(@types/node@22.19.5)(terser@5.44.1)
     transitivePeerDependencies:
       - '@types/node'
@@ -20515,54 +20493,31 @@ snapshots:
     optionalDependencies:
       vite: 6.4.1(@types/node@22.19.5)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)
 
-  vitest@0.24.3(jsdom@16.7.0)(terser@5.44.1):
+  vitest@0.34.6(jsdom@16.7.0)(terser@5.44.1):
     dependencies:
       '@types/chai': 4.3.20
       '@types/chai-subset': 1.3.6(@types/chai@4.3.20)
       '@types/node': 22.19.5
-      chai: 4.5.0
-      debug: 4.4.3
-      local-pkg: 0.4.3
-      strip-literal: 0.4.2
-      tinybench: 2.9.0
-      tinypool: 0.3.1
-      tinyspy: 1.1.1
-      vite: 3.2.11(@types/node@22.19.5)(terser@5.44.1)
-    optionalDependencies:
-      jsdom: 16.7.0
-    transitivePeerDependencies:
-      - less
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vitest@0.28.5(jsdom@16.7.0)(terser@5.44.1):
-    dependencies:
-      '@types/chai': 4.3.20
-      '@types/chai-subset': 1.3.6(@types/chai@4.3.20)
-      '@types/node': 22.19.5
-      '@vitest/expect': 0.28.5
-      '@vitest/runner': 0.28.5
-      '@vitest/spy': 0.28.5
-      '@vitest/utils': 0.28.5
+      '@vitest/expect': 0.34.6
+      '@vitest/runner': 0.34.6
+      '@vitest/snapshot': 0.34.6
+      '@vitest/spy': 0.34.6
+      '@vitest/utils': 0.34.6
       acorn: 8.15.0
       acorn-walk: 8.3.4
       cac: 6.7.14
       chai: 4.5.0
       debug: 4.4.3
       local-pkg: 0.4.3
+      magic-string: 0.30.21
       pathe: 1.1.2
       picocolors: 1.1.1
-      source-map: 0.6.1
       std-env: 3.10.0
       strip-literal: 1.3.0
       tinybench: 2.9.0
-      tinypool: 0.3.1
-      tinyspy: 1.1.1
+      tinypool: 0.7.0
       vite: 3.2.11(@types/node@22.19.5)(terser@5.44.1)
-      vite-node: 0.28.5(@types/node@22.19.5)(terser@5.44.1)
+      vite-node: 0.34.6(@types/node@22.19.5)(terser@5.44.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       jsdom: 16.7.0


### PR DESCRIPTION
## Summary

- Closes #1180.
- Upgrades the root and `@crxjs/vite-plugin` Vitest pins to `0.34.6`, the latest 0.x release compatible with the current Node/Vite support range.
- Refreshes `pnpm-lock.yaml` and updates Vitest snapshot headers generated by the newer runner.

## Why not Vitest 4 in this PR

The latest registry version checked on 2026-06-09 is `vitest@4.1.8`, but it is not currently a drop-in upgrade here. A local attempt against the existing Vite 3 test stack failed at startup with:

```text
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './module-runner' is not defined by "exports" in vite/package.json
```

A minimal Vite 8 peer-stack attempt exposed broader migration work: removed `configDefaults.watchExclude`, Vite 8 Node/types/tooling requirements, Vite 3-era fixture plugins, TypeScript/module-resolution issues for Vite 8 exports, and Vitest test option typing changes.

## Verification

- `pnpm -C packages/vite-plugin run build`
- `pnpm -C packages/vite-plugin run lint` (passes with the existing `no-explicit-any` warning in `plugin-manifest.ts`)
- `pnpm -C packages/vite-plugin run test:run:compat`
- `pnpm -C packages/vite-plugin run test:run:out`
- `pnpm -C packages/vite-plugin run test:run:e2e`
