### PR TITLE
feat: harden content script HMR runtime port

### DIFF
--- a/.changeset/harden-hmr-runtime-port.md
+++ b/.changeset/harden-hmr-runtime-port.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+Harden content-script HMR ports so disconnected extension runtime ports are treated like closed WebSocket connections, failed `postMessage` calls are logged instead of surfacing as uncaught page errors, and the runtime-port reconnect interval can be configured for tests and advanced dev setups.

--- a/packages/vite-plugin/src/client/es/hmr-content-port.ts
+++ b/packages/vite-plugin/src/client/es/hmr-content-port.ts
@@ -4,13 +4,30 @@ import type { CrxHMRPayload } from 'src/types'
 import type { HMRPayload } from 'vite'
 
 declare const __CRX_HMR_TIMEOUT__: number
+declare const __CRX_HMR_RECONNECT_INTERVAL__: number
 declare const __CRX_LIVE_RELOAD__: boolean
 
 function isCrxHMRPayload(x: HMRPayload): x is CrxHMRPayload {
   return x.type === 'custom' && x.event.startsWith('crx:')
 }
 
+function isExtensionContextInvalidated(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes('Extension context invalidated.')
+  )
+}
+
+type PortMessage = { data: string } | { type: string }
+
 export class HMRPort {
+  readonly CONNECTING = 0
+  readonly OPEN = 1
+  readonly CLOSING = 2
+  readonly CLOSED = 3
+
+  readyState = this.CONNECTING
+
   private port: chrome.runtime.Port | undefined
   private callbacks = new Map<string, Set<(event: any) => void>>()
 
@@ -18,39 +35,37 @@ export class HMRPort {
     /**
      * To keep extension background alive:
      *
-     * - Ping service worker every 5 seconds
-     * - Re-initialize port every 5 minutes
+     * - Ping service worker on a configured interval (5 seconds by default)
+     * - Re-initialize port on a configured interval (5 minutes by default)
      */
-    setInterval(() => {
-      try {
-        this.port?.postMessage({ data: 'ping' })
-      } catch (error) {
-        if (
-          error instanceof Error &&
-          error.message.includes('Extension context invalidated.')
-        ) {
-          // TODO: hook into error overlay?
-          location.reload()
-        } else throw error
-      }
-    }, __CRX_HMR_TIMEOUT__)
-    setInterval(this.initPort, 5 * 60 * 1000)
+    setInterval(() => this.postMessage({ data: 'ping' }), __CRX_HMR_TIMEOUT__)
+    setInterval(this.initPort, __CRX_HMR_RECONNECT_INTERVAL__)
     this.initPort()
   }
 
   initPort = () => {
-    this.port?.disconnect()
-    this.port = chrome.runtime.connect({ name: '@crx/client' })
-    this.port.onDisconnect.addListener(this.handleDisconnect.bind(this))
-    this.port.onMessage.addListener(this.handleMessage.bind(this))
-    this.port.postMessage({ type: 'connected' })
+    if (this.port) {
+      this.readyState = this.CLOSING
+      this.port.disconnect()
+    }
+
+    this.readyState = this.CONNECTING
+    const port = chrome.runtime.connect({ name: '@crx/client' })
+    this.port = port
+    port.onDisconnect.addListener(this.handleDisconnect.bind(this, port))
+    port.onMessage.addListener(this.handleMessage.bind(this))
+    this.readyState = this.OPEN
+    setTimeout(() => {
+      if (this.port === port && this.readyState === this.OPEN) {
+        this.dispatchEvent('open', {})
+      }
+    }, 0)
+    this.postMessage({ type: 'connected' })
   }
 
-  handleDisconnect = () => {
-    if (this.callbacks.has('close'))
-      for (const cb of this.callbacks.get('close')!) {
-        cb({ wasClean: true })
-      }
+  handleDisconnect = (port: chrome.runtime.Port) => {
+    if (port !== this.port) return
+    this.closePort(true)
   }
 
   handleMessage = (message: any) => {
@@ -83,14 +98,55 @@ export class HMRPort {
     }
   }
 
-  addEventListener = (event: string, callback: (event: any) => void) => {
+  addEventListener = (
+    event: string,
+    callback: (event: any) => void,
+    options?: { once?: boolean } | boolean,
+  ) => {
     const cbs = this.callbacks.get(event) ?? new Set()
-    cbs.add(callback)
+    const cb =
+      typeof options === 'object' && options.once
+        ? (event: any) => {
+            cbs.delete(cb)
+            callback(event)
+          }
+        : callback
+    cbs.add(cb)
     this.callbacks.set(event, cbs)
   }
 
+  dispatchEvent = (event: string, payload: any) => {
+    if (this.callbacks.has(event))
+      for (const cb of this.callbacks.get(event)!) {
+        cb(payload)
+      }
+  }
+
+  closePort = (wasClean: boolean) => {
+    if (this.readyState === this.CLOSED) return
+    this.port = undefined
+    this.readyState = this.CLOSED
+    this.dispatchEvent('close', { wasClean })
+  }
+
+  postMessage = (message: PortMessage) => {
+    if (this.readyState !== this.OPEN || !this.port) return false
+
+    try {
+      this.port.postMessage(message)
+      return true
+    } catch (error) {
+      console.error('[crx] HMR runtime port postMessage failed', error)
+      this.closePort(false)
+      if (isExtensionContextInvalidated(error)) {
+        // TODO: hook into error overlay?
+        location.reload()
+      }
+      return false
+    }
+  }
+
   send = (data: string) => {
-    if (this.port) this.port.postMessage({ data })
-    else throw new Error('HMRPort is not initialized')
+    this.postMessage({ data })
   }
 }

--- a/packages/vite-plugin/src/node/plugin-contentScripts.ts
+++ b/packages/vite-plugin/src/node/plugin-contentScripts.ts
@@ -36,6 +36,7 @@ export const pluginContentScripts: CrxPluginFn = () => {
   let server: ViteDevServer
   let preambleCode: string | false | undefined
   let hmrTimeout: number | undefined
+  let hmrReconnectInterval: number | undefined
   let liveReload = true
   let sub = new Subscription()
 
@@ -75,6 +76,8 @@ export const pluginContentScripts: CrxPluginFn = () => {
         const opts = await getOptions(config)
         const { contentScripts = {} } = opts
         hmrTimeout = contentScripts.hmrTimeout ?? 5000
+        hmrReconnectInterval =
+          contentScripts.hmrReconnectInterval ?? 5 * 60 * 1000
         preambleCode = preambleCode ?? contentScripts.preambleCode
         liveReload = opts.liveReload !== false
       },
@@ -148,6 +151,10 @@ export const pluginContentScripts: CrxPluginFn = () => {
         if (id === contentHmrPortId) {
           const defined = contentHmrPort
             .replace('__CRX_HMR_TIMEOUT__', JSON.stringify(hmrTimeout))
+            .replace(
+              '__CRX_HMR_RECONNECT_INTERVAL__',
+              JSON.stringify(hmrReconnectInterval),
+            )
             .replace('__CRX_LIVE_RELOAD__', JSON.stringify(liveReload))
           return defined
         }

--- a/packages/vite-plugin/src/node/types.ts
+++ b/packages/vite-plugin/src/node/types.ts
@@ -83,6 +83,11 @@ export interface CrxOptions {
   contentScripts?: {
     preambleCode?: string | false
     hmrTimeout?: number
+    /**
+     * How often content-script HMR ports are recreated during development.
+     * Defaults to 5 minutes.
+     */
+    hmrReconnectInterval?: number
     injectCss?: boolean
     /**
      * List of content script files (relative to project root) that should be

--- a/packages/vite-plugin/tests/e2e/mv3-vite-react-content-script-hmr/hmr-port.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-react-content-script-hmr/hmr-port.test.ts
@@ -1,0 +1,159 @@
+import fs from 'fs-extra'
+import path from 'pathe'
+import { expect, test } from 'vitest'
+import { serve } from '../runners'
+
+const hmrPortProbe = `
+import { HMRPort as CrxProbeHMRPort } from '/@crx/client-port'
+
+const crxProbePort = new CrxProbeHMRPort()
+let openEvents = 0
+
+function logStatus(label, extra = {}) {
+  console.log('[crx-test] ' + label + ' ' + JSON.stringify({
+    readyState: crxProbePort.readyState,
+    isOpen: crxProbePort.readyState === crxProbePort.OPEN,
+    openEvents,
+    ...extra,
+  }))
+}
+
+crxProbePort.addEventListener('open', () => {
+  openEvents += 1
+  logStatus('open')
+})
+
+window.addEventListener('message', (event) => {
+  if (event.source !== window || event.data?.type !== 'crx-test-hmr-port') {
+    return
+  }
+
+  if (event.data.action === 'disconnect-then-send') {
+    crxProbePort.port.disconnect()
+    crxProbePort.send('{"type":"ping"}')
+    setTimeout(() => logStatus('after-disconnect-send'), 0)
+  }
+
+  if (event.data.action === 'check-after-delay') {
+    setTimeout(() => {
+      let sendOk = true
+      try {
+        crxProbePort.send('{"type":"ping"}')
+      } catch (error) {
+        sendOk = false
+        console.error('[crx-test] send failed after reconnect', error)
+      }
+      logStatus('after-reconnect', { sendOk })
+    }, event.data.delay)
+  }
+})
+`
+
+async function prepareFixture() {
+  const src = path.join(__dirname, 'src')
+  const src1 = path.join(__dirname, 'src1')
+
+  await fs.remove(src)
+  await fs.copy(src1, src, { recursive: true })
+  await fs.appendFile(path.join(src, 'main.jsx'), hmrPortProbe)
+}
+
+async function withReconnectInterval<T>(
+  interval: number,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const previous = process.env.CRX_TEST_HMR_RECONNECT_INTERVAL
+  process.env.CRX_TEST_HMR_RECONNECT_INTERVAL = `${interval}`
+
+  try {
+    return await fn()
+  } finally {
+    if (typeof previous === 'undefined') {
+      delete process.env.CRX_TEST_HMR_RECONNECT_INTERVAL
+    } else {
+      process.env.CRX_TEST_HMR_RECONNECT_INTERVAL = previous
+    }
+  }
+}
+
+function getStatus(messages: string[], label: string) {
+  const prefix = `[crx-test] ${label} `
+  const message = [...messages]
+    .reverse()
+    .find((text) => text.startsWith(prefix))
+  if (!message) throw new Error(`Missing ${label} status`)
+  return JSON.parse(message.slice(prefix.length)) as {
+    readyState: number
+    isOpen: boolean
+    openEvents: number
+    sendOk?: boolean
+  }
+}
+
+test('HMRPort logs postMessage failures instead of throwing page errors', async () => {
+  await prepareFixture()
+
+  const { browser } = await serve(__dirname)
+  const page = await browser.newPage()
+  const pageErrors: string[] = []
+  const consoleMessages: string[] = []
+
+  page.on('pageerror', (error) => pageErrors.push(error.message))
+  page.on('console', (message) => consoleMessages.push(message.text()))
+
+  await page.goto('https://example.com')
+  await page.locator('.App').waitFor()
+
+  await page.evaluate(() => {
+    window.postMessage(
+      { type: 'crx-test-hmr-port', action: 'disconnect-then-send' },
+      '*',
+    )
+  })
+  await new Promise((resolve) => setTimeout(resolve, 500))
+
+  expect(pageErrors).toEqual([])
+  expect(
+    consoleMessages.some(
+      (message) =>
+        message.includes('[crx] HMR runtime port postMessage failed') &&
+        message.includes('Attempting to use a disconnected port object'),
+    ),
+  ).toBe(true)
+
+  const status = getStatus(consoleMessages, 'after-disconnect-send')
+  expect(status.isOpen).toBe(false)
+})
+
+test('HMRPort reconnect interval restores an open runtime port after dev server disconnect', async () => {
+  await prepareFixture()
+
+  const { browser, devServer } = await withReconnectInterval(100, () =>
+    serve(__dirname),
+  )
+  const page = await browser.newPage()
+  const pageErrors: string[] = []
+  const consoleMessages: string[] = []
+
+  page.on('pageerror', (error) => pageErrors.push(error.message))
+  page.on('console', (message) => consoleMessages.push(message.text()))
+
+  await page.goto('https://example.com')
+  await page.locator('.App').waitFor()
+
+  await devServer.close()
+  await page.evaluate(() => {
+    window.postMessage(
+      { type: 'crx-test-hmr-port', action: 'check-after-delay', delay: 350 },
+      '*',
+    )
+  })
+  await new Promise((resolve) => setTimeout(resolve, 700))
+
+  expect(pageErrors).toEqual([])
+
+  const status = getStatus(consoleMessages, 'after-reconnect')
+  expect(status.isOpen).toBe(true)
+  expect(status.openEvents).toBeGreaterThan(1)
+  expect(status.sendOk).toBe(true)
+})

--- a/packages/vite-plugin/tests/e2e/mv3-vite-react-content-script-hmr/vite.config.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-react-content-script-hmr/vite.config.ts
@@ -4,10 +4,22 @@ import { defineConfig } from 'vite'
 import manifest from './manifest.json'
 
 const { preambleCode } = react
+const hmrReconnectInterval = process.env.CRX_TEST_HMR_RECONNECT_INTERVAL
 
 export default defineConfig({
   build: { minify: false },
   clearScreen: false,
   logLevel: 'error',
-  plugins: [crx({ manifest, contentScripts: { preambleCode } }), react()],
+  plugins: [
+    crx({
+      manifest,
+      contentScripts: {
+        preambleCode,
+        ...(hmrReconnectInterval
+          ? { hmrReconnectInterval: Number(hmrReconnectInterval) }
+          : {}),
+      },
+    }),
+    react(),
+  ],
 })


### PR DESCRIPTION
## Summary

Follow-up to #1184. This hardens the content-script HMR runtime port so it behaves more like the WebSocket object Vite expects.

## Root Cause

The content-script HMR transport kept a stale `chrome.runtime.Port` after disconnects. A later `send()` could call `port.postMessage` on that stale port and surface Chrome errors such as `Attempting to use a disconnected port object` or `Extension context invalidated.` as uncaught page errors. The transport also did not expose `readyState`/`OPEN`, which made Vite's open-state checks unreliable.

## Changes

- Add WebSocket-like `readyState` constants and `open`/`close` dispatching to `HMRPort`.
- Route ping and `send()` calls through guarded `postMessage` handling.
- Log failed runtime-port `postMessage` calls instead of throwing uncaught page errors.
- Keep the existing 5 minute reconnect default, with a configurable reconnect interval for regression tests and advanced dev setups.
- Add e2e coverage for disconnected-port sends and reconnecting after the dev server is stopped.

## Validation

- `pnpm --dir packages/vite-plugin exec vitest --run --mode e2e mv3-vite-react-content-script-hmr/hmr-port.test.ts`
- `pnpm --dir packages/vite-plugin run lint:types`
- Earlier full-suite checks before splitting this follow-up branch: `pnpm --dir packages/vite-plugin exec vitest --run --mode e2e`, `pnpm --dir packages/vite-plugin exec vitest --run --mode out`, `pnpm --dir packages/vite-plugin run lint:eslint`