### PR TITLE
docs: local vite-plugin testing without publishing

### DIFF
--- a/packages/vite-plugin/CONTRIBUTING.md
+++ b/packages/vite-plugin/CONTRIBUTING.md
@@ -2,7 +2,9 @@
 
 ## Test In Another Project Without Publishing
 
-Use a direct link when you want another extension project to use your local checkout instead of the package from npm.
+Pack the local plugin and install the tarball when you want another extension project to use your local checkout instead of the package from npm.
+
+This is preferred over `pnpm link` because a linked checkout can keep this repository's development dependencies in Node's resolution path. For example, the plugin may import this checkout's local Vite or Rollup version instead of the extension project's Vite peer dependency.
 
 1. Prepare this repository:
 
@@ -20,30 +22,32 @@ pnpm install
 "version": "2.5.0-local.<short-git-sha>"
 ```
 
-3. Build the plugin:
+3. Build and pack the plugin:
 
 ```shell
 pnpm build:vite-plugin
+mkdir -p "$CRXJS_REPO/.tmp"
+cd "$CRXJS_REPO/packages/vite-plugin"
+pnpm pack --out "$CRXJS_REPO/.tmp/crxjs-vite-plugin.tgz"
 ```
 
-4. Link the plugin into the extension project:
+4. Install the packed plugin into the extension project:
 
 ```shell
 export EXTENSION_PROJECT=/path/to/extension-project
 cd "$EXTENSION_PROJECT"
-rm -rf node_modules
-pnpm link "$CRXJS_REPO/packages/vite-plugin"
+npm install --save-dev "$CRXJS_REPO/.tmp/crxjs-vite-plugin.tgz"
 ```
 
-Removing `node_modules` first is useful when the target project was previously installed by a different package manager.
+If the extension project uses pnpm, use `pnpm add -D "$CRXJS_REPO/.tmp/crxjs-vite-plugin.tgz"` instead.
 
-5. Verify that the project resolves the linked package:
+5. Verify that the project resolves the packed package:
 
 ```shell
 node -p "require.resolve('@crxjs/vite-plugin/package.json')"
 ```
 
-The plugin package path should point at `$CRXJS_REPO/packages/vite-plugin`.
+The plugin package path should point inside the extension project's `node_modules`, not at `$CRXJS_REPO/packages/vite-plugin`.
 
 6. Run the extension project's build and dev scripts:
 
@@ -52,16 +56,20 @@ npm run build
 npm run dev
 ```
 
-After CRXJS code changes, rebuild the plugin. The linked project will use the updated `dist` output without reinstalling:
+After CRXJS code changes, rebuild, repack, and reinstall the tarball:
 
 ```shell
 cd "$CRXJS_REPO"
 pnpm build:vite-plugin
+cd "$CRXJS_REPO/packages/vite-plugin"
+pnpm pack --out "$CRXJS_REPO/.tmp/crxjs-vite-plugin.tgz"
+cd "$EXTENSION_PROJECT"
+npm install --save-dev "$CRXJS_REPO/.tmp/crxjs-vite-plugin.tgz"
 ```
 
-To return to the registry package, reinstall from the target project's lockfile:
+To return to the registry package, reinstall the desired registry version:
 
 ```shell
 cd "$EXTENSION_PROJECT"
-npm install
+npm install --save-dev @crxjs/vite-plugin@latest
 ```

--- a/packages/vite-plugin/CONTRIBUTING.md
+++ b/packages/vite-plugin/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing To `@crxjs/vite-plugin`
+
+## Test In Another Project Without Publishing
+
+Use a direct link when you want another extension project to use your local checkout instead of the package from npm.
+
+1. Prepare this repository:
+
+```shell
+export CRXJS_REPO=/path/to/chrome-extension-tools
+cd "$CRXJS_REPO"
+git checkout main
+git pull --ff-only origin main
+pnpm install
+```
+
+2. Optionally mark the local package version so it is obvious when the other project resolves this checkout. For example, edit `packages/vite-plugin/package.json`:
+
+```json
+"version": "2.5.0-local.<short-git-sha>"
+```
+
+3. Build the plugin:
+
+```shell
+pnpm build:vite-plugin
+```
+
+4. Link the plugin into the extension project:
+
+```shell
+export EXTENSION_PROJECT=/path/to/extension-project
+cd "$EXTENSION_PROJECT"
+rm -rf node_modules
+pnpm link "$CRXJS_REPO/packages/vite-plugin"
+```
+
+Removing `node_modules` first is useful when the target project was previously installed by a different package manager.
+
+5. Verify that the project resolves the linked package:
+
+```shell
+node -p "require.resolve('@crxjs/vite-plugin/package.json')"
+```
+
+The plugin package path should point at `$CRXJS_REPO/packages/vite-plugin`.
+
+6. Run the extension project's build and dev scripts:
+
+```shell
+npm run build
+npm run dev
+```
+
+After CRXJS code changes, rebuild the plugin. The linked project will use the updated `dist` output without reinstalling:
+
+```shell
+cd "$CRXJS_REPO"
+pnpm build:vite-plugin
+```
+
+To return to the registry package, reinstall from the target project's lockfile:
+
+```shell
+cd "$EXTENSION_PROJECT"
+npm install
+```

--- a/packages/vite-plugin/CONTRIBUTING.md
+++ b/packages/vite-plugin/CONTRIBUTING.md
@@ -2,9 +2,7 @@
 
 ## Test In Another Project Without Publishing
 
-Pack the local plugin and install the tarball when you want another extension project to use your local checkout instead of the package from npm.
-
-This is preferred over `pnpm link` because a linked checkout can keep this repository's development dependencies in Node's resolution path. For example, the plugin may import this checkout's local Vite or Rollup version instead of the extension project's Vite peer dependency.
+Use a direct link when you want another extension project to use your local checkout instead of the package from npm.
 
 1. Prepare this repository:
 
@@ -22,32 +20,30 @@ pnpm install
 "version": "2.5.0-local.<short-git-sha>"
 ```
 
-3. Build and pack the plugin:
+3. Build the plugin:
 
 ```shell
 pnpm build:vite-plugin
-mkdir -p "$CRXJS_REPO/.tmp"
-cd "$CRXJS_REPO/packages/vite-plugin"
-pnpm pack --out "$CRXJS_REPO/.tmp/crxjs-vite-plugin.tgz"
 ```
 
-4. Install the packed plugin into the extension project:
+4. Link the plugin into the extension project:
 
 ```shell
 export EXTENSION_PROJECT=/path/to/extension-project
 cd "$EXTENSION_PROJECT"
-npm install --save-dev "$CRXJS_REPO/.tmp/crxjs-vite-plugin.tgz"
+rm -rf node_modules
+pnpm link "$CRXJS_REPO/packages/vite-plugin"
 ```
 
-If the extension project uses pnpm, use `pnpm add -D "$CRXJS_REPO/.tmp/crxjs-vite-plugin.tgz"` instead.
+Removing `node_modules` first is useful when the target project was previously installed by a different package manager.
 
-5. Verify that the project resolves the packed package:
+5. Verify that the project resolves the linked package:
 
 ```shell
 node -p "require.resolve('@crxjs/vite-plugin/package.json')"
 ```
 
-The plugin package path should point inside the extension project's `node_modules`, not at `$CRXJS_REPO/packages/vite-plugin`.
+The plugin package path should point at `$CRXJS_REPO/packages/vite-plugin`.
 
 6. Run the extension project's build and dev scripts:
 
@@ -56,20 +52,38 @@ npm run build
 npm run dev
 ```
 
-After CRXJS code changes, rebuild, repack, and reinstall the tarball:
+After CRXJS code changes, rebuild the plugin. The linked project will use the updated `dist` output without reinstalling:
 
 ```shell
 cd "$CRXJS_REPO"
 pnpm build:vite-plugin
+```
+
+<details>
+<summary>Alternative: test with a packed tarball</summary>
+
+If you suspect the linked checkout is changing package resolution, pack the plugin and install the tarball instead. This is closer to the published package shape, but you must repack and reinstall after each CRXJS code change.
+
+```shell
+cd "$CRXJS_REPO"
+pnpm build:vite-plugin
+mkdir -p "$CRXJS_REPO/.tmp"
 cd "$CRXJS_REPO/packages/vite-plugin"
 pnpm pack --out "$CRXJS_REPO/.tmp/crxjs-vite-plugin.tgz"
+
 cd "$EXTENSION_PROJECT"
 npm install --save-dev "$CRXJS_REPO/.tmp/crxjs-vite-plugin.tgz"
 ```
 
-To return to the registry package, reinstall the desired registry version:
+If the extension project uses pnpm, use `pnpm add -D "$CRXJS_REPO/.tmp/crxjs-vite-plugin.tgz"` instead.
+
+After installing the tarball, `node -p "require.resolve('@crxjs/vite-plugin/package.json')"` should point inside the extension project's `node_modules`, not at `$CRXJS_REPO/packages/vite-plugin`.
+
+</details>
+
+To return to the registry package, reinstall from the target project's lockfile:
 
 ```shell
 cd "$EXTENSION_PROJECT"
-npm install --save-dev @crxjs/vite-plugin@latest
+npm install
 ```

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -38,6 +38,10 @@ npm create crxjs@latest
 > [!NOTE]  
 > Looking for MV2 support? See [`rollup-plugin`](packages/rollup-plugin/README.md)  
 
+## 💻 Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for local development workflows.
+
 ## 💝 Contributors
 
 This project exists thanks to all the people who contribute.


### PR DESCRIPTION
## Summary

Adds `packages/vite-plugin/CONTRIBUTING.md` with instructions for testing a local `@crxjs/vite-plugin` checkout in another extension project without publishing to npm.

The primary workflow uses `pnpm link <local vite-plugin path>` so a real extension project can consume the local plugin build directly. The guide also includes a collapsed alternative for packing and installing a tarball when dependency resolution through a symlink needs to be ruled out. The package README links to the contributing guide.

## Why

This gives vite-plugin contributors a repeatable way to validate CRXJS changes in an external extension project before publishing.

The instructions include removing `node_modules` first when the target project was previously installed by a different package manager, because `pnpm link` can otherwise interact poorly with an existing mixed install.

## Validation

Validated against an external Vite 8 extension project context:

- `pnpm build:vite-plugin`
- removed the target project's `node_modules`
- `pnpm link /Users/toumash/repo/chrome-extension-tools/packages/vite-plugin`
- confirmed `node_modules/@crxjs/vite-plugin` points at the local CRXJS package
- documented the packed tarball flow as an optional troubleshooting fallback
- `git diff --check`