### PR TITLE
fix: limit dev file writer concurrency

### DIFF
--- a/.changeset/quiet-files-wait.md
+++ b/.changeset/quiet-files-wait.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+Limit concurrent dev file writes and debounce readiness checks to reduce memory usage when serving extensions with large module graphs.

--- a/packages/vite-plugin/src/node/fileWriter-rxjs.ts
+++ b/packages/vite-plugin/src/node/fileWriter-rxjs.ts
@@ -5,6 +5,7 @@ import MagicString from 'magic-string'
 import { OutputAsset, OutputChunk } from 'rollup'
 import {
   BehaviorSubject,
+  debounceTime,
   filter,
   first,
   firstValueFrom,
@@ -94,6 +95,7 @@ export const buildStart$ = fileWriterEvent$.pipe(
 /** Emit when all script files are written */
 export const allFilesReady$ = buildEnd$.pipe(
   switchMap(() => outputFiles.change$.pipe(startWith({ type: 'start' }))),
+  debounceTime(25),
   map(() => [...outputFiles.values()]),
   switchMap((files) =>
     Promise.allSettled(files.map((file) => waitForOutputFile(file))),

--- a/packages/vite-plugin/src/node/fileWriter.ts
+++ b/packages/vite-plugin/src/node/fileWriter.ts
@@ -26,6 +26,45 @@ export { allFilesReady, fileReady }
 const { outputFile } = fsx
 
 const debug = _debug('file-writer')
+const defaultMaxParallelWrites = 8
+const configuredMaxParallelWrites = Number.parseInt(
+  process.env.CRXJS_FILE_WRITER_CONCURRENCY ?? '',
+  10,
+)
+const maxParallelWrites =
+  Number.isFinite(configuredMaxParallelWrites) && configuredMaxParallelWrites > 0
+    ? configuredMaxParallelWrites
+    : defaultMaxParallelWrites
+let activeWrites = 0
+const pendingWrites: Array<() => void> = []
+
+async function acquireWriteSlot(): Promise<void> {
+  if (activeWrites < maxParallelWrites) {
+    activeWrites += 1
+    return
+  }
+
+  await new Promise<void>((resolve) => pendingWrites.push(resolve))
+}
+
+function releaseWriteSlot(): void {
+  const pendingWrite = pendingWrites.shift()
+  if (pendingWrite) {
+    pendingWrite()
+    return
+  }
+
+  activeWrites -= 1
+}
+
+async function withWriteSlot<T>(fn: () => Promise<T>): Promise<T> {
+  await acquireWriteSlot()
+  try {
+    return await fn()
+  } finally {
+    releaseWriteSlot()
+  }
+}
 
 function queueWrite(
   script: CrxDevAssetId | CrxDevScriptId,
@@ -58,9 +97,11 @@ export async function start({
     p.name?.startsWith('crx:'),
   )
   const { rollupOptions, outDir } = server.config.build
+  const { platform: _platform, ...rollupInputOptions } =
+    rollupOptions as RollupOptions & { platform?: unknown }
   const inputOptions: RollupOptions = {
     input: 'index.html',
-    ...rollupOptions,
+    ...rollupInputOptions,
     plugins,
   }
   // handle the various output option types
@@ -168,30 +209,32 @@ export async function write(
   fileId: CrxDevAssetId | CrxDevScriptId,
 ): Promise<{ start: number; close: number; deps: OutputFile[] }> {
   const start = performance.now()
-  const deps = await firstValueFrom(
-    // wait for start event
-    start$.pipe(
-      // prepare either asset or script contents
-      prepFileData(fileId),
-      // output file and add dependencies to file writer
-      mergeMap(async ({ target, source, deps }) => {
-        const files = deps
-          .map((id: string) => {
-            const r = [add({ id, type: 'module' })]
-            if (id.includes('?import')) {
-              const [imported] = id.split('?import')
-              r.push(add({ id: imported, type: 'asset' }))
-            }
-            return r
-          })
-          .flat()
-        if (source instanceof Uint8Array) await outputFile(target, source)
-        else await outputFile(target, source, { encoding: 'utf8' })
-        return files
-      }),
-      // abort write operation on close event
-      takeUntil(close$),
-      concatWith(of([])),
+  const deps = await withWriteSlot(() =>
+    firstValueFrom(
+      // wait for start event
+      start$.pipe(
+        // prepare either asset or script contents
+        prepFileData(fileId),
+        // output file and add dependencies to file writer
+        mergeMap(async ({ target, source, deps }) => {
+          const files = deps
+            .map((id: string) => {
+              const r = [add({ id, type: 'module' })]
+              if (id.includes('?import')) {
+                const [imported] = id.split('?import')
+                r.push(add({ id: imported, type: 'asset' }))
+              }
+              return r
+            })
+            .flat()
+          if (source instanceof Uint8Array) await outputFile(target, source)
+          else await outputFile(target, source, { encoding: 'utf8' })
+          return files
+        }),
+        // abort write operation on close event
+        takeUntil(close$),
+        concatWith(of([])),
+      ),
     ),
   )
   const close = performance.now()


### PR DESCRIPTION
## Summary

- Limits concurrent dev file writer work so large module graphs do not fan out into OOM-level memory usage.
- Debounces file readiness checks so readiness waits settle after bursts of output-file discovery.
- Strips Vite's `platform` option before the internal Rollup call used by the dev file writer.

## Reproduction Evidence

The PostHog fixture is intentionally not part of this upstream PR. It lives only on my fork as a proof branch:

- [PostHog OOM repro branch](https://github.com/Toumash/chrome-extension-tools/tree/repro/posthog-memory-oom)
- [Repro commit `4cb1883`](https://github.com/Toumash/chrome-extension-tools/commit/4cb18838dae989bec16024b0655f9743f548e1e3)

On that branch, the repro uses PanelPro's `posthog-js/dist/module.full.no-external` entry. With the unfixed baseline, this command reproduces the OOM:

```shell
CRXJS_RUN_POSTHOG_MEMORY_REPRO=1 \
CRXJS_POSTHOG_REPRO_LEAVES=240 \
NODE_OPTIONS="--max-old-space-size=512" \
pnpm --dir packages/vite-plugin exec vitest --mode e2e --run tests/e2e/mv3-vite-posthog-memory-repro/vite-serve.test.ts
```

Observed failure on the repro branch: `ERR_WORKER_OUT_OF_MEMORY`.

## Validation

Validation against the same PostHog fixture was run before removing the fixture from this PR branch:

- Vite 3 + 512 MB heap passed after the fix: `[posthog-memory-repro] files=250 heapUsedMB=76 rssMB=410 heapDeltaMB=22`.
- Vite 8 + 512 MB heap passed after the fix: `[posthog-memory-repro] files=250 heapUsedMB=59 rssMB=260 heapDeltaMB=8`.

Fix-only branch checks:

- `pnpm --dir packages/vite-plugin run lint:types`
- `pnpm --dir packages/vite-plugin run lint:eslint` exits 0 with the existing `plugin-manifest.ts` `any` warning.
- `pnpm --dir packages/vite-plugin exec vitest --mode e2e --run tests/e2e/mv3-messages-esm/vite-serve.test.ts`
- `pnpm --dir packages/vite-plugin test:vite-matrix -- --skip-install --skip-build --mode e2e --vite 8 -- tests/e2e/mv3-messages-esm/vite-serve.test.ts`
- `pnpm install --frozen-lockfile --ignore-scripts --prefer-offline`
- `git diff --check`