### PR TITLE
fix: dev loading page readiness loop

### DIFF
--- a/.changeset/loading-page-readiness.md
+++ b/.changeset/loading-page-readiness.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+Fix the dev-mode loading page so it waits for the requested extension HTML file, preserves the page URL query string, allows extension-origin readiness polling, and throttles automatic reloads to avoid rapid flicker.

--- a/packages/vite-plugin/src/client/es/loading-page-script.ts
+++ b/packages/vite-plugin/src/client/es/loading-page-script.ts
@@ -4,6 +4,17 @@
  */
 
 const VITE_URL = '%PROTO%://localhost:%PORT%'
+const READY_PATH = '%READY_PATH%'
+const VITE_PAGE_URL = new URL(location.pathname + location.search, VITE_URL)
+  .href
+const RELOAD_DELAY = 100
+
+function getReadyUrl() {
+  const url = new URL(READY_PATH, VITE_URL)
+  url.searchParams.set('path', location.pathname + location.search)
+  url.searchParams.set('t', Date.now().toString())
+  return url.href
+}
 
 document.body.innerHTML = /* html */ `
 <style>
@@ -222,7 +233,7 @@ document.body.innerHTML = /* html */ `
 
   <div class="content">
     <p>
-      Cannot connect to <a href="${VITE_URL}">${VITE_URL}</a>.
+      Cannot connect to <a href="${VITE_PAGE_URL}">${VITE_PAGE_URL}</a>.
       Make sure Vite is running, then reload the extension.
     </p>
     <p>This page will close automatically after the extension reloads.</p>
@@ -245,18 +256,22 @@ let tries = 0
 let ready = false
 do {
   try {
-    await fetch(VITE_URL)
+    const response = await fetch(getReadyUrl())
+    if (!response.ok) throw new Error(`HTTP ${response.status}`)
     ready = true
   } catch {
     // exponential backoff for retries, maxing out at every 5 seconds
     const timeout = Math.min(100 * Math.pow(2, ++tries), 5000)
-    console.log(`[CRXJS] Vite Dev Server is not available on ${VITE_URL}`)
+    console.log(`[CRXJS] Vite Dev Server is not available on ${VITE_PAGE_URL}`)
     console.log(`[CRXJS] Retrying in ${timeout}ms...`)
     await new Promise((resolve) => setTimeout(resolve, timeout))
   }
 } while (!ready)
 
 // reload the page to load the built files from the dev server
+console.log(`[CRXJS] Vite Dev Server is ready on ${VITE_PAGE_URL}`)
+console.log(`[CRXJS] Reloading in ${RELOAD_DELAY}ms...`)
+await new Promise((resolve) => setTimeout(resolve, RELOAD_DELAY))
 location.reload()
 
 export {}

--- a/packages/vite-plugin/src/node/plugin-manifest.ts
+++ b/packages/vite-plugin/src/node/plugin-manifest.ts
@@ -9,7 +9,7 @@ import { formatFileData, getFileName, prefix } from './fileWriter-utilities'
 import { htmlFiles, manifestFiles } from './files'
 import { decodeManifest, encodeManifest, isString } from './helpers'
 import { ManifestV3 } from './manifest'
-import { basename, isAbsolute, join, relative } from './path'
+import { basename, isAbsolute, join, normalize, relative } from './path'
 import { getOptions } from './plugin-optionsProvider'
 import { CrxPlugin, CrxPluginFn, ManifestFiles } from './types'
 import {
@@ -24,6 +24,46 @@ const { readFile } = fs
 
 declare const structuredClone: <T>(value: T) => T
 
+const loadingPageReadyPath = '/@crx/dev-ready'
+
+function normalizeHtmlPath(pathname: string): string | null {
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(pathname)
+  } catch {
+    return null
+  }
+
+  const normalized = normalize(decoded.replace(/^\/+/, '') || 'index.html')
+  if (normalized.startsWith('..') || isAbsolute(normalized)) return null
+  return normalized
+}
+
+function getLoadingPageReadyHtmlPath(requestUrl: string | undefined) {
+  if (!requestUrl) return null
+
+  let url: URL
+  try {
+    url = new URL(requestUrl, 'http://crxjs.local')
+  } catch {
+    return null
+  }
+
+  if (url.pathname !== loadingPageReadyPath) return undefined
+
+  const path = url.searchParams.get('path')
+  if (!path) return null
+
+  let pageUrl: URL
+  try {
+    pageUrl = new URL(path, 'http://crxjs.local')
+  } catch {
+    return null
+  }
+
+  return normalizeHtmlPath(pageUrl.pathname)
+}
+
 /**
  * This plugin emits, transforms, renders, and outputs the manifest.
  *
@@ -36,6 +76,7 @@ export const pluginManifest: CrxPluginFn = () => {
   // This is important for rolldown-vite (Vite 7) compatibility where buildStart
   // doesn't receive options.plugins
   let plugins: CrxPlugin[] = []
+  let devHtmlFiles = new Set<string>()
   let refId: string
   let config: ResolvedConfig
 
@@ -64,6 +105,7 @@ export const pluginManifest: CrxPluginFn = () => {
             background: sw,
             html,
           } = await manifestFiles(manifest, { cwd: config.root })
+          devHtmlFiles = new Set(html.map(normalizeHtmlPath).filter(isString))
           const { entries = [] } = config.optimizeDeps ?? {}
           // Vite ignores build inputs if optimize deps has explicit entries,
           // so we need to merge both to include extra HTML files
@@ -97,6 +139,32 @@ export const pluginManifest: CrxPluginFn = () => {
         if (resolvedConfig.plugins) {
           plugins = resolvedConfig.plugins as CrxPlugin[]
         }
+      },
+      configureServer(server) {
+        server.middlewares.use((req, res, next) => {
+          const htmlPath = getLoadingPageReadyHtmlPath(req.url)
+          if (typeof htmlPath === 'undefined') {
+            next()
+            return
+          }
+
+          res.setHeader('Access-Control-Allow-Origin', '*')
+          res.setHeader('Access-Control-Allow-Methods', 'GET')
+
+          if (!htmlPath) {
+            res.statusCode = 400
+            res.end()
+            return
+          }
+
+          const exists =
+            devHtmlFiles.has(htmlPath) &&
+            (existsSync(join(server.config.root, htmlPath)) ||
+              existsSync(join(server.config.publicDir, htmlPath)))
+
+          res.statusCode = exists ? 204 : 404
+          res.end()
+        })
       },
       buildStart(options) {
         // Keep this as fallback for older Vite versions where buildStart provides plugins
@@ -435,6 +503,11 @@ export const pluginManifest: CrxPluginFn = () => {
           'webAccessibleResources',
         ]
         const files = await manifestFiles(manifest, { cwd: config.root })
+        if (config.command === 'serve') {
+          devHtmlFiles = new Set(
+            files.html.map(normalizeHtmlPath).filter(isString),
+          )
+        }
         await Promise.all(
           assetTypes
             .map((k) => files[k])
@@ -484,7 +557,8 @@ Public dir: "${config.publicDir}"`,
             name: 'loading-page.js',
             source: loadingPageScript
               .replace('%PROTO%', config.server.https ? 'https' : 'http')
-              .replace('%PORT%', `${config.server.port ?? 0}`),
+              .replace('%PORT%', `${config.server.port ?? 0}`)
+              .replace('%READY_PATH%', loadingPageReadyPath),
           })
           const loadingPageScriptName = this.getFileName(refId)
           files.html.map((f) =>

--- a/packages/vite-plugin/tests/e2e/mv3-vite-vue-page-hmr/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-vue-page-hmr/vite-serve.test.ts
@@ -19,10 +19,11 @@ test(
     const page = await getPage(browser, 'chrome-extension')
     const update = createUpdate({ target: src, src: src2 })
     const styles = page.locator('head style')
-    const button = page.locator('button')
+    const button = page.locator('button', { hasText: /count is:/ })
     const buttonText = new Set<string>()
 
     await page.waitForLoadState()
+    await button.waitFor()
     await button.click()
     buttonText.add(await button.innerText())
 

--- a/packages/vite-plugin/tests/out/basic-js-optional-host-permissions/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/basic-js-optional-host-permissions/__snapshots__/serve.test.ts.snap
@@ -75,6 +75,15 @@ Set {
 
 exports[`serve fs output > assets/loading-page.hash0.js 1`] = `
 "const VITE_URL = \\"http://localhost:3000\\";
+const READY_PATH = \\"/@crx/dev-ready\\";
+const VITE_PAGE_URL = new URL(location.pathname + location.search, VITE_URL).href;
+const RELOAD_DELAY = 100;
+function getReadyUrl() {
+  const url = new URL(READY_PATH, VITE_URL);
+  url.searchParams.set(\\"path\\", location.pathname + location.search);
+  url.searchParams.set(\\"t\\", Date.now().toString());
+  return url.href;
+}
 document.body.innerHTML = /* html */
 \`
 <style>
@@ -293,7 +302,7 @@ document.body.innerHTML = /* html */
 
   <div class=\\"content\\">
     <p>
-      Cannot connect to <a href=\\"\${VITE_URL}\\">\${VITE_URL}</a>.
+      Cannot connect to <a href=\\"\${VITE_PAGE_URL}\\">\${VITE_PAGE_URL}</a>.
       Make sure Vite is running, then reload the extension.
     </p>
     <p>This page will close automatically after the extension reloads.</p>
@@ -314,15 +323,20 @@ let tries = 0;
 let ready = false;
 do {
   try {
-    await fetch(VITE_URL);
+    const response = await fetch(getReadyUrl());
+    if (!response.ok)
+      throw new Error(\`HTTP \${response.status}\`);
     ready = true;
   } catch {
     const timeout = Math.min(100 * Math.pow(2, ++tries), 5e3);
-    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_URL}\`);
+    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_PAGE_URL}\`);
     console.log(\`[CRXJS] Retrying in \${timeout}ms...\`);
     await new Promise((resolve) => setTimeout(resolve, timeout));
   }
 } while (!ready);
+console.log(\`[CRXJS] Vite Dev Server is ready on \${VITE_PAGE_URL}\`);
+console.log(\`[CRXJS] Reloading in \${RELOAD_DELAY}ms...\`);
+await new Promise((resolve) => setTimeout(resolve, RELOAD_DELAY));
 location.reload();
 "
 `;

--- a/packages/vite-plugin/tests/out/basic-js/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/basic-js/__snapshots__/serve.test.ts.snap
@@ -67,6 +67,15 @@ Set {
 
 exports[`serve fs output > assets/loading-page.hash0.js 1`] = `
 "const VITE_URL = \\"http://localhost:3000\\";
+const READY_PATH = \\"/@crx/dev-ready\\";
+const VITE_PAGE_URL = new URL(location.pathname + location.search, VITE_URL).href;
+const RELOAD_DELAY = 100;
+function getReadyUrl() {
+  const url = new URL(READY_PATH, VITE_URL);
+  url.searchParams.set(\\"path\\", location.pathname + location.search);
+  url.searchParams.set(\\"t\\", Date.now().toString());
+  return url.href;
+}
 document.body.innerHTML = /* html */
 \`
 <style>
@@ -285,7 +294,7 @@ document.body.innerHTML = /* html */
 
   <div class=\\"content\\">
     <p>
-      Cannot connect to <a href=\\"\${VITE_URL}\\">\${VITE_URL}</a>.
+      Cannot connect to <a href=\\"\${VITE_PAGE_URL}\\">\${VITE_PAGE_URL}</a>.
       Make sure Vite is running, then reload the extension.
     </p>
     <p>This page will close automatically after the extension reloads.</p>
@@ -306,15 +315,20 @@ let tries = 0;
 let ready = false;
 do {
   try {
-    await fetch(VITE_URL);
+    const response = await fetch(getReadyUrl());
+    if (!response.ok)
+      throw new Error(\`HTTP \${response.status}\`);
     ready = true;
   } catch {
     const timeout = Math.min(100 * Math.pow(2, ++tries), 5e3);
-    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_URL}\`);
+    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_PAGE_URL}\`);
     console.log(\`[CRXJS] Retrying in \${timeout}ms...\`);
     await new Promise((resolve) => setTimeout(resolve, timeout));
   }
 } while (!ready);
+console.log(\`[CRXJS] Vite Dev Server is ready on \${VITE_PAGE_URL}\`);
+console.log(\`[CRXJS] Reloading in \${RELOAD_DELAY}ms...\`);
+await new Promise((resolve) => setTimeout(resolve, RELOAD_DELAY));
 location.reload();
 "
 `;

--- a/packages/vite-plugin/tests/out/basic-ts/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/basic-ts/__snapshots__/serve.test.ts.snap
@@ -64,6 +64,15 @@ Set {
 
 exports[`serve fs output > assets/loading-page.hash0.js 1`] = `
 "const VITE_URL = \\"http://localhost:3000\\";
+const READY_PATH = \\"/@crx/dev-ready\\";
+const VITE_PAGE_URL = new URL(location.pathname + location.search, VITE_URL).href;
+const RELOAD_DELAY = 100;
+function getReadyUrl() {
+  const url = new URL(READY_PATH, VITE_URL);
+  url.searchParams.set(\\"path\\", location.pathname + location.search);
+  url.searchParams.set(\\"t\\", Date.now().toString());
+  return url.href;
+}
 document.body.innerHTML = /* html */
 \`
 <style>
@@ -282,7 +291,7 @@ document.body.innerHTML = /* html */
 
   <div class=\\"content\\">
     <p>
-      Cannot connect to <a href=\\"\${VITE_URL}\\">\${VITE_URL}</a>.
+      Cannot connect to <a href=\\"\${VITE_PAGE_URL}\\">\${VITE_PAGE_URL}</a>.
       Make sure Vite is running, then reload the extension.
     </p>
     <p>This page will close automatically after the extension reloads.</p>
@@ -303,15 +312,20 @@ let tries = 0;
 let ready = false;
 do {
   try {
-    await fetch(VITE_URL);
+    const response = await fetch(getReadyUrl());
+    if (!response.ok)
+      throw new Error(\`HTTP \${response.status}\`);
     ready = true;
   } catch {
     const timeout = Math.min(100 * Math.pow(2, ++tries), 5e3);
-    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_URL}\`);
+    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_PAGE_URL}\`);
     console.log(\`[CRXJS] Retrying in \${timeout}ms...\`);
     await new Promise((resolve) => setTimeout(resolve, timeout));
   }
 } while (!ready);
+console.log(\`[CRXJS] Vite Dev Server is ready on \${VITE_PAGE_URL}\`);
+console.log(\`[CRXJS] Reloading in \${RELOAD_DELAY}ms...\`);
+await new Promise((resolve) => setTimeout(resolve, RELOAD_DELAY));
 location.reload();
 "
 `;

--- a/packages/vite-plugin/tests/out/loading-page-readiness/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/loading-page-readiness/__snapshots__/serve.test.ts.snap
@@ -1,0 +1,75 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`serve loading page waits for the requested extension html > _00 manifest.json 1`] = `
+Object {
+  "action": Object {
+    "default_popup": "src/popup.html?page=default",
+  },
+  "background": Object {
+    "service_worker": "service-worker-loader.js",
+    "type": "module",
+  },
+  "description": "loading page readiness test extension",
+  "manifest_version": 3,
+  "name": "Loading Page Readiness",
+  "version": "1.0.0",
+  "web_accessible_resources": Array [
+    Object {
+      "matches": Array [
+        "<all_urls>",
+      ],
+      "resources": Array [
+        "*",
+        "**/*",
+      ],
+      "use_dynamic_url": false,
+    },
+  ],
+}
+`;
+
+exports[`serve loading page waits for the requested extension html > _01 output files 1`] = `
+Array [
+  "assets/loading-page.hash0.js",
+  "manifest.json",
+  "service-worker-loader.js",
+  "src/popup.html",
+]
+`;
+
+exports[`serve loading page waits for the requested extension html > _02 optimized deps 1`] = `
+Set {
+  "src/background.js",
+  "src/popup.html",
+}
+`;
+
+exports[`serve loading page waits for the requested extension html > assets/loading-page.hash0.js 1`] = `
+Object {
+  "rejectsHttpErrors": true,
+  "throttlesReloads": true,
+  "usesCurrentPage": true,
+  "usesReadyEndpoint": true,
+}
+`;
+
+exports[`serve loading page waits for the requested extension html > service-worker-loader.js 1`] = `
+"import 'http://localhost:3000/@vite/env';
+import 'http://localhost:3000/@crx/client-worker';
+import 'http://localhost:3000/src/background.js';
+"
+`;
+
+exports[`serve loading page waits for the requested extension html > src/popup.html 1`] = `
+"<!DOCTYPE html>
+<html lang=\\"en\\">
+  <head>
+    <title>CRXJS DEV MODE</title>
+    <script src=\\"/assets/loading-page.hash0.js\\" type=\\"module\\"></script>
+  </head>
+  <body>
+    <p>An unknown error occurred. Failed to load the script.</p>
+  </body>
+</html>
+"
+`;

--- a/packages/vite-plugin/tests/out/loading-page-readiness/manifest.json
+++ b/packages/vite-plugin/tests/out/loading-page-readiness/manifest.json
@@ -1,0 +1,12 @@
+{
+  "action": {
+    "default_popup": "src/popup.html?page=default"
+  },
+  "background": {
+    "service_worker": "src/background.js"
+  },
+  "description": "loading page readiness test extension",
+  "manifest_version": 3,
+  "name": "Loading Page Readiness",
+  "version": "1.0.0"
+}

--- a/packages/vite-plugin/tests/out/loading-page-readiness/serve.test.ts
+++ b/packages/vite-plugin/tests/out/loading-page-readiness/serve.test.ts
@@ -1,0 +1,93 @@
+import { request } from 'http'
+import { serve } from 'tests/runners'
+import { testOutput } from 'tests/testOutput'
+import { afterAll, expect, test } from 'vitest'
+
+let result: Awaited<ReturnType<typeof serve>> | undefined
+
+afterAll(async () => {
+  try {
+    await result?.server.close()
+  } catch (error) {}
+})
+
+function getResponse(
+  port: number,
+  path: string,
+): Promise<{ status: number; headers: Record<string, string | string[]> }> {
+  return new Promise((resolve, reject) => {
+    const req = request(
+      {
+        hostname: 'localhost',
+        method: 'GET',
+        path,
+        port,
+      },
+      (res) => {
+        res.resume()
+        res.on('end', () =>
+          resolve({
+            status: res.statusCode ?? 0,
+            headers: res.headers as Record<string, string | string[]>,
+          }),
+        )
+      },
+    )
+    req.on('error', reject)
+    req.end()
+  })
+}
+
+test('serve loading page waits for the requested extension html', async () => {
+  result = await serve(__dirname)
+
+  const port = result.config.server.port
+  if (typeof port !== 'number') throw new TypeError('server port is undefined')
+
+  const readyPath = '/@crx/dev-ready'
+  const popupPath = encodeURIComponent('/src/popup.html?page=default')
+  const rootPath = encodeURIComponent('/')
+  const missingPath = encodeURIComponent('/missing.html')
+
+  await expect(
+    getResponse(port, `${readyPath}?path=${popupPath}`),
+  ).resolves.toMatchObject({
+    status: 204,
+    headers: { 'access-control-allow-origin': '*' },
+  })
+  await expect(
+    getResponse(port, `${readyPath}?path=${rootPath}`),
+  ).resolves.toMatchObject({
+    status: 404,
+    headers: { 'access-control-allow-origin': '*' },
+  })
+  await expect(
+    getResponse(port, `${readyPath}?path=${missingPath}`),
+  ).resolves.toMatchObject({
+    status: 404,
+    headers: { 'access-control-allow-origin': '*' },
+  })
+
+  await testOutput(
+    result,
+    new Map([
+      [
+        /assets\/loading-page\..+\.js/,
+        (source, name) => {
+          expect(source).toContain('/@crx/dev-ready')
+          expect(source).toContain('location.pathname + location.search')
+          expect(source).toContain('RELOAD_DELAY = 100')
+          expect(source).toContain('Reloading in')
+          expect({
+            usesCurrentPage: source.includes(
+              'location.pathname + location.search',
+            ),
+            usesReadyEndpoint: source.includes('/@crx/dev-ready'),
+            rejectsHttpErrors: source.includes('!response.ok'),
+            throttlesReloads: source.includes('RELOAD_DELAY = 100'),
+          }).toMatchSnapshot(name)
+        },
+      ],
+    ]),
+  )
+})

--- a/packages/vite-plugin/tests/out/loading-page-readiness/src/background.js
+++ b/packages/vite-plugin/tests/out/loading-page-readiness/src/background.js
@@ -1,0 +1,1 @@
+console.log('background')

--- a/packages/vite-plugin/tests/out/loading-page-readiness/src/popup.html
+++ b/packages/vite-plugin/tests/out/loading-page-readiness/src/popup.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Popup Page</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="./popup.js" type="module"></script>
+  </body>
+</html>

--- a/packages/vite-plugin/tests/out/loading-page-readiness/src/popup.js
+++ b/packages/vite-plugin/tests/out/loading-page-readiness/src/popup.js
@@ -1,0 +1,1 @@
+document.querySelector('#root').textContent = 'popup ready'

--- a/packages/vite-plugin/tests/out/loading-page-readiness/vite.config.ts
+++ b/packages/vite-plugin/tests/out/loading-page-readiness/vite.config.ts
@@ -1,0 +1,19 @@
+import { crx } from '../../plugin-testOptionsProvider'
+import { defineConfig } from 'vite'
+import manifest from './manifest.json'
+
+export default defineConfig({
+  build: {
+    minify: false,
+    rollupOptions: {
+      output: {
+        assetFileNames: 'assets/[name].hash[hash].[ext]',
+        chunkFileNames: 'assets/[name].hash[hash].js',
+        entryFileNames: 'assets/[name].hash[hash].js',
+      },
+    },
+  },
+  clearScreen: false,
+  logLevel: 'error',
+  plugins: [crx({ manifest })],
+})

--- a/packages/vite-plugin/tests/out/vite-react-fast-refresh/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-react-fast-refresh/__snapshots__/serve.test.ts.snap
@@ -68,6 +68,15 @@ Set {
 
 exports[`serve fs output > assets/loading-page.hash0.js 1`] = `
 "const VITE_URL = \\"http://localhost:3000\\";
+const READY_PATH = \\"/@crx/dev-ready\\";
+const VITE_PAGE_URL = new URL(location.pathname + location.search, VITE_URL).href;
+const RELOAD_DELAY = 100;
+function getReadyUrl() {
+  const url = new URL(READY_PATH, VITE_URL);
+  url.searchParams.set(\\"path\\", location.pathname + location.search);
+  url.searchParams.set(\\"t\\", Date.now().toString());
+  return url.href;
+}
 document.body.innerHTML = /* html */
 \`
 <style>
@@ -286,7 +295,7 @@ document.body.innerHTML = /* html */
 
   <div class=\\"content\\">
     <p>
-      Cannot connect to <a href=\\"\${VITE_URL}\\">\${VITE_URL}</a>.
+      Cannot connect to <a href=\\"\${VITE_PAGE_URL}\\">\${VITE_PAGE_URL}</a>.
       Make sure Vite is running, then reload the extension.
     </p>
     <p>This page will close automatically after the extension reloads.</p>
@@ -307,15 +316,20 @@ let tries = 0;
 let ready = false;
 do {
   try {
-    await fetch(VITE_URL);
+    const response = await fetch(getReadyUrl());
+    if (!response.ok)
+      throw new Error(\`HTTP \${response.status}\`);
     ready = true;
   } catch {
     const timeout = Math.min(100 * Math.pow(2, ++tries), 5e3);
-    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_URL}\`);
+    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_PAGE_URL}\`);
     console.log(\`[CRXJS] Retrying in \${timeout}ms...\`);
     await new Promise((resolve) => setTimeout(resolve, timeout));
   }
 } while (!ready);
+console.log(\`[CRXJS] Vite Dev Server is ready on \${VITE_PAGE_URL}\`);
+console.log(\`[CRXJS] Reloading in \${RELOAD_DELAY}ms...\`);
+await new Promise((resolve) => setTimeout(resolve, RELOAD_DELAY));
 location.reload();
 "
 `;

--- a/packages/vite-plugin/tests/out/vite-self-directive-in-csp/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-self-directive-in-csp/__snapshots__/serve.test.ts.snap
@@ -67,6 +67,15 @@ Set {
 
 exports[`works with 'self' directive > assets/loading-page.hash0.js 1`] = `
 "const VITE_URL = \\"http://localhost:3000\\";
+const READY_PATH = \\"/@crx/dev-ready\\";
+const VITE_PAGE_URL = new URL(location.pathname + location.search, VITE_URL).href;
+const RELOAD_DELAY = 100;
+function getReadyUrl() {
+  const url = new URL(READY_PATH, VITE_URL);
+  url.searchParams.set(\\"path\\", location.pathname + location.search);
+  url.searchParams.set(\\"t\\", Date.now().toString());
+  return url.href;
+}
 document.body.innerHTML = /* html */
 \`
 <style>
@@ -285,7 +294,7 @@ document.body.innerHTML = /* html */
 
   <div class=\\"content\\">
     <p>
-      Cannot connect to <a href=\\"\${VITE_URL}\\">\${VITE_URL}</a>.
+      Cannot connect to <a href=\\"\${VITE_PAGE_URL}\\">\${VITE_PAGE_URL}</a>.
       Make sure Vite is running, then reload the extension.
     </p>
     <p>This page will close automatically after the extension reloads.</p>
@@ -306,15 +315,20 @@ let tries = 0;
 let ready = false;
 do {
   try {
-    await fetch(VITE_URL);
+    const response = await fetch(getReadyUrl());
+    if (!response.ok)
+      throw new Error(\`HTTP \${response.status}\`);
     ready = true;
   } catch {
     const timeout = Math.min(100 * Math.pow(2, ++tries), 5e3);
-    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_URL}\`);
+    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_PAGE_URL}\`);
     console.log(\`[CRXJS] Retrying in \${timeout}ms...\`);
     await new Promise((resolve) => setTimeout(resolve, timeout));
   }
 } while (!ready);
+console.log(\`[CRXJS] Vite Dev Server is ready on \${VITE_PAGE_URL}\`);
+console.log(\`[CRXJS] Reloading in \${RELOAD_DELAY}ms...\`);
+await new Promise((resolve) => setTimeout(resolve, RELOAD_DELAY));
 location.reload();
 "
 `;

--- a/packages/vite-plugin/tests/out/vite-svelte/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-svelte/__snapshots__/serve.test.ts.snap
@@ -77,6 +77,15 @@ Set {
 
 exports[`serve fs output > assets/loading-page.hash.js 1`] = `
 "const VITE_URL = \\"http://localhost:3000\\";
+const READY_PATH = \\"/@crx/dev-ready\\";
+const VITE_PAGE_URL = new URL(location.pathname + location.search, VITE_URL).href;
+const RELOAD_DELAY = 100;
+function getReadyUrl() {
+  const url = new URL(READY_PATH, VITE_URL);
+  url.searchParams.set(\\"path\\", location.pathname + location.search);
+  url.searchParams.set(\\"t\\", Date.now().toString());
+  return url.href;
+}
 document.body.innerHTML = /* html */
 \`
 <style>
@@ -295,7 +304,7 @@ document.body.innerHTML = /* html */
 
   <div class=\\"content\\">
     <p>
-      Cannot connect to <a href=\\"\${VITE_URL}\\">\${VITE_URL}</a>.
+      Cannot connect to <a href=\\"\${VITE_PAGE_URL}\\">\${VITE_PAGE_URL}</a>.
       Make sure Vite is running, then reload the extension.
     </p>
     <p>This page will close automatically after the extension reloads.</p>
@@ -316,15 +325,20 @@ let tries = 0;
 let ready = false;
 do {
   try {
-    await fetch(VITE_URL);
+    const response = await fetch(getReadyUrl());
+    if (!response.ok)
+      throw new Error(\`HTTP \${response.status}\`);
     ready = true;
   } catch {
     const timeout = Math.min(100 * Math.pow(2, ++tries), 5e3);
-    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_URL}\`);
+    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_PAGE_URL}\`);
     console.log(\`[CRXJS] Retrying in \${timeout}ms...\`);
     await new Promise((resolve) => setTimeout(resolve, timeout));
   }
 } while (!ready);
+console.log(\`[CRXJS] Vite Dev Server is ready on \${VITE_PAGE_URL}\`);
+console.log(\`[CRXJS] Reloading in \${RELOAD_DELAY}ms...\`);
+await new Promise((resolve) => setTimeout(resolve, RELOAD_DELAY));
 location.reload();
 "
 `;

--- a/packages/vite-plugin/tests/out/with-circular-deps/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-circular-deps/__snapshots__/serve.test.ts.snap
@@ -66,6 +66,15 @@ Set {
 
 exports[`serve fs output > assets/loading-page.hash0.js 1`] = `
 "const VITE_URL = \\"http://localhost:3000\\";
+const READY_PATH = \\"/@crx/dev-ready\\";
+const VITE_PAGE_URL = new URL(location.pathname + location.search, VITE_URL).href;
+const RELOAD_DELAY = 100;
+function getReadyUrl() {
+  const url = new URL(READY_PATH, VITE_URL);
+  url.searchParams.set(\\"path\\", location.pathname + location.search);
+  url.searchParams.set(\\"t\\", Date.now().toString());
+  return url.href;
+}
 document.body.innerHTML = /* html */
 \`
 <style>
@@ -284,7 +293,7 @@ document.body.innerHTML = /* html */
 
   <div class=\\"content\\">
     <p>
-      Cannot connect to <a href=\\"\${VITE_URL}\\">\${VITE_URL}</a>.
+      Cannot connect to <a href=\\"\${VITE_PAGE_URL}\\">\${VITE_PAGE_URL}</a>.
       Make sure Vite is running, then reload the extension.
     </p>
     <p>This page will close automatically after the extension reloads.</p>
@@ -305,15 +314,20 @@ let tries = 0;
 let ready = false;
 do {
   try {
-    await fetch(VITE_URL);
+    const response = await fetch(getReadyUrl());
+    if (!response.ok)
+      throw new Error(\`HTTP \${response.status}\`);
     ready = true;
   } catch {
     const timeout = Math.min(100 * Math.pow(2, ++tries), 5e3);
-    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_URL}\`);
+    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_PAGE_URL}\`);
     console.log(\`[CRXJS] Retrying in \${timeout}ms...\`);
     await new Promise((resolve) => setTimeout(resolve, timeout));
   }
 } while (!ready);
+console.log(\`[CRXJS] Vite Dev Server is ready on \${VITE_PAGE_URL}\`);
+console.log(\`[CRXJS] Reloading in \${RELOAD_DELAY}ms...\`);
+await new Promise((resolve) => setTimeout(resolve, RELOAD_DELAY));
 location.reload();
 "
 `;

--- a/packages/vite-plugin/tests/out/with-https-server/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-https-server/__snapshots__/serve.test.ts.snap
@@ -67,6 +67,15 @@ Set {
 
 exports[`serve fs output > assets/loading-page.hash0.js 1`] = `
 "const VITE_URL = \\"https://localhost:3000\\";
+const READY_PATH = \\"/@crx/dev-ready\\";
+const VITE_PAGE_URL = new URL(location.pathname + location.search, VITE_URL).href;
+const RELOAD_DELAY = 100;
+function getReadyUrl() {
+  const url = new URL(READY_PATH, VITE_URL);
+  url.searchParams.set(\\"path\\", location.pathname + location.search);
+  url.searchParams.set(\\"t\\", Date.now().toString());
+  return url.href;
+}
 document.body.innerHTML = /* html */
 \`
 <style>
@@ -285,7 +294,7 @@ document.body.innerHTML = /* html */
 
   <div class=\\"content\\">
     <p>
-      Cannot connect to <a href=\\"\${VITE_URL}\\">\${VITE_URL}</a>.
+      Cannot connect to <a href=\\"\${VITE_PAGE_URL}\\">\${VITE_PAGE_URL}</a>.
       Make sure Vite is running, then reload the extension.
     </p>
     <p>This page will close automatically after the extension reloads.</p>
@@ -306,15 +315,20 @@ let tries = 0;
 let ready = false;
 do {
   try {
-    await fetch(VITE_URL);
+    const response = await fetch(getReadyUrl());
+    if (!response.ok)
+      throw new Error(\`HTTP \${response.status}\`);
     ready = true;
   } catch {
     const timeout = Math.min(100 * Math.pow(2, ++tries), 5e3);
-    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_URL}\`);
+    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_PAGE_URL}\`);
     console.log(\`[CRXJS] Retrying in \${timeout}ms...\`);
     await new Promise((resolve) => setTimeout(resolve, timeout));
   }
 } while (!ready);
+console.log(\`[CRXJS] Vite Dev Server is ready on \${VITE_PAGE_URL}\`);
+console.log(\`[CRXJS] Reloading in \${RELOAD_DELAY}ms...\`);
+await new Promise((resolve) => setTimeout(resolve, RELOAD_DELAY));
 location.reload();
 "
 `;

--- a/packages/vite-plugin/tests/out/with-manifest-url-fragment/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-manifest-url-fragment/__snapshots__/serve.test.ts.snap
@@ -45,6 +45,15 @@ Set {
 
 exports[`serve fs output > assets/loading-page.hash0.js 1`] = `
 "const VITE_URL = \\"http://localhost:3000\\";
+const READY_PATH = \\"/@crx/dev-ready\\";
+const VITE_PAGE_URL = new URL(location.pathname + location.search, VITE_URL).href;
+const RELOAD_DELAY = 100;
+function getReadyUrl() {
+  const url = new URL(READY_PATH, VITE_URL);
+  url.searchParams.set(\\"path\\", location.pathname + location.search);
+  url.searchParams.set(\\"t\\", Date.now().toString());
+  return url.href;
+}
 document.body.innerHTML = /* html */
 \`
 <style>
@@ -263,7 +272,7 @@ document.body.innerHTML = /* html */
 
   <div class=\\"content\\">
     <p>
-      Cannot connect to <a href=\\"\${VITE_URL}\\">\${VITE_URL}</a>.
+      Cannot connect to <a href=\\"\${VITE_PAGE_URL}\\">\${VITE_PAGE_URL}</a>.
       Make sure Vite is running, then reload the extension.
     </p>
     <p>This page will close automatically after the extension reloads.</p>
@@ -284,15 +293,20 @@ let tries = 0;
 let ready = false;
 do {
   try {
-    await fetch(VITE_URL);
+    const response = await fetch(getReadyUrl());
+    if (!response.ok)
+      throw new Error(\`HTTP \${response.status}\`);
     ready = true;
   } catch {
     const timeout = Math.min(100 * Math.pow(2, ++tries), 5e3);
-    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_URL}\`);
+    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_PAGE_URL}\`);
     console.log(\`[CRXJS] Retrying in \${timeout}ms...\`);
     await new Promise((resolve) => setTimeout(resolve, timeout));
   }
 } while (!ready);
+console.log(\`[CRXJS] Vite Dev Server is ready on \${VITE_PAGE_URL}\`);
+console.log(\`[CRXJS] Reloading in \${RELOAD_DELAY}ms...\`);
+await new Promise((resolve) => setTimeout(resolve, RELOAD_DELAY));
 location.reload();
 "
 `;

--- a/packages/vite-plugin/tests/out/with-manifest-url-query-string/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-manifest-url-query-string/__snapshots__/serve.test.ts.snap
@@ -45,6 +45,15 @@ Set {
 
 exports[`serve fs output > assets/loading-page.hash0.js 1`] = `
 "const VITE_URL = \\"http://localhost:3000\\";
+const READY_PATH = \\"/@crx/dev-ready\\";
+const VITE_PAGE_URL = new URL(location.pathname + location.search, VITE_URL).href;
+const RELOAD_DELAY = 100;
+function getReadyUrl() {
+  const url = new URL(READY_PATH, VITE_URL);
+  url.searchParams.set(\\"path\\", location.pathname + location.search);
+  url.searchParams.set(\\"t\\", Date.now().toString());
+  return url.href;
+}
 document.body.innerHTML = /* html */
 \`
 <style>
@@ -263,7 +272,7 @@ document.body.innerHTML = /* html */
 
   <div class=\\"content\\">
     <p>
-      Cannot connect to <a href=\\"\${VITE_URL}\\">\${VITE_URL}</a>.
+      Cannot connect to <a href=\\"\${VITE_PAGE_URL}\\">\${VITE_PAGE_URL}</a>.
       Make sure Vite is running, then reload the extension.
     </p>
     <p>This page will close automatically after the extension reloads.</p>
@@ -284,15 +293,20 @@ let tries = 0;
 let ready = false;
 do {
   try {
-    await fetch(VITE_URL);
+    const response = await fetch(getReadyUrl());
+    if (!response.ok)
+      throw new Error(\`HTTP \${response.status}\`);
     ready = true;
   } catch {
     const timeout = Math.min(100 * Math.pow(2, ++tries), 5e3);
-    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_URL}\`);
+    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_PAGE_URL}\`);
     console.log(\`[CRXJS] Retrying in \${timeout}ms...\`);
     await new Promise((resolve) => setTimeout(resolve, timeout));
   }
 } while (!ready);
+console.log(\`[CRXJS] Vite Dev Server is ready on \${VITE_PAGE_URL}\`);
+console.log(\`[CRXJS] Reloading in \${RELOAD_DELAY}ms...\`);
+await new Promise((resolve) => setTimeout(resolve, RELOAD_DELAY));
 location.reload();
 "
 `;

--- a/packages/vite-plugin/tests/out/with-public-dir/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-public-dir/__snapshots__/serve.test.ts.snap
@@ -66,6 +66,15 @@ Set {
 
 exports[`serve fs output > assets/loading-page.hash0.js 1`] = `
 "const VITE_URL = \\"http://localhost:3000\\";
+const READY_PATH = \\"/@crx/dev-ready\\";
+const VITE_PAGE_URL = new URL(location.pathname + location.search, VITE_URL).href;
+const RELOAD_DELAY = 100;
+function getReadyUrl() {
+  const url = new URL(READY_PATH, VITE_URL);
+  url.searchParams.set(\\"path\\", location.pathname + location.search);
+  url.searchParams.set(\\"t\\", Date.now().toString());
+  return url.href;
+}
 document.body.innerHTML = /* html */
 \`
 <style>
@@ -284,7 +293,7 @@ document.body.innerHTML = /* html */
 
   <div class=\\"content\\">
     <p>
-      Cannot connect to <a href=\\"\${VITE_URL}\\">\${VITE_URL}</a>.
+      Cannot connect to <a href=\\"\${VITE_PAGE_URL}\\">\${VITE_PAGE_URL}</a>.
       Make sure Vite is running, then reload the extension.
     </p>
     <p>This page will close automatically after the extension reloads.</p>
@@ -305,15 +314,20 @@ let tries = 0;
 let ready = false;
 do {
   try {
-    await fetch(VITE_URL);
+    const response = await fetch(getReadyUrl());
+    if (!response.ok)
+      throw new Error(\`HTTP \${response.status}\`);
     ready = true;
   } catch {
     const timeout = Math.min(100 * Math.pow(2, ++tries), 5e3);
-    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_URL}\`);
+    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_PAGE_URL}\`);
     console.log(\`[CRXJS] Retrying in \${timeout}ms...\`);
     await new Promise((resolve) => setTimeout(resolve, timeout));
   }
 } while (!ready);
+console.log(\`[CRXJS] Vite Dev Server is ready on \${VITE_PAGE_URL}\`);
+console.log(\`[CRXJS] Reloading in \${RELOAD_DELAY}ms...\`);
+await new Promise((resolve) => setTimeout(resolve, RELOAD_DELAY));
 location.reload();
 "
 `;

--- a/packages/vite-plugin/tests/out/with-sourcemaps-inline/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-sourcemaps-inline/__snapshots__/serve.test.ts.snap
@@ -64,6 +64,15 @@ Set {
 
 exports[`serve fs output > assets/loading-page.hash0.js 1`] = `
 "const VITE_URL = \\"http://localhost:3000\\";
+const READY_PATH = \\"/@crx/dev-ready\\";
+const VITE_PAGE_URL = new URL(location.pathname + location.search, VITE_URL).href;
+const RELOAD_DELAY = 100;
+function getReadyUrl() {
+  const url = new URL(READY_PATH, VITE_URL);
+  url.searchParams.set(\\"path\\", location.pathname + location.search);
+  url.searchParams.set(\\"t\\", Date.now().toString());
+  return url.href;
+}
 document.body.innerHTML = /* html */
 \`
 <style>
@@ -282,7 +291,7 @@ document.body.innerHTML = /* html */
 
   <div class=\\"content\\">
     <p>
-      Cannot connect to <a href=\\"\${VITE_URL}\\">\${VITE_URL}</a>.
+      Cannot connect to <a href=\\"\${VITE_PAGE_URL}\\">\${VITE_PAGE_URL}</a>.
       Make sure Vite is running, then reload the extension.
     </p>
     <p>This page will close automatically after the extension reloads.</p>
@@ -303,15 +312,20 @@ let tries = 0;
 let ready = false;
 do {
   try {
-    await fetch(VITE_URL);
+    const response = await fetch(getReadyUrl());
+    if (!response.ok)
+      throw new Error(\`HTTP \${response.status}\`);
     ready = true;
   } catch {
     const timeout = Math.min(100 * Math.pow(2, ++tries), 5e3);
-    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_URL}\`);
+    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_PAGE_URL}\`);
     console.log(\`[CRXJS] Retrying in \${timeout}ms...\`);
     await new Promise((resolve) => setTimeout(resolve, timeout));
   }
 } while (!ready);
+console.log(\`[CRXJS] Vite Dev Server is ready on \${VITE_PAGE_URL}\`);
+console.log(\`[CRXJS] Reloading in \${RELOAD_DELAY}ms...\`);
+await new Promise((resolve) => setTimeout(resolve, RELOAD_DELAY));
 location.reload();
 "
 `;

--- a/packages/vite-plugin/tests/out/with-sourcemaps-separate/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/with-sourcemaps-separate/__snapshots__/serve.test.ts.snap
@@ -64,6 +64,15 @@ Set {
 
 exports[`serve fs output > assets/loading-page.hash0.js 1`] = `
 "const VITE_URL = \\"http://localhost:3000\\";
+const READY_PATH = \\"/@crx/dev-ready\\";
+const VITE_PAGE_URL = new URL(location.pathname + location.search, VITE_URL).href;
+const RELOAD_DELAY = 100;
+function getReadyUrl() {
+  const url = new URL(READY_PATH, VITE_URL);
+  url.searchParams.set(\\"path\\", location.pathname + location.search);
+  url.searchParams.set(\\"t\\", Date.now().toString());
+  return url.href;
+}
 document.body.innerHTML = /* html */
 \`
 <style>
@@ -282,7 +291,7 @@ document.body.innerHTML = /* html */
 
   <div class=\\"content\\">
     <p>
-      Cannot connect to <a href=\\"\${VITE_URL}\\">\${VITE_URL}</a>.
+      Cannot connect to <a href=\\"\${VITE_PAGE_URL}\\">\${VITE_PAGE_URL}</a>.
       Make sure Vite is running, then reload the extension.
     </p>
     <p>This page will close automatically after the extension reloads.</p>
@@ -303,15 +312,20 @@ let tries = 0;
 let ready = false;
 do {
   try {
-    await fetch(VITE_URL);
+    const response = await fetch(getReadyUrl());
+    if (!response.ok)
+      throw new Error(\`HTTP \${response.status}\`);
     ready = true;
   } catch {
     const timeout = Math.min(100 * Math.pow(2, ++tries), 5e3);
-    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_URL}\`);
+    console.log(\`[CRXJS] Vite Dev Server is not available on \${VITE_PAGE_URL}\`);
     console.log(\`[CRXJS] Retrying in \${timeout}ms...\`);
     await new Promise((resolve) => setTimeout(resolve, timeout));
   }
 } while (!ready);
+console.log(\`[CRXJS] Vite Dev Server is ready on \${VITE_PAGE_URL}\`);
+console.log(\`[CRXJS] Reloading in \${RELOAD_DELAY}ms...\`);
+await new Promise((resolve) => setTimeout(resolve, RELOAD_DELAY));
 location.reload();
 "
 `;


### PR DESCRIPTION
## Summary

Fixes #900.

- make the dev-mode loading page wait for the requested extension HTML path instead of probing the dev server root
- add a CRX-specific dev readiness endpoint that returns ready only for manifest HTML files that exist in the current project
- add a small 100ms delay before automatic loading-page reloads so a false-positive readiness signal cannot tight-loop reloads
- add an output regression fixture covering popup URLs with query strings, missing paths, and emitted loader behavior

## Root Cause

The dev loading page treated any successful request to the Vite dev server root as readiness. When Vite served fallback HTML or the requested extension page was not actually available yet, the loading page could immediately reload back into itself and flicker repeatedly.

## Validation

- `pnpm --dir packages/vite-plugin exec vitest --run --mode out`
- `pnpm --dir packages/vite-plugin exec vitest --run --mode e2e tests/e2e/mv3-vite-react-page-hmr/vite-serve.test.ts`
- `pnpm --dir packages/vite-plugin run lint:types`
- `pnpm --dir packages/vite-plugin run lint:eslint` (passes with the existing `no-explicit-any` warning in `plugin-manifest.ts`)
