### PR TITLE
feat: add MAIN world content script HMR

### DIFF
--- a/.changeset/main-world-hmr.md
+++ b/.changeset/main-world-hmr.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": minor
+---
+
+Add dev HMR support for manifest-declared MAIN world content scripts.

--- a/packages/vite-plugin/src/client/es/hmr-client-worker.ts
+++ b/packages/vite-plugin/src/client/es/hmr-client-worker.ts
@@ -17,6 +17,9 @@ declare const __HMR_TIMEOUT__: number
 declare const __SERVER_PROTO__: string
 declare const __SERVER_PORT__: string
 declare const __LIVE_RELOAD__: boolean
+declare const __CRX_HMR_TOKEN__: string
+
+const crxClientPortName = `@crx/client:${__CRX_HMR_TOKEN__}`
 
 /* -------- REDIRECT FETCH TO THE DEV SERVER ------- */
 
@@ -71,8 +74,15 @@ async function sendToServer(req: Request): Promise<Response> {
 
 const ports = new Set<chrome.runtime.Port>()
 
-chrome.runtime.onConnect.addListener((port) => {
-  if (port.name === '@crx/client') {
+function isExternalSenderAllowed(port: chrome.runtime.Port) {
+  return !port.sender?.id || port.sender.id === chrome.runtime.id
+}
+
+function handlePort(port: chrome.runtime.Port, { external = false } = {}) {
+  if (
+    port.name === crxClientPortName &&
+    (!external || isExternalSenderAllowed(port))
+  ) {
     ports.add(port)
     port.onDisconnect.addListener((port) => {
       if (chrome.runtime.lastError) {
@@ -87,7 +97,12 @@ chrome.runtime.onConnect.addListener((port) => {
     })
     port.postMessage({ data: JSON.stringify({ type: 'connected' }) })
   }
-})
+}
+
+chrome.runtime.onConnect.addListener(handlePort)
+chrome.runtime.onConnectExternal.addListener((port) =>
+  handlePort(port, { external: true }),
+)
 
 function notifyContentScripts(payload: HMRPayload) {
   const data = JSON.stringify(payload)

--- a/packages/vite-plugin/src/client/es/hmr-content-port.ts
+++ b/packages/vite-plugin/src/client/es/hmr-content-port.ts
@@ -5,9 +5,31 @@ import type { HMRPayload } from 'vite'
 
 declare const __CRX_HMR_TIMEOUT__: number
 declare const __CRX_LIVE_RELOAD__: boolean
+declare const __CRX_HMR_TOKEN__: string
+
+const crxClientPortName = `@crx/client:${__CRX_HMR_TOKEN__}`
 
 function isCrxHMRPayload(x: HMRPayload): x is CrxHMRPayload {
   return x.type === 'custom' && x.event.startsWith('crx:')
+}
+
+function getRuntime() {
+  return typeof chrome === 'undefined' ? undefined : chrome.runtime
+}
+
+function getExtensionId() {
+  return new URL(import.meta.url).host
+}
+
+function hasOwnExtensionRuntime(
+  runtime: typeof chrome.runtime,
+  extensionId: string,
+) {
+  try {
+    return new URL(runtime.getURL('')).host === extensionId
+  } catch {
+    return false
+  }
 }
 
 export class HMRPort {
@@ -39,8 +61,16 @@ export class HMRPort {
   }
 
   initPort = () => {
+    const runtime = getRuntime()
+    if (!runtime) throw new Error('[crx] chrome.runtime is not available')
+
+    const extensionId = getExtensionId()
+    const connectInfo = { name: crxClientPortName }
+
     this.port?.disconnect()
-    this.port = chrome.runtime.connect({ name: '@crx/client' })
+    this.port = hasOwnExtensionRuntime(runtime, extensionId)
+      ? runtime.connect(connectInfo)
+      : runtime.connect(extensionId, connectInfo)
     this.port.onDisconnect.addListener(this.handleDisconnect.bind(this))
     this.port.onMessage.addListener(this.handleMessage.bind(this))
     this.port.postMessage({ type: 'connected' })

--- a/packages/vite-plugin/src/client/es/hmr-content-port.ts
+++ b/packages/vite-plugin/src/client/es/hmr-content-port.ts
@@ -9,18 +9,6 @@ declare const __CRX_HMR_TOKEN__: string
 
 const crxClientPortName = `@crx/client:${__CRX_HMR_TOKEN__}`
 
-function isCrxHMRPayload(x: HMRPayload): x is CrxHMRPayload {
-  return x.type === 'custom' && x.event.startsWith('crx:')
-}
-
-function getRuntime() {
-  return typeof chrome === 'undefined' ? undefined : chrome.runtime
-}
-
-function getExtensionId() {
-  return new URL(import.meta.url).host
-}
-
 function hasOwnExtensionRuntime(
   runtime: typeof chrome.runtime,
   extensionId: string,
@@ -30,6 +18,16 @@ function hasOwnExtensionRuntime(
   } catch {
     return false
   }
+}
+
+const runtime = typeof chrome === 'undefined' ? undefined : chrome.runtime
+const extensionId = new URL(import.meta.url).host
+const connectsToOwnRuntime = runtime
+  ? hasOwnExtensionRuntime(runtime, extensionId)
+  : false
+
+function isCrxHMRPayload(x: HMRPayload): x is CrxHMRPayload {
+  return x.type === 'custom' && x.event.startsWith('crx:')
 }
 
 export class HMRPort {
@@ -61,14 +59,12 @@ export class HMRPort {
   }
 
   initPort = () => {
-    const runtime = getRuntime()
     if (!runtime) throw new Error('[crx] chrome.runtime is not available')
 
-    const extensionId = getExtensionId()
     const connectInfo = { name: crxClientPortName }
 
     this.port?.disconnect()
-    this.port = hasOwnExtensionRuntime(runtime, extensionId)
+    this.port = connectsToOwnRuntime
       ? runtime.connect(connectInfo)
       : runtime.connect(extensionId, connectInfo)
     this.port.onDisconnect.addListener(this.handleDisconnect.bind(this))

--- a/packages/vite-plugin/src/client/iife/content-dev-main-loader.ts
+++ b/packages/vite-plugin/src/client/iife/content-dev-main-loader.ts
@@ -1,10 +1,22 @@
 declare const __SCRIPT__: string
+declare const __PREAMBLE__: string
+declare const __CLIENT__: string
 const injectTime = performance.now()
 ;(async () => {
-  console.warn(__SCRIPT__, 'Content-script doesn\'t support HMR because the world is MAIN');
-  const { onExecute } = await import(/* @vite-ignore */ __SCRIPT__) as ContentScriptAPI.ModuleExports
+  try {
+    if (__PREAMBLE__) await import(/* @vite-ignore */ __PREAMBLE__)
+    await import(/* @vite-ignore */ __CLIENT__)
+  } catch (error) {
+    console.warn('[crx] MAIN world HMR client failed to load', error)
+  }
+
+  const { onExecute } = (await import(
+    /* @vite-ignore */ __SCRIPT__
+  )) as ContentScriptAPI.ModuleExports
   // this is the entry point of the content script, it will run each time this script is injected
-  onExecute?.({ perf: { injectTime, loadTime: performance.now() - injectTime } })
+  onExecute?.({
+    perf: { injectTime, loadTime: performance.now() - injectTime },
+  })
 })().catch(console.error)
 
 export {}

--- a/packages/vite-plugin/src/node/contentScripts.ts
+++ b/packages/vite-plugin/src/node/contentScripts.ts
@@ -92,15 +92,25 @@ export function createProLoader({ fileName }: { fileName: string }): string {
 }
 
 export function createDevMainLoader({
+  preamble,
+  client,
   fileName,
 }: {
+  preamble: string
+  client: string
   fileName: string
 }): string {
   return contentDevMainLoader
+    .replace(/__PREAMBLE__/g, JSON.stringify(preamble))
+    .replace(/__CLIENT__/g, JSON.stringify(client))
     .replace(/__SCRIPT__/g, JSON.stringify(fileName))
     .replace(/__TIMESTAMP__/g, JSON.stringify(Date.now()))
 }
 
-export function createProMainLoader({ fileName }: { fileName: string }): string {
+export function createProMainLoader({
+  fileName,
+}: {
+  fileName: string
+}): string {
   return contentProMainLoader.replace(/__SCRIPT__/g, JSON.stringify(fileName))
 }

--- a/packages/vite-plugin/src/node/hmrToken.ts
+++ b/packages/vite-plugin/src/node/hmrToken.ts
@@ -1,0 +1,16 @@
+import { randomBytes } from 'crypto'
+import type { ResolvedConfigWithHMRToken } from './types'
+
+const crxHmrTokens = new WeakMap<ResolvedConfigWithHMRToken, string>()
+
+export function getCrxHmrToken(config: ResolvedConfigWithHMRToken) {
+  if (config.webSocketToken) return config.webSocketToken
+
+  let token = crxHmrTokens.get(config)
+  if (!token) {
+    token = randomBytes(16).toString('hex')
+    crxHmrTokens.set(config, token)
+  }
+
+  return token
+}

--- a/packages/vite-plugin/src/node/plugin-background.ts
+++ b/packages/vite-plugin/src/node/plugin-background.ts
@@ -2,9 +2,10 @@ import workerHmrClient from 'client/es/hmr-client-worker.ts'
 import type { ResolvedConfig } from 'vite'
 import { defineClientValues } from './defineClientValues'
 import { getFileName } from './fileWriter-utilities'
+import { getCrxHmrToken } from './hmrToken'
 import { ChromeManifestBackground, FirefoxManifestBackground } from './manifest'
 import { getOptions } from './plugin-optionsProvider'
-import type { Browser, CrxPluginFn } from './types'
+import type { Browser, CrxPluginFn, ResolvedConfigWithHMRToken } from './types'
 import { workerClientId } from './virtualFileIds'
 
 /**
@@ -41,7 +42,13 @@ export const pluginBackground: CrxPluginFn = () => {
           return defineClientValues(
             workerHmrClient
               .replace('__BASE__', JSON.stringify(base))
-              .replace('__LIVE_RELOAD__', JSON.stringify(liveReload)),
+              .replace('__LIVE_RELOAD__', JSON.stringify(liveReload))
+              .replace(
+                '__CRX_HMR_TOKEN__',
+                JSON.stringify(
+                  getCrxHmrToken(config as ResolvedConfigWithHMRToken),
+                ),
+              ),
             config,
           )
         }

--- a/packages/vite-plugin/src/node/plugin-contentScripts.ts
+++ b/packages/vite-plugin/src/node/plugin-contentScripts.ts
@@ -11,12 +11,49 @@ import {
 } from './contentScripts'
 import { add } from './fileWriter'
 import { formatFileData, getFileName, prefix } from './fileWriter-utilities'
+import { getCrxHmrToken } from './hmrToken'
 import { getOptions } from './plugin-optionsProvider'
-import { basename } from './path'
+import { basename, dirname, relative } from './path'
 import { RxMap } from './RxMap'
-import { CrxPluginFn } from './types'
+import { CrxPluginFn, ResolvedConfigWithHMRToken } from './types'
 import { contentHmrPortId, preambleId, viteClientId } from './virtualFileIds'
 import colors from 'picocolors'
+
+function asRelativeImport(fromFileName: string, toFileName: string) {
+  const path = relative(dirname(fromFileName), toFileName)
+  return path.startsWith('.') ? path : `./${path}`
+}
+
+function getExternallyConnectableMatch(match: string) {
+  if (match === '<all_urls>') return null
+
+  const parsed = /^(\*|https?):\/\/([^/]+)\/.*$/.exec(match)
+  if (!parsed) return null
+
+  const [, , host] = parsed
+  if (host === '*') return null
+
+  return match
+}
+
+function getExternallyConnectableMatches(matches: string[]) {
+  const result = new Set<string>()
+  const unsupported = new Set<string>()
+
+  for (const match of matches) {
+    const externallyConnectableMatch = getExternallyConnectableMatch(match)
+    if (externallyConnectableMatch) {
+      result.add(externallyConnectableMatch)
+    } else {
+      unsupported.add(match)
+    }
+  }
+
+  return {
+    matches: [...result],
+    unsupported: [...unsupported],
+  }
+}
 
 /**
  * Emits content scripts and loaders.
@@ -40,6 +77,8 @@ export const pluginContentScripts: CrxPluginFn = () => {
   let sub = new Subscription()
 
   const worldMainIds = new Set<string>()
+  const worldMainExternallyConnectableMatches = new Set<string>()
+  const unsupportedWorldMainExternallyConnectableMatches = new Set<string>()
 
   const findWorldMainIds = async (config: UserConfig, env: ConfigEnv) => {
     const { manifest: _manifest } = await getOptions(config)
@@ -53,17 +92,33 @@ export const pluginContentScripts: CrxPluginFn = () => {
         js.forEach((path) => worldMainIds.add(prefix('/', path)))
       }
     })
+    ;(manifest.content_scripts || []).forEach(({ world, matches = [] }) => {
+      if (world === 'MAIN') {
+        const externallyConnectable = getExternallyConnectableMatches(matches)
+        externallyConnectable.matches.forEach((match) =>
+          worldMainExternallyConnectableMatches.add(match),
+        )
+        externallyConnectable.unsupported.forEach((match) =>
+          unsupportedWorldMainExternallyConnectableMatches.add(match),
+        )
+      }
+    })
+  }
 
-    if (worldMainIds.size) {
-      const name = `[${pluginName}]`
-      const message = colors.yellow(
-        [
-          `${name} Some content-scripts don't support HMR because the world is MAIN:`,
-          ...[...worldMainIds].map((id) => `  ${id}`),
-        ].join('\r\n'),
-      )
-      console.log(message)
-    }
+  const warnUnsupportedWorldMainExternallyConnectableMatches = () => {
+    if (unsupportedWorldMainExternallyConnectableMatches.size === 0) return
+
+    const name = `[${pluginName}]`
+    const message = colors.yellow(
+      [
+        `${name} MAIN world HMR requires externally_connectable.matches. CRX cannot auto-add these Chrome-rejected content-script match patterns:`,
+        ...[...unsupportedWorldMainExternallyConnectableMatches].map(
+          (match) => `  ${match}`,
+        ),
+        'Add explicit http(s) host addresses to your content script matches during development if you want MAIN world HMR for those pages.',
+      ].join('\r\n'),
+    )
+    console.warn(message)
   }
 
   return [
@@ -72,6 +127,7 @@ export const pluginContentScripts: CrxPluginFn = () => {
       apply: 'serve',
       async config(config, env) {
         await findWorldMainIds(config, env)
+        warnUnsupportedWorldMainExternallyConnectableMatches()
         const opts = await getOptions(config)
         const { contentScripts = {} } = opts
         hmrTimeout = contentScripts.hmrTimeout ?? 5000
@@ -111,12 +167,23 @@ export const pluginContentScripts: CrxPluginFn = () => {
                 const client = add({ type: 'module', id: viteClientId })
 
                 const file = add({ type: 'module', id })
+                const loaderFileName = getFileName({ type: 'loader', id })
                 const loader = add({
                   type: 'asset',
-                  id: getFileName({ type: 'loader', id }),
+                  id: loaderFileName,
                   source: worldMainIds.has(file.id)
                     ? createDevMainLoader({
-                        fileName: `./${file.fileName.split('/').at(-1)}`,
+                        preamble: preamble.fileName
+                          ? asRelativeImport(loaderFileName, preamble.fileName)
+                          : '',
+                        client: asRelativeImport(
+                          loaderFileName,
+                          client.fileName,
+                        ),
+                        fileName: asRelativeImport(
+                          loaderFileName,
+                          file.fileName,
+                        ),
                       })
                     : createDevLoader({
                         preamble: preamble.fileName,
@@ -149,12 +216,31 @@ export const pluginContentScripts: CrxPluginFn = () => {
           const defined = contentHmrPort
             .replace('__CRX_HMR_TIMEOUT__', JSON.stringify(hmrTimeout))
             .replace('__CRX_LIVE_RELOAD__', JSON.stringify(liveReload))
+            .replace(
+              '__CRX_HMR_TOKEN__',
+              JSON.stringify(
+                getCrxHmrToken(server.config as ResolvedConfigWithHMRToken),
+              ),
+            )
           return defined
         }
       },
       closeBundle() {
         sub.unsubscribe()
         sub = new Subscription() // can't reuse subscriptions
+      },
+      transformCrxManifest(manifest) {
+        if (worldMainExternallyConnectableMatches.size === 0) return null
+
+        manifest.externally_connectable = manifest.externally_connectable ?? {}
+        manifest.externally_connectable.matches = [
+          ...new Set([
+            ...(manifest.externally_connectable.matches ?? []),
+            ...worldMainExternallyConnectableMatches,
+          ]),
+        ]
+
+        return manifest
       },
     },
     {

--- a/packages/vite-plugin/tests/e2e/mv3-main-world-content-script-hmr/manifest.json
+++ b/packages/vite-plugin/tests/e2e/mv3-main-world-content-script-hmr/manifest.json
@@ -1,0 +1,13 @@
+{
+  "description": "test MAIN world content script HMR",
+  "manifest_version": 3,
+  "name": "MAIN World Content Script HMR Test",
+  "content_scripts": [
+    {
+      "matches": ["https://example.com/*"],
+      "js": ["src/content.ts"],
+      "world": "MAIN"
+    }
+  ],
+  "version": "1.0.0"
+}

--- a/packages/vite-plugin/tests/e2e/mv3-main-world-content-script-hmr/src1/content.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-main-world-content-script-hmr/src1/content.ts
@@ -1,6 +1,10 @@
+// @ts-expect-error virtual module provided by CRX during dev serve
+import { HMRPort } from '/@crx/client-port'
+
 declare global {
   interface Window {
     crxMainWorldHmrMessage?: string
+    crxMainWorldReconnectAfterChromeMutation?: () => boolean
   }
 }
 
@@ -19,6 +23,17 @@ function render(value: string) {
 }
 
 render(message)
+
+window.crxMainWorldReconnectAfterChromeMutation = () => {
+  const hmrPort = new HMRPort()
+  try {
+    hmrPort.initPort()
+    hmrPort.send(JSON.stringify({ type: 'connected' }))
+    return true
+  } finally {
+    ;(hmrPort as unknown as { port?: chrome.runtime.Port }).port?.disconnect()
+  }
+}
 
 if (import.meta.hot) {
   import.meta.hot.accept((mod) => {

--- a/packages/vite-plugin/tests/e2e/mv3-main-world-content-script-hmr/src1/content.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-main-world-content-script-hmr/src1/content.ts
@@ -1,0 +1,27 @@
+declare global {
+  interface Window {
+    crxMainWorldHmrMessage?: string
+  }
+}
+
+export const message = 'MAIN world HMR before update'
+
+const root =
+  document.querySelector<HTMLDivElement>('#crx-main-world-hmr') ??
+  document.createElement('div')
+
+root.id = 'crx-main-world-hmr'
+if (!root.parentElement) document.body.append(root)
+
+function render(value: string) {
+  window.crxMainWorldHmrMessage = value
+  root.textContent = value
+}
+
+render(message)
+
+if (import.meta.hot) {
+  import.meta.hot.accept((mod) => {
+    if (mod) render(mod.message)
+  })
+}

--- a/packages/vite-plugin/tests/e2e/mv3-main-world-content-script-hmr/src2/content.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-main-world-content-script-hmr/src2/content.ts
@@ -1,6 +1,10 @@
+// @ts-expect-error virtual module provided by CRX during dev serve
+import { HMRPort } from '/@crx/client-port'
+
 declare global {
   interface Window {
     crxMainWorldHmrMessage?: string
+    crxMainWorldReconnectAfterChromeMutation?: () => boolean
   }
 }
 
@@ -19,6 +23,17 @@ function render(value: string) {
 }
 
 render(message)
+
+window.crxMainWorldReconnectAfterChromeMutation = () => {
+  const hmrPort = new HMRPort()
+  try {
+    hmrPort.initPort()
+    hmrPort.send(JSON.stringify({ type: 'connected' }))
+    return true
+  } finally {
+    ;(hmrPort as unknown as { port?: chrome.runtime.Port }).port?.disconnect()
+  }
+}
 
 if (import.meta.hot) {
   import.meta.hot.accept((mod) => {

--- a/packages/vite-plugin/tests/e2e/mv3-main-world-content-script-hmr/src2/content.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-main-world-content-script-hmr/src2/content.ts
@@ -1,0 +1,27 @@
+declare global {
+  interface Window {
+    crxMainWorldHmrMessage?: string
+  }
+}
+
+export const message = 'MAIN world HMR after update'
+
+const root =
+  document.querySelector<HTMLDivElement>('#crx-main-world-hmr') ??
+  document.createElement('div')
+
+root.id = 'crx-main-world-hmr'
+if (!root.parentElement) document.body.append(root)
+
+function render(value: string) {
+  window.crxMainWorldHmrMessage = value
+  root.textContent = value
+}
+
+render(message)
+
+if (import.meta.hot) {
+  import.meta.hot.accept((mod) => {
+    if (mod) render(mod.message)
+  })
+}

--- a/packages/vite-plugin/tests/e2e/mv3-main-world-content-script-hmr/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-main-world-content-script-hmr/vite-serve.test.ts
@@ -1,0 +1,56 @@
+import fs from 'fs-extra'
+import path from 'pathe'
+import { expect, test } from 'vitest'
+import { createUpdate } from '../helpers'
+import { serve } from '../runners'
+
+async function waitForMainWorldMessage(
+  page: {
+    evaluate: <T>(fn: () => T) => Promise<T>
+  },
+  expected: string,
+) {
+  const deadline = Date.now() + 15_000
+  while (Date.now() < deadline) {
+    const actual = await page.evaluate(() => window.crxMainWorldHmrMessage)
+    if (actual === expected) return
+    await new Promise((r) => setTimeout(r, 100))
+  }
+
+  throw new Error(`Timed out waiting for MAIN world message "${expected}"`)
+}
+
+test(
+  'MAIN world content script updates through HMR without reloading the page',
+  async () => {
+    const src = path.join(__dirname, 'src')
+    const src1 = path.join(__dirname, 'src1')
+    const src2 = path.join(__dirname, 'src2')
+
+    await fs.remove(src)
+    await fs.copy(src1, src, { recursive: true })
+
+    const { browser, routes } = await serve(__dirname)
+    const page = await browser.newPage()
+    const update = createUpdate({ target: src, src: src2 })
+
+    await page.goto('https://example.com')
+
+    const marker = page.locator('#crx-main-world-hmr')
+    await marker.waitFor({ timeout: 15_000 })
+    expect(await marker.textContent()).toBe('MAIN world HMR before update')
+    await waitForMainWorldMessage(page, 'MAIN world HMR before update')
+
+    let reloads = 0
+    routes.subscribe(() => {
+      reloads++
+    })
+
+    await update('content.ts')
+
+    await waitForMainWorldMessage(page, 'MAIN world HMR after update')
+    expect(await marker.textContent()).toBe('MAIN world HMR after update')
+    expect(reloads).toBe(0)
+  },
+  { retry: process.env.CI ? 5 : 2 },
+)

--- a/packages/vite-plugin/tests/e2e/mv3-main-world-content-script-hmr/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-main-world-content-script-hmr/vite-serve.test.ts
@@ -4,6 +4,16 @@ import { expect, test } from 'vitest'
 import { createUpdate } from '../helpers'
 import { serve } from '../runners'
 
+async function copyInitialFixture() {
+  const src = path.join(__dirname, 'src')
+  const src1 = path.join(__dirname, 'src1')
+
+  await fs.remove(src)
+  await fs.copy(src1, src, { recursive: true })
+
+  return src
+}
+
 async function waitForMainWorldMessage(
   page: {
     evaluate: <T>(fn: () => T) => Promise<T>
@@ -23,12 +33,8 @@ async function waitForMainWorldMessage(
 test(
   'MAIN world content script updates through HMR without reloading the page',
   async () => {
-    const src = path.join(__dirname, 'src')
-    const src1 = path.join(__dirname, 'src1')
+    const src = await copyInitialFixture()
     const src2 = path.join(__dirname, 'src2')
-
-    await fs.remove(src)
-    await fs.copy(src1, src, { recursive: true })
 
     const { browser, routes } = await serve(__dirname)
     const page = await browser.newPage()
@@ -51,6 +57,50 @@ test(
     await waitForMainWorldMessage(page, 'MAIN world HMR after update')
     expect(await marker.textContent()).toBe('MAIN world HMR after update')
     expect(reloads).toBe(0)
+  },
+  { retry: process.env.CI ? 5 : 2 },
+)
+
+test(
+  'MAIN world HMR port connects after host page replaces window.chrome',
+  async () => {
+    await copyInitialFixture()
+
+    const { browser } = await serve(__dirname)
+    const page = await browser.newPage()
+
+    await page.goto('https://example.com')
+
+    const marker = page.locator('#crx-main-world-hmr')
+    await marker.waitFor({ timeout: 15_000 })
+    await waitForMainWorldMessage(page, 'MAIN world HMR before update')
+
+    const reconnected = await page.evaluate(() => {
+      const scope = window as unknown as {
+        chrome: unknown
+        crxMainWorldReconnectAfterChromeMutation?: () => boolean
+      }
+      const originalChrome = scope.chrome
+
+      scope.chrome = {
+        runtime: {
+          connect() {
+            throw new Error('host page chrome.runtime.connect was used')
+          },
+          getURL() {
+            throw new Error('host page chrome.runtime.getURL was used')
+          },
+        },
+      }
+
+      try {
+        return scope.crxMainWorldReconnectAfterChromeMutation?.() === true
+      } finally {
+        scope.chrome = originalChrome
+      }
+    })
+
+    expect(reconnected).toBe(true)
   },
   { retry: process.env.CI ? 5 : 2 },
 )

--- a/packages/vite-plugin/tests/e2e/mv3-main-world-content-script-hmr/vite.config.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-main-world-content-script-hmr/vite.config.ts
@@ -1,0 +1,10 @@
+import { crx } from '../../plugin-testOptionsProvider'
+import { defineConfig } from 'vite'
+import manifest from './manifest.json'
+
+export default defineConfig({
+  build: { minify: false },
+  clearScreen: false,
+  logLevel: 'error',
+  plugins: [crx({ manifest })],
+})

--- a/packages/vite-plugin/tests/e2e/mv3-main-world-react-content-script-hmr/manifest.json
+++ b/packages/vite-plugin/tests/e2e/mv3-main-world-react-content-script-hmr/manifest.json
@@ -1,0 +1,13 @@
+{
+  "description": "test React MAIN world content script HMR",
+  "manifest_version": 3,
+  "name": "React MAIN World Content Script HMR Test",
+  "content_scripts": [
+    {
+      "matches": ["https://example.com/*"],
+      "js": ["src/main.jsx"],
+      "world": "MAIN"
+    }
+  ],
+  "version": "1.0.0"
+}

--- a/packages/vite-plugin/tests/e2e/mv3-main-world-react-content-script-hmr/src1/App.jsx
+++ b/packages/vite-plugin/tests/e2e/mv3-main-world-react-content-script-hmr/src1/App.jsx
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react'
+
+const message = 'React MAIN world HMR before update'
+
+function App() {
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    window.crxReactMainWorldHmrMessage = message
+  })
+
+  return (
+    <section id='crx-react-main-world-hmr'>
+      <p>{message}</p>
+      <button type='button' onClick={() => setCount((value) => value + 1)}>
+        count is: {count}
+      </button>
+    </section>
+  )
+}
+
+export default App

--- a/packages/vite-plugin/tests/e2e/mv3-main-world-react-content-script-hmr/src1/main.jsx
+++ b/packages/vite-plugin/tests/e2e/mv3-main-world-react-content-script-hmr/src1/main.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import App from './App.jsx'
+
+const root =
+  document.querySelector('#crx-react-main-world-hmr-root') ??
+  document.createElement('div')
+
+root.id = 'crx-react-main-world-hmr-root'
+if (!root.parentElement) document.body.append(root)
+
+ReactDOM.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+  root,
+)

--- a/packages/vite-plugin/tests/e2e/mv3-main-world-react-content-script-hmr/src2/App.jsx
+++ b/packages/vite-plugin/tests/e2e/mv3-main-world-react-content-script-hmr/src2/App.jsx
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react'
+
+const message = 'React MAIN world HMR after update'
+
+function App() {
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    window.crxReactMainWorldHmrMessage = message
+  })
+
+  return (
+    <section id='crx-react-main-world-hmr'>
+      <p>{message}</p>
+      <button type='button' onClick={() => setCount((value) => value + 1)}>
+        count is: {count}
+      </button>
+    </section>
+  )
+}
+
+export default App

--- a/packages/vite-plugin/tests/e2e/mv3-main-world-react-content-script-hmr/src2/main.jsx
+++ b/packages/vite-plugin/tests/e2e/mv3-main-world-react-content-script-hmr/src2/main.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import App from './App.jsx'
+
+const root =
+  document.querySelector('#crx-react-main-world-hmr-root') ??
+  document.createElement('div')
+
+root.id = 'crx-react-main-world-hmr-root'
+if (!root.parentElement) document.body.append(root)
+
+ReactDOM.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+  root,
+)

--- a/packages/vite-plugin/tests/e2e/mv3-main-world-react-content-script-hmr/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-main-world-react-content-script-hmr/vite-serve.test.ts
@@ -1,0 +1,83 @@
+import fs from 'fs-extra'
+import path from 'pathe'
+import { expect, test } from 'vitest'
+import { createUpdate } from '../helpers'
+import { serve } from '../runners'
+
+declare global {
+  interface Window {
+    crxReactMainWorldHmrMessage?: string
+  }
+}
+
+async function waitForReactMainWorldMessage(
+  page: {
+    evaluate: <T>(fn: () => T) => Promise<T>
+  },
+  expected: string,
+) {
+  const deadline = Date.now() + 15_000
+  while (Date.now() < deadline) {
+    const actual = await page.evaluate(() => window.crxReactMainWorldHmrMessage)
+    if (actual === expected) return
+    await new Promise((r) => setTimeout(r, 100))
+  }
+
+  throw new Error(
+    `Timed out waiting for React MAIN world message "${expected}"`,
+  )
+}
+
+test(
+  'React MAIN world content script updates through HMR without reloading the page',
+  async () => {
+    const src = path.join(__dirname, 'src')
+    const src1 = path.join(__dirname, 'src1')
+    const src2 = path.join(__dirname, 'src2')
+
+    await fs.remove(src)
+    await fs.copy(src1, src, { recursive: true })
+
+    const { browser, routes } = await serve(__dirname)
+    const page = await browser.newPage()
+    const update = createUpdate({ target: src, src: src2 })
+
+    await page.goto('https://example.com')
+
+    const app = page.locator('#crx-react-main-world-hmr')
+    await app.waitFor({ timeout: 15_000 })
+    await waitForReactMainWorldMessage(
+      page,
+      'React MAIN world HMR before update',
+    )
+
+    const message = app.locator('p')
+    const button = app.locator('button')
+    await button.click()
+    expect(await button.innerText()).toBe('count is: 1')
+
+    let reloads = 0
+    routes.subscribe(() => {
+      reloads++
+    })
+
+    let navigated = false
+    page.on('framenavigated', (frame) => {
+      if (frame === page.mainFrame()) navigated = true
+    })
+
+    await update('App.jsx')
+
+    await waitForReactMainWorldMessage(
+      page,
+      'React MAIN world HMR after update',
+    )
+    expect(await message.textContent()).toBe(
+      'React MAIN world HMR after update',
+    )
+    expect(await button.innerText()).toBe('count is: 1')
+    expect(reloads).toBe(0)
+    expect(navigated).toBe(false)
+  },
+  { retry: process.env.CI ? 5 : 2 },
+)

--- a/packages/vite-plugin/tests/e2e/mv3-main-world-react-content-script-hmr/vite.config.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-main-world-react-content-script-hmr/vite.config.ts
@@ -1,0 +1,13 @@
+import react from '@vitejs/plugin-react'
+import { crx } from '../../plugin-testOptionsProvider'
+import { defineConfig } from 'vite'
+import manifest from './manifest.json'
+
+const { preambleCode } = react
+
+export default defineConfig({
+  build: { minify: false },
+  clearScreen: false,
+  logLevel: 'error',
+  plugins: [crx({ manifest, contentScripts: { preambleCode } }), react()],
+})

--- a/packages/vite-plugin/tests/out/content-script-world-main-all-urls/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/content-script-world-main-all-urls/__snapshots__/serve.test.ts.snap
@@ -12,19 +12,14 @@ Object {
         "src/content.js-loader.js",
       ],
       "matches": Array [
-        "https://example.com/*",
+        "<all_urls>",
       ],
       "world": "MAIN",
     },
   ],
-  "description": "test content script with world MAIN",
-  "externally_connectable": Object {
-    "matches": Array [
-      "https://example.com/*",
-    ],
-  },
+  "description": "test content script with world MAIN and all urls",
   "manifest_version": 3,
-  "name": "Test Content Script World Main",
+  "name": "Test Content Script World Main All URLs",
   "version": "1.0.0",
   "web_accessible_resources": Array [
     Object {
@@ -67,7 +62,7 @@ import 'http://localhost:3000/@crx/client-worker';
 `;
 
 exports[`serve fs output > src/content.js.js 1`] = `
-"console.log('content script running in MAIN world')
+"console.log('content script running in MAIN world on all urls')
 "
 `;
 

--- a/packages/vite-plugin/tests/out/content-script-world-main-all-urls/manifest.json
+++ b/packages/vite-plugin/tests/out/content-script-world-main-all-urls/manifest.json
@@ -1,0 +1,13 @@
+{
+  "content_scripts": [
+    {
+      "js": ["src/content.js"],
+      "matches": ["<all_urls>"],
+      "world": "MAIN"
+    }
+  ],
+  "description": "test content script with world MAIN and all urls",
+  "manifest_version": 3,
+  "name": "Test Content Script World Main All URLs",
+  "version": "1.0.0"
+}

--- a/packages/vite-plugin/tests/out/content-script-world-main-all-urls/serve.test.ts
+++ b/packages/vite-plugin/tests/out/content-script-world-main-all-urls/serve.test.ts
@@ -1,0 +1,8 @@
+import { serve } from 'tests/runners'
+import { testOutput } from 'tests/testOutput'
+import { test } from 'vitest'
+
+test('serve fs output', async () => {
+  const result = await serve(__dirname)
+  await testOutput(result)
+})

--- a/packages/vite-plugin/tests/out/content-script-world-main-all-urls/src/content.js
+++ b/packages/vite-plugin/tests/out/content-script-world-main-all-urls/src/content.js
@@ -1,0 +1,1 @@
+console.log('content script running in MAIN world on all urls')

--- a/packages/vite-plugin/tests/out/content-script-world-main-all-urls/vite.config.ts
+++ b/packages/vite-plugin/tests/out/content-script-world-main-all-urls/vite.config.ts
@@ -1,0 +1,20 @@
+import { crx } from '../../plugin-testOptionsProvider'
+import { defineConfig } from 'vite'
+import manifest from './manifest.json'
+
+export default defineConfig({
+  build: {
+    minify: false,
+    rollupOptions: {
+      output: {
+        // the hash randomly changes between environments
+        assetFileNames: 'assets/[name].hash[hash].[ext]',
+        chunkFileNames: 'assets/[name].hash[hash].js',
+        entryFileNames: 'assets/[name].hash[hash].js',
+      },
+    },
+  },
+  clearScreen: false,
+  logLevel: 'error',
+  plugins: [crx({ manifest })],
+})


### PR DESCRIPTION
## What changed

- Adds dev HMR support for manifest-declared `world: "MAIN"` content scripts by loading the Vite client from the MAIN-world loader.
- Routes MAIN-world HMR through a tokenized `chrome.runtime.connect` port to the extension service worker.
- Adds dev-only `externally_connectable.matches` for valid concrete MAIN-world content-script host matches, without broad `ids: ["*"]` access.
- Warns when Chrome cannot accept a content-script match pattern such as `<all_urls>` for `externally_connectable.matches`.
- Adds an e2e regression test proving MAIN-world content scripts update without page reload.

## Why

Manifest-declared MAIN-world content scripts previously fell back to reload behavior and logged that HMR was unsupported. The extension service worker already proxies Vite HMR, but MAIN-world scripts need an externally-connectable runtime port because they execute in the page context.

Fixes #1159.

## Validation

- `pnpm run lint:types`
- `pnpm run lint:eslint` (passes with the existing `plugin-manifest.ts` warning)
- `pnpm run build`
- `pnpm run test:run:out`
- `pnpm run test:run:compat`
- `pnpm run test:run:e2e`
- Targeted Vite 3 e2e and output tests for MAIN-world HMR and `externally_connectable` behavior


https://github.com/user-attachments/assets/5897d33a-1439-4d7c-9cb0-99b4f6a41209


