### PR TITLE
Add native content script HMR proof of concept

### DIFF
--- a/.changeset/native-content-script-hmr.md
+++ b/.changeset/native-content-script-hmr.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": minor
+---
+
+Add experimental native HMR for module content scripts served directly from the Vite dev server. When `liveReload` is disabled, native content scripts still load from the dev server but native HMR updates are disabled.

--- a/packages/vite-plugin/src/client/iife/content-dev-main-loader.ts
+++ b/packages/vite-plugin/src/client/iife/content-dev-main-loader.ts
@@ -5,7 +5,7 @@ const injectTime = performance.now()
 ;(async () => {
   try {
     if (__PREAMBLE__) await import(/* @vite-ignore */ __PREAMBLE__)
-    await import(/* @vite-ignore */ __CLIENT__)
+    if (__CLIENT__) await import(/* @vite-ignore */ __CLIENT__)
   } catch (error) {
     console.warn('[crx] MAIN world HMR client failed to load', error)
   }

--- a/packages/vite-plugin/src/client/iife/content-dev-native-loader.ts
+++ b/packages/vite-plugin/src/client/iife/content-dev-native-loader.ts
@@ -1,0 +1,25 @@
+declare const __PREAMBLE__: string
+declare const __SCRIPT__: string
+declare const __VITE_ORIGIN__: string
+
+const injectTime = performance.now()
+const fromVite = (id: string) => new URL(id, __VITE_ORIGIN__).href
+
+;(async () => {
+  if (__PREAMBLE__) {
+    await import(/* @vite-ignore */ fromVite(__PREAMBLE__))
+  }
+
+  await import(/* @vite-ignore */ fromVite('/@vite/client'))
+
+  const { onExecute } = (await import(
+    /* @vite-ignore */ fromVite(__SCRIPT__)
+  )) as ContentScriptAPI.ModuleExports
+
+  // this is the entry point of the content script, it will run each time this script is injected
+  onExecute?.({
+    perf: { injectTime, loadTime: performance.now() - injectTime },
+  })
+})().catch(console.error)
+
+export {}

--- a/packages/vite-plugin/src/client/iife/content-dev-native-loader.ts
+++ b/packages/vite-plugin/src/client/iife/content-dev-native-loader.ts
@@ -1,4 +1,5 @@
 declare const __PREAMBLE__: string
+declare const __CRX_LIVE_RELOAD__: boolean
 declare const __SCRIPT__: string
 declare const __VITE_ORIGIN__: string
 
@@ -10,7 +11,9 @@ const fromVite = (id: string) => new URL(id, __VITE_ORIGIN__).href
     await import(/* @vite-ignore */ fromVite(__PREAMBLE__))
   }
 
-  await import(/* @vite-ignore */ fromVite('/@vite/client'))
+  if (__CRX_LIVE_RELOAD__) {
+    await import(/* @vite-ignore */ fromVite('/@vite/client'))
+  }
 
   const { onExecute } = (await import(
     /* @vite-ignore */ fromVite(__SCRIPT__)

--- a/packages/vite-plugin/src/node/contentScripts.ts
+++ b/packages/vite-plugin/src/node/contentScripts.ts
@@ -89,15 +89,18 @@ export function createDevLoader({
 }
 
 export function createDevNativeLoader({
+  liveReload,
   preamble,
   fileName,
   viteOrigin,
 }: {
+  liveReload: boolean
   preamble: string
   fileName: string
   viteOrigin: string
 }): string {
   return contentDevNativeLoader
+    .replace(/__CRX_LIVE_RELOAD__/g, JSON.stringify(liveReload))
     .replace(/__PREAMBLE__/g, JSON.stringify(preamble))
     .replace(/__SCRIPT__/g, JSON.stringify(fileName))
     .replace(/__VITE_ORIGIN__/g, JSON.stringify(viteOrigin))

--- a/packages/vite-plugin/src/node/contentScripts.ts
+++ b/packages/vite-plugin/src/node/contentScripts.ts
@@ -1,5 +1,6 @@
 import contentDevLoader from 'client/iife/content-dev-loader.ts'
 import contentDevMainLoader from 'client/iife/content-dev-main-loader.ts'
+import contentDevNativeLoader from 'client/iife/content-dev-native-loader.ts'
 import contentProLoader from 'client/iife/content-pro-loader.ts'
 import contentProMainLoader from 'client/iife/content-pro-main-loader.ts'
 import { filter } from 'rxjs'
@@ -85,6 +86,21 @@ export function createDevLoader({
     .replace(/__CLIENT__/g, JSON.stringify(client))
     .replace(/__SCRIPT__/g, JSON.stringify(fileName))
     .replace(/__TIMESTAMP__/g, JSON.stringify(Date.now()))
+}
+
+export function createDevNativeLoader({
+  preamble,
+  fileName,
+  viteOrigin,
+}: {
+  preamble: string
+  fileName: string
+  viteOrigin: string
+}): string {
+  return contentDevNativeLoader
+    .replace(/__PREAMBLE__/g, JSON.stringify(preamble))
+    .replace(/__SCRIPT__/g, JSON.stringify(fileName))
+    .replace(/__VITE_ORIGIN__/g, JSON.stringify(viteOrigin))
 }
 
 export function createProLoader({ fileName }: { fileName: string }): string {

--- a/packages/vite-plugin/src/node/plugin-contentScripts.ts
+++ b/packages/vite-plugin/src/node/plugin-contentScripts.ts
@@ -6,6 +6,7 @@ import {
   contentScripts,
   createDevLoader,
   createDevMainLoader,
+  createDevNativeLoader,
   createProLoader,
   createProMainLoader,
 } from './contentScripts'
@@ -74,6 +75,7 @@ export const pluginContentScripts: CrxPluginFn = () => {
   let preambleCode: string | false | undefined
   let hmrTimeout: number | undefined
   let liveReload = true
+  let nativeHmr = false
   let sub = new Subscription()
 
   const worldMainIds = new Set<string>()
@@ -121,6 +123,18 @@ export const pluginContentScripts: CrxPluginFn = () => {
     console.warn(message)
   }
 
+  const getViteOrigin = () => {
+    const resolvedLocal = server.resolvedUrls?.local[0]
+    if (resolvedLocal) return new URL(resolvedLocal).origin
+
+    const proto = server.config.server.https ? 'https' : 'http'
+    const port = server.config.server.port?.toString()
+    if (typeof port === 'undefined')
+      throw new Error('server port is undefined in watch mode')
+
+    return `${proto}://localhost:${port}`
+  }
+
   return [
     {
       name: pluginName,
@@ -133,6 +147,7 @@ export const pluginContentScripts: CrxPluginFn = () => {
         hmrTimeout = contentScripts.hmrTimeout ?? 5000
         preambleCode = preambleCode ?? contentScripts.preambleCode
         liveReload = opts.liveReload !== false
+        nativeHmr = contentScripts.hmr === 'native'
       },
       async configureServer(_server) {
         server = _server
@@ -161,34 +176,61 @@ export const pluginContentScripts: CrxPluginFn = () => {
             .subscribe(({ value: script }) => {
               const { type, id } = script
               if (type === 'loader') {
+                const fileId = prefix('/', id)
                 let preamble = { fileName: '' } // no preamble by default
-                if (preambleCode)
+                if (preambleCode && !nativeHmr)
                   preamble = add({ type: 'module', id: preambleId })
-                const client = add({ type: 'module', id: viteClientId })
 
-                const file = add({ type: 'module', id })
+                if (!nativeHmr) {
+                  const client = add({ type: 'module', id: viteClientId })
+                  const file = add({ type: 'module', id })
+                  const loaderFileName = getFileName({ type: 'loader', id })
+                  const loader = add({
+                    type: 'asset',
+                    id: loaderFileName,
+                    source: worldMainIds.has(file.id)
+                      ? createDevMainLoader({
+                          preamble: preamble.fileName
+                            ? asRelativeImport(
+                                loaderFileName,
+                                preamble.fileName,
+                              )
+                            : '',
+                          client: asRelativeImport(
+                            loaderFileName,
+                            client.fileName,
+                          ),
+                          fileName: asRelativeImport(
+                            loaderFileName,
+                            file.fileName,
+                          ),
+                        })
+                      : createDevLoader({
+                          preamble: preamble.fileName,
+                          client: client.fileName,
+                          fileName: file.fileName,
+                        }),
+                  })
+                  script.fileName = loader.fileName
+                  return
+                }
+
+                const viteOrigin = getViteOrigin()
+                const fromVite = (id: string) => new URL(id, viteOrigin).href
                 const loaderFileName = getFileName({ type: 'loader', id })
                 const loader = add({
                   type: 'asset',
                   id: loaderFileName,
-                  source: worldMainIds.has(file.id)
+                  source: worldMainIds.has(fileId)
                     ? createDevMainLoader({
-                        preamble: preamble.fileName
-                          ? asRelativeImport(loaderFileName, preamble.fileName)
-                          : '',
-                        client: asRelativeImport(
-                          loaderFileName,
-                          client.fileName,
-                        ),
-                        fileName: asRelativeImport(
-                          loaderFileName,
-                          file.fileName,
-                        ),
+                        preamble: preambleCode ? fromVite(preambleId) : '',
+                        client: fromVite('/@vite/client'),
+                        fileName: fromVite(fileId),
                       })
-                    : createDevLoader({
-                        preamble: preamble.fileName,
-                        client: client.fileName,
-                        fileName: file.fileName,
+                    : createDevNativeLoader({
+                        preamble: preambleCode ? preambleId : '',
+                        fileName: fileId,
+                        viteOrigin,
                       }),
                 })
                 script.fileName = loader.fileName

--- a/packages/vite-plugin/src/node/plugin-contentScripts.ts
+++ b/packages/vite-plugin/src/node/plugin-contentScripts.ts
@@ -224,12 +224,13 @@ export const pluginContentScripts: CrxPluginFn = () => {
                   source: worldMainIds.has(fileId)
                     ? createDevMainLoader({
                         preamble: preambleCode ? fromVite(preambleId) : '',
-                        client: fromVite('/@vite/client'),
+                        client: liveReload ? fromVite('/@vite/client') : '',
                         fileName: fromVite(fileId),
                       })
                     : createDevNativeLoader({
                         preamble: preambleCode ? preambleId : '',
                         fileName: fileId,
+                        liveReload,
                         viteOrigin,
                       }),
                 })

--- a/packages/vite-plugin/src/node/plugin-extensionCors.test.ts
+++ b/packages/vite-plugin/src/node/plugin-extensionCors.test.ts
@@ -1,5 +1,7 @@
 import type { CorsOptions, UserConfig } from 'vite'
 import { expect, test } from 'vitest'
+import type { CrxInputOptions } from './plugin-optionsProvider'
+import { pluginOptionsProvider } from './plugin-optionsProvider'
 import { addExtensionCors, pluginExtensionCors } from './plugin-extensionCors'
 
 type OriginFunction = (
@@ -32,12 +34,23 @@ function checkOrigin(origin: OriginFunction, value: string) {
   })
 }
 
-async function runExtensionCorsConfig(config: UserConfig) {
+const manifest: CrxInputOptions['manifest'] = {
+  manifest_version: 3,
+  name: 'Test Extension',
+  version: '1.0.0',
+}
+
+async function runExtensionCorsConfig(
+  config: UserConfig,
+  options: CrxInputOptions = { manifest },
+) {
   const hook = pluginExtensionCors().config
 
   if (typeof hook !== 'function') {
     throw new Error('Unable to find extension CORS config hook')
   }
+
+  config.plugins = [...(config.plugins ?? []), pluginOptionsProvider(options)]
 
   await hook(config, {
     command: 'serve',
@@ -76,9 +89,9 @@ test('preserves user cors origin functions', async () => {
     }),
   ) as OriginFunction
 
-  await expect(checkOrigin(origin, 'chrome-extension://extension-id')).resolves.toBe(
-    true,
-  )
+  await expect(
+    checkOrigin(origin, 'chrome-extension://extension-id'),
+  ).resolves.toBe(true)
   await expect(checkOrigin(origin, 'https://example.com')).resolves.toBe(true)
   await expect(checkOrigin(origin, 'https://blocked.example')).resolves.toBe(
     false,
@@ -92,4 +105,25 @@ test('plugin applies extension cors to dev server config', async () => {
 
   const origin = getOrigin(config.server!.cors!)
   expect(originAllows(origin, 'chrome-extension://extension-id')).toBe(true)
+})
+
+test('plugin allows content script match origins for native hmr', async () => {
+  const config: UserConfig = {}
+
+  await runExtensionCorsConfig(config, {
+    manifest: {
+      ...manifest,
+      content_scripts: [
+        {
+          matches: ['https://example.com/*'],
+          js: ['src/content.js'],
+        },
+      ],
+    },
+    contentScripts: { hmr: 'native' },
+  })
+
+  const origin = getOrigin(config.server!.cors!)
+  expect(originAllows(origin, 'https://example.com')).toBe(true)
+  expect(originAllows(origin, 'https://other.example')).toBe(false)
 })

--- a/packages/vite-plugin/src/node/plugin-extensionCors.ts
+++ b/packages/vite-plugin/src/node/plugin-extensionCors.ts
@@ -1,20 +1,71 @@
 import type { CorsOptions, Plugin } from 'vite'
+import type { ManifestV3 } from './manifest'
+import { getOptions } from './plugin-optionsProvider'
 
 const extensionOrigins = [/^chrome-extension:\/\//, /^moz-extension:\/\//]
 
-function isExtensionOrigin(origin?: string) {
+type CorsOrigin = string | RegExp
+type ExtraCorsOrigins = true | CorsOrigin[]
+
+function isAllowedOrigin(origin: string | undefined, allowed: CorsOrigin[]) {
   return origin
-    ? extensionOrigins.some((pattern) => pattern.test(origin))
+    ? allowed.some((item) =>
+        typeof item === 'string' ? item === origin : item.test(origin),
+      )
     : false
 }
 
-function addExtensionOrigins(
+function escapeRegExp(text: string) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function matchPatternToCorsOrigins(pattern: string): true | CorsOrigin[] {
+  if (pattern === '<all_urls>') return true
+
+  const match = pattern.match(/^(\*|http|https):\/\/([^/]+)\//)
+  if (!match) return []
+
+  const [, scheme, host] = match
+  const schemes = scheme === '*' ? ['http', 'https'] : [scheme]
+
+  return schemes.map((item) => {
+    if (host === '*') return new RegExp(`^${item}:\\/\\/`)
+
+    if (host.startsWith('*.')) {
+      const escapedHost = escapeRegExp(host.slice(2))
+      return new RegExp(`^${item}:\\/\\/([^/]+\\.)?${escapedHost}(?::\\d+)?$`)
+    }
+
+    return new RegExp(`^${item}:\\/\\/${escapeRegExp(host)}(?::\\d+)?$`)
+  })
+}
+
+function getContentScriptCorsOrigins(manifest: ManifestV3): ExtraCorsOrigins {
+  const origins: CorsOrigin[] = []
+
+  for (const script of manifest.content_scripts ?? []) {
+    for (const match of script.matches ?? []) {
+      const result = matchPatternToCorsOrigins(match)
+      if (result === true) return true
+      origins.push(...result)
+    }
+  }
+
+  return origins
+}
+
+function addAllowedOrigins(
   origin: CorsOptions['origin'],
+  extraOrigins: ExtraCorsOrigins,
 ): CorsOptions['origin'] {
+  if (extraOrigins === true) return true
   if (origin === true) return true
+
+  const allowed = [...extensionOrigins, ...extraOrigins]
+
   if (typeof origin === 'function') {
     return (requestOrigin, cb) => {
-      if (isExtensionOrigin(requestOrigin)) {
+      if (isAllowedOrigin(requestOrigin, allowed)) {
         cb(null as unknown as Error, true)
         return
       }
@@ -23,37 +74,50 @@ function addExtensionOrigins(
     }
   }
 
-  if (Array.isArray(origin)) return [...origin, ...extensionOrigins]
-  if (origin) return [origin, ...extensionOrigins]
+  if (Array.isArray(origin)) return [...origin, ...allowed]
+  if (origin) return [origin, ...allowed]
 
-  return extensionOrigins
+  return allowed
 }
 
 export function addExtensionCors(
   cors: CorsOptions | boolean | undefined,
+  extraOrigins: ExtraCorsOrigins = [],
 ): CorsOptions | boolean {
   if (cors === true) return true
   if (cors && typeof cors === 'object') {
     return {
       ...cors,
-      origin: addExtensionOrigins(cors.origin),
+      origin: addAllowedOrigins(cors.origin, extraOrigins),
     }
   }
 
-  return { origin: extensionOrigins }
+  if (extraOrigins === true) return true
+
+  return { origin: [...extensionOrigins, ...extraOrigins] }
 }
 
 export function pluginExtensionCors(): Plugin {
   return {
     name: 'crx:extension-cors',
     apply: 'serve',
-    config(config) {
+    async config(config, env) {
+      const opts = await getOptions(config)
+      let extraOrigins: ExtraCorsOrigins = []
+
+      if (opts.contentScripts?.hmr === 'native') {
+        const manifest = await (typeof opts.manifest === 'function'
+          ? opts.manifest(env)
+          : opts.manifest)
+        extraOrigins = getContentScriptCorsOrigins(manifest)
+      }
+
       // Vite's dev-server CORS default was tightened in patched releases
       // (4.5.6, 5.4.12, 6.0.9+). Extension pages still need access to
       // dev-server files; WebSocket HMR tokens do not cover fetch CORS.
       config.server = {
         ...config.server,
-        cors: addExtensionCors(config.server?.cors),
+        cors: addExtensionCors(config.server?.cors, extraOrigins),
       }
     },
   }

--- a/packages/vite-plugin/src/node/plugin-hmr.ts
+++ b/packages/vite-plugin/src/node/plugin-hmr.ts
@@ -63,6 +63,10 @@ export const pluginHMR: CrxPluginFn = () => {
         const opts = await getOptions({ ...config, server })
         liveReload = opts.liveReload !== false
         nativeHmr = opts.contentScripts?.hmr === 'native'
+        if (nativeHmr && !liveReload) {
+          server.hmr = false
+          return { server, ...config }
+        }
         if (server.hmr === false) return
         if (server.hmr === true) server.hmr = {}
         server.hmr = server.hmr ?? {}

--- a/packages/vite-plugin/src/node/plugin-hmr.ts
+++ b/packages/vite-plugin/src/node/plugin-hmr.ts
@@ -51,6 +51,7 @@ export const pluginHMR: CrxPluginFn = () => {
   let config: ResolvedConfig
   let subs: Subscription
   let liveReload = true
+  let nativeHmr = false
 
   return [
     {
@@ -61,10 +62,15 @@ export const pluginHMR: CrxPluginFn = () => {
       async config({ server = {}, ...config }) {
         const opts = await getOptions({ ...config, server })
         liveReload = opts.liveReload !== false
+        nativeHmr = opts.contentScripts?.hmr === 'native'
         if (server.hmr === false) return
         if (server.hmr === true) server.hmr = {}
         server.hmr = server.hmr ?? {}
         server.hmr.host = 'localhost'
+        if (nativeHmr) {
+          server.hmr.protocol =
+            server.hmr.protocol ?? (server.https ? 'wss' : 'ws')
+        }
 
         return { server }
       },
@@ -86,14 +92,16 @@ export const pluginHMR: CrxPluginFn = () => {
           // decorate server websocket send method
           const { send } = server.ws
           decoratedSend = (payload: HMRPayload) => {
-            if (payload.type === 'error') {
-              send({
-                type: 'custom',
-                event: 'crx:content-script-payload',
-                data: payload,
-              })
-            } else {
-              hmrPayload$.next(payload) // sniff hmr events
+            if (!nativeHmr) {
+              if (payload.type === 'error') {
+                send({
+                  type: 'custom',
+                  event: 'crx:content-script-payload',
+                  data: payload,
+                })
+              } else {
+                hmrPayload$.next(payload) // sniff hmr events
+              }
             }
 
             send(payload) // don't interfere with normal hmr
@@ -102,15 +110,17 @@ export const pluginHMR: CrxPluginFn = () => {
 
           subs = new Subscription(() => (subs = new Subscription()))
           subs.add(fileWriterError$.subscribe(send))
-          subs.add(
-            crxHMRPayload$.subscribe((payload) => {
-              // keep subscription alive for file writer side effects,
-              // but skip sending HMR payloads when liveReload is disabled
-              if (liveReload) {
-                send(payload) // send crx hmr and error events
-              }
-            }),
-          )
+          if (!nativeHmr) {
+            subs.add(
+              crxHMRPayload$.subscribe((payload) => {
+                // keep subscription alive for file writer side effects,
+                // but skip sending HMR payloads when liveReload is disabled
+                if (liveReload) {
+                  send(payload) // send crx hmr and error events
+                }
+              }),
+            )
+          }
         }
       },
       closeBundle() {
@@ -171,6 +181,8 @@ export const pluginHMR: CrxPluginFn = () => {
 
         for (const [key, script] of contentScripts)
           if (key === script.id) {
+            if (nativeHmr && script.type !== 'iife') continue
+
             // Handle synthetic CSS content script entries (virtual modules)
             if (isContentCssId(script.id)) {
               // Check if any of the CSS files associated with this synthetic entry changed

--- a/packages/vite-plugin/src/node/plugin-manifest.ts
+++ b/packages/vite-plugin/src/node/plugin-manifest.ts
@@ -64,6 +64,17 @@ function getLoadingPageReadyHtmlPath(requestUrl: string | undefined) {
   return normalizeHtmlPath(pageUrl.pathname)
 }
 
+function addDevServerHostPermission(
+  manifest: ManifestV3,
+  config: ResolvedConfig,
+) {
+  const proto = config.server.https ? 'https' : 'http'
+  const permission = `${proto}://localhost/*`
+  manifest.host_permissions = [
+    ...new Set([...(manifest.host_permissions ?? []), permission]),
+  ]
+}
+
 /**
  * This plugin emits, transforms, renders, and outputs the manifest.
  *
@@ -79,13 +90,16 @@ export const pluginManifest: CrxPluginFn = () => {
   let devHtmlFiles = new Set<string>()
   let refId: string
   let config: ResolvedConfig
+  let nativeContentScriptHmr = false
 
   return [
     {
       name: 'crx:manifest-init',
       enforce: 'pre',
       async config(config, env) {
-        const { manifest: _manifest } = await getOptions(config)
+        const opts = await getOptions(config)
+        const { manifest: _manifest } = opts
+        nativeContentScriptHmr = opts.contentScripts?.hmr === 'native'
         manifest = await (typeof _manifest === 'function'
           ? _manifest(env)
           : _manifest)
@@ -335,7 +349,7 @@ export const pluginManifest: CrxPluginFn = () => {
               for (const file of js) {
                 // Skip IIFE/standalone content scripts - they're built separately
                 if (isIifeContentScript(file) || isStandaloneFile(file)) continue
-                
+
                 const id = join(config.root, file)
                 const refId = this.emitFile({
                   type: 'chunk',
@@ -401,6 +415,10 @@ export const pluginManifest: CrxPluginFn = () => {
         if (config.command === 'serve') {
           // plugin-background emits service worker loader in renderCrxManifest
           // vite dev server sends html files through local host
+          if (nativeContentScriptHmr) {
+            addDevServerHostPermission(manifest, config)
+          }
+
           if (manifest.content_scripts) {
             // Get all registered CSS entries
             const cssEntries = getContentCssEntries()

--- a/packages/vite-plugin/src/node/types.ts
+++ b/packages/vite-plugin/src/node/types.ts
@@ -83,6 +83,16 @@ export interface CrxOptions {
   contentScripts?: {
     preambleCode?: string | false
     hmrTimeout?: number
+    /**
+     * Development HMR transport for module content scripts.
+     *
+     * - "file" keeps the historical CRXJS file-writer bridge.
+     * - "native" is experimental and loads Vite modules and Vite's HMR client
+     *   directly from the dev server.
+     *
+     * Default is "file".
+     */
+    hmr?: 'file' | 'native'
     injectCss?: boolean
     /**
      * List of content script files (relative to project root) that should be

--- a/packages/vite-plugin/src/node/types.ts
+++ b/packages/vite-plugin/src/node/types.ts
@@ -126,6 +126,8 @@ export interface CrxOptions {
    * - The extension will not call `chrome.runtime.reload()` on background changes
    *   or dev server reconnection.
    * - Content scripts will not receive HMR updates or reload their host pages.
+   *   Native content scripts still load from the dev server, but native HMR
+   *   updates are disabled.
    * - Files are still rebuilt and written to the output directory on change.
    *
    * Use this when content scripts have side effects on injection and you want

--- a/packages/vite-plugin/tests/e2e/mv3-content-script-manifest-css-hmr/vite.config.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-content-script-manifest-css-hmr/vite.config.ts
@@ -16,5 +16,5 @@ export default defineConfig({
   },
   clearScreen: false,
   logLevel: 'error',
-  plugins: [crx({ manifest })],
+  plugins: [crx({ manifest, contentScripts: { hmr: 'native' } })],
 })

--- a/packages/vite-plugin/tests/e2e/mv3-vite-native-content-script-hmr-disabled/manifest.json
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-native-content-script-hmr-disabled/manifest.json
@@ -1,0 +1,12 @@
+{
+  "description": "test extension",
+  "manifest_version": 3,
+  "name": "test extension",
+  "content_scripts": [
+    {
+      "matches": ["https://example.com/*"],
+      "js": ["src/content.js"]
+    }
+  ],
+  "version": "1.0.0"
+}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-native-content-script-hmr-disabled/src1/content.js
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-native-content-script-hmr-disabled/src1/content.js
@@ -1,0 +1,17 @@
+const text = 'one'
+
+export function render() {
+  let app = document.querySelector('#native-hmr-app')
+  if (!app) {
+    app = document.createElement('div')
+    app.id = 'native-hmr-app'
+    document.body.append(app)
+  }
+  app.textContent = text
+}
+
+render()
+
+if (import.meta.hot) {
+  import.meta.hot.accept((mod) => mod?.render())
+}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-native-content-script-hmr-disabled/src2/content.js
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-native-content-script-hmr-disabled/src2/content.js
@@ -1,0 +1,17 @@
+const text = 'two'
+
+export function render() {
+  let app = document.querySelector('#native-hmr-app')
+  if (!app) {
+    app = document.createElement('div')
+    app.id = 'native-hmr-app'
+    document.body.append(app)
+  }
+  app.textContent = text
+}
+
+render()
+
+if (import.meta.hot) {
+  import.meta.hot.accept((mod) => mod?.render())
+}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-native-content-script-hmr-disabled/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-native-content-script-hmr-disabled/vite-serve.test.ts
@@ -1,10 +1,10 @@
 import fs from 'fs-extra'
 import path from 'pathe'
 import { expect, test } from 'vitest'
-import { createUpdate, waitForInnerHtml } from '../helpers'
+import { createUpdate } from '../helpers'
 import { serve } from '../runners'
 
-test('content script uses native Vite HMR over WebSocket', async () => {
+test('liveReload false disables native content script HMR accept', async () => {
   const src = path.join(__dirname, 'src')
   const src1 = path.join(__dirname, 'src1')
   const src2 = path.join(__dirname, 'src2')
@@ -34,14 +34,7 @@ test('content script uses native Vite HMR over WebSocket', async () => {
   expect(await app.textContent()).toBe('one')
 
   await update('content.js')
+  await new Promise((resolve) => setTimeout(resolve, 2000))
 
-  try {
-    await waitForInnerHtml(app, (html) => html.includes('two'))
-  } catch (error) {
-    throw new Error(
-      `${error}\n\nCurrent text: ${await app.textContent()}\n\nBrowser messages:\n${messages.join(
-        '\n',
-      )}`,
-    )
-  }
+  expect(await app.textContent()).toBe('one')
 })

--- a/packages/vite-plugin/tests/e2e/mv3-vite-native-content-script-hmr-disabled/vite.config.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-native-content-script-hmr-disabled/vite.config.ts
@@ -1,0 +1,16 @@
+import { crx } from '../../plugin-testOptionsProvider'
+import { defineConfig } from 'vite'
+import manifest from './manifest.json'
+
+export default defineConfig({
+  build: { minify: false },
+  clearScreen: false,
+  logLevel: 'error',
+  plugins: [
+    crx({
+      manifest,
+      contentScripts: { hmr: 'native' },
+      liveReload: false,
+    }),
+  ],
+})

--- a/packages/vite-plugin/tests/e2e/mv3-vite-native-content-script-hmr/manifest.json
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-native-content-script-hmr/manifest.json
@@ -1,0 +1,12 @@
+{
+  "description": "test extension",
+  "manifest_version": 3,
+  "name": "test extension",
+  "content_scripts": [
+    {
+      "matches": ["https://example.com/*"],
+      "js": ["src/content.js"]
+    }
+  ],
+  "version": "1.0.0"
+}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-native-content-script-hmr/src1/content.js
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-native-content-script-hmr/src1/content.js
@@ -1,0 +1,17 @@
+const text = 'one'
+
+export function render() {
+  let app = document.querySelector('#native-hmr-app')
+  if (!app) {
+    app = document.createElement('div')
+    app.id = 'native-hmr-app'
+    document.body.append(app)
+  }
+  app.textContent = text
+}
+
+render()
+
+if (import.meta.hot) {
+  import.meta.hot.accept((mod) => mod?.render())
+}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-native-content-script-hmr/src2/content.js
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-native-content-script-hmr/src2/content.js
@@ -1,0 +1,17 @@
+const text = 'two'
+
+export function render() {
+  let app = document.querySelector('#native-hmr-app')
+  if (!app) {
+    app = document.createElement('div')
+    app.id = 'native-hmr-app'
+    document.body.append(app)
+  }
+  app.textContent = text
+}
+
+render()
+
+if (import.meta.hot) {
+  import.meta.hot.accept((mod) => mod?.render())
+}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-native-content-script-hmr/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-native-content-script-hmr/vite-serve.test.ts
@@ -1,0 +1,47 @@
+import fs from 'fs-extra'
+import path from 'pathe'
+import { expect, test } from 'vitest'
+import { createUpdate, waitForInnerHtml } from '../helpers'
+import { serve } from '../runners'
+
+test('content script uses native Vite HMR over WebSocket', async () => {
+  const src = path.join(__dirname, 'src')
+  const src1 = path.join(__dirname, 'src1')
+  const src2 = path.join(__dirname, 'src2')
+
+  await fs.remove(src)
+  await fs.copy(src1, src, { recursive: true })
+
+  const { browser } = await serve(__dirname)
+  const page = await browser.newPage()
+  const app = page.locator('#native-hmr-app')
+  const update = createUpdate({ target: src, src: src2 })
+  const messages: string[] = []
+
+  page.on('console', (message) => {
+    messages.push(`${message.type()}: ${message.text()}`)
+  })
+  page.on('pageerror', (error) => {
+    messages.push(`pageerror: ${error.message}`)
+  })
+
+  await page.goto('https://example.com')
+  try {
+    await app.waitFor({ timeout: 5000 })
+  } catch (error) {
+    throw new Error(`${error}\n\nBrowser messages:\n${messages.join('\n')}`)
+  }
+  expect(await app.textContent()).toBe('one')
+
+  await update('content.js')
+
+  try {
+    await waitForInnerHtml(app, (html) => html.includes('two'))
+  } catch (error) {
+    throw new Error(
+      `${error}\n\nCurrent text: ${await app.textContent()}\n\nBrowser messages:\n${messages.join(
+        '\n',
+      )}`,
+    )
+  }
+})

--- a/packages/vite-plugin/tests/e2e/mv3-vite-native-content-script-hmr/vite.config.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-native-content-script-hmr/vite.config.ts
@@ -1,0 +1,10 @@
+import { crx } from '../../plugin-testOptionsProvider'
+import { defineConfig } from 'vite'
+import manifest from './manifest.json'
+
+export default defineConfig({
+  build: { minify: false },
+  clearScreen: false,
+  logLevel: 'error',
+  plugins: [crx({ manifest, contentScripts: { hmr: 'native' } })],
+})

--- a/packages/vite-plugin/tests/e2e/mv3-vite-react-content-script-hmr/vite.config.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-react-content-script-hmr/vite.config.ts
@@ -9,5 +9,8 @@ export default defineConfig({
   build: { minify: false },
   clearScreen: false,
   logLevel: 'error',
-  plugins: [crx({ manifest, contentScripts: { preambleCode } }), react()],
+  plugins: [
+    crx({ manifest, contentScripts: { preambleCode, hmr: 'native' } }),
+    react(),
+  ],
 })

--- a/packages/vite-plugin/tests/e2e/mv3-vite-svelte-content-script-hmr/vite.config.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-svelte-content-script-hmr/vite.config.ts
@@ -17,5 +17,5 @@ export default defineConfig({
   },
   clearScreen: false,
   logLevel: 'error',
-  plugins: [crx({ manifest }), svelte()],
+  plugins: [crx({ manifest, contentScripts: { hmr: 'native' } }), svelte()],
 })

--- a/packages/vite-plugin/tests/e2e/mv3-vite-vanilla-content-script-hmr/vite.config.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-vanilla-content-script-hmr/vite.config.ts
@@ -6,5 +6,5 @@ export default defineConfig({
   build: { minify: false },
   clearScreen: false,
   logLevel: 'error',
-  plugins: [crx({ manifest })],
+  plugins: [crx({ manifest, contentScripts: { hmr: 'native' } })],
 })

--- a/packages/vite-plugin/tests/e2e/mv3-vite-vanilla-content-script-seq-hmr/vite.config.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-vanilla-content-script-seq-hmr/vite.config.ts
@@ -18,5 +18,5 @@ export default defineConfig({
   build: { minify: false },
   clearScreen: false,
   logLevel: 'error',
-  plugins: [crx({ manifest })],
+  plugins: [crx({ manifest, contentScripts: { hmr: 'native' } })],
 })

--- a/packages/vite-plugin/tests/e2e/mv3-vite-vue-content-script-hmr/vite.config.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-vue-content-script-hmr/vite.config.ts
@@ -5,5 +5,5 @@ import manifest from './manifest.json'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue(), crx({ manifest })],
+  plugins: [vue(), crx({ manifest, contentScripts: { hmr: 'native' } })],
 })

--- a/packages/vite-plugin/tests/out/content-script-world-main-all-urls/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/content-script-world-main-all-urls/__snapshots__/serve.test.ts.snap
@@ -78,10 +78,11 @@ exports[`serve fs output > src/content.js-loader.js 1`] = `
           /* @vite-ignore */
           \\"\\"
         );
-      await import(
-        /* @vite-ignore */
-        \\"../vendor/vite-client.js\\"
-      );
+      if (\\"../vendor/vite-client.js\\")
+        await import(
+          /* @vite-ignore */
+          \\"../vendor/vite-client.js\\"
+        );
     } catch (error) {
       console.warn(\\"[crx] MAIN world HMR client failed to load\\", error);
     }

--- a/packages/vite-plugin/tests/out/content-script-world-main/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/content-script-world-main/__snapshots__/serve.test.ts.snap
@@ -83,10 +83,11 @@ exports[`serve fs output > src/content.js-loader.js 1`] = `
           /* @vite-ignore */
           \\"\\"
         );
-      await import(
-        /* @vite-ignore */
-        \\"../vendor/vite-client.js\\"
-      );
+      if (\\"../vendor/vite-client.js\\")
+        await import(
+          /* @vite-ignore */
+          \\"../vendor/vite-client.js\\"
+        );
     } catch (error) {
       console.warn(\\"[crx] MAIN world HMR client failed to load\\", error);
     }

--- a/packages/vite-plugin/tests/out/native-content-script-hmr-disabled/manifest.json
+++ b/packages/vite-plugin/tests/out/native-content-script-hmr-disabled/manifest.json
@@ -1,0 +1,12 @@
+{
+  "description": "test extension",
+  "manifest_version": 3,
+  "name": "Test Extension",
+  "content_scripts": [
+    {
+      "js": ["src/content.js"],
+      "matches": ["https://example.com/*"]
+    }
+  ],
+  "version": "1.0.0"
+}

--- a/packages/vite-plugin/tests/out/native-content-script-hmr-disabled/serve.test.ts
+++ b/packages/vite-plugin/tests/out/native-content-script-hmr-disabled/serve.test.ts
@@ -3,7 +3,7 @@ import path from 'pathe'
 import { serve } from 'tests/runners'
 import { expect, test } from 'vitest'
 
-test('serve native content script hmr output', async () => {
+test('liveReload false disables native content script hmr client', async () => {
   const result = await serve(__dirname)
   const files = await fs.readdir(path.join(result.outDir, 'src'))
   const manifest = await fs.readJson(path.join(result.outDir, 'manifest.json'))
@@ -12,11 +12,13 @@ test('serve native content script hmr output', async () => {
     'utf8',
   )
 
+  expect(result.config.server.hmr).toBe(false)
   expect(manifest.host_permissions).toContain('http://localhost/*')
   expect(manifest.content_scripts[0].js).toEqual(['src/content.js-loader.js'])
   expect(files).toContain('content.js-loader.js')
   expect(files).not.toContain('content.js.js')
   expect(loader).toMatch(/http:\/\/localhost:\d+/)
+  expect(loader).toContain('if (false)')
   expect(loader).toContain('/@vite/client')
   expect(loader).toContain('/src/content.js')
 })

--- a/packages/vite-plugin/tests/out/native-content-script-hmr-disabled/src/content.js
+++ b/packages/vite-plugin/tests/out/native-content-script-hmr-disabled/src/content.js
@@ -1,0 +1,4 @@
+const app = document.createElement('div')
+app.id = 'app'
+app.textContent = 'native hmr disabled'
+document.body.append(app)

--- a/packages/vite-plugin/tests/out/native-content-script-hmr-disabled/vite.config.ts
+++ b/packages/vite-plugin/tests/out/native-content-script-hmr-disabled/vite.config.ts
@@ -1,0 +1,15 @@
+import { crx } from '../../plugin-testOptionsProvider'
+import { defineConfig } from 'vite'
+import manifest from './manifest.json'
+
+export default defineConfig({
+  clearScreen: false,
+  logLevel: 'error',
+  plugins: [
+    crx({
+      manifest,
+      contentScripts: { hmr: 'native' },
+      liveReload: false,
+    }),
+  ],
+})

--- a/packages/vite-plugin/tests/out/native-content-script-hmr/manifest.json
+++ b/packages/vite-plugin/tests/out/native-content-script-hmr/manifest.json
@@ -1,0 +1,12 @@
+{
+  "description": "test extension",
+  "manifest_version": 3,
+  "name": "Test Extension",
+  "content_scripts": [
+    {
+      "js": ["src/content.js"],
+      "matches": ["https://example.com/*"]
+    }
+  ],
+  "version": "1.0.0"
+}

--- a/packages/vite-plugin/tests/out/native-content-script-hmr/serve.test.ts
+++ b/packages/vite-plugin/tests/out/native-content-script-hmr/serve.test.ts
@@ -1,0 +1,22 @@
+import fs from 'fs-extra'
+import path from 'pathe'
+import { serve } from 'tests/runners'
+import { expect, test } from 'vitest'
+
+test('serve native content script hmr output', async () => {
+  const result = await serve(__dirname)
+  const files = await fs.readdir(path.join(result.outDir, 'src'))
+  const manifest = await fs.readJson(path.join(result.outDir, 'manifest.json'))
+  const loader = await fs.readFile(
+    path.join(result.outDir, 'src/content.js-loader.js'),
+    'utf8',
+  )
+
+  expect(manifest.host_permissions).toContain('http://localhost/*')
+  expect(manifest.content_scripts[0].js).toEqual(['src/content.js-loader.js'])
+  expect(files).toContain('content.js-loader.js')
+  expect(files).not.toContain('content.js.js')
+  expect(loader).toContain('http://localhost:5200')
+  expect(loader).toContain('/@vite/client')
+  expect(loader).toContain('/src/content.js')
+})

--- a/packages/vite-plugin/tests/out/native-content-script-hmr/src/content.js
+++ b/packages/vite-plugin/tests/out/native-content-script-hmr/src/content.js
@@ -1,0 +1,4 @@
+const app = document.createElement('div')
+app.id = 'app'
+app.textContent = 'native hmr'
+document.body.append(app)

--- a/packages/vite-plugin/tests/out/native-content-script-hmr/vite.config.ts
+++ b/packages/vite-plugin/tests/out/native-content-script-hmr/vite.config.ts
@@ -1,0 +1,9 @@
+import { crx } from '../../plugin-testOptionsProvider'
+import { defineConfig } from 'vite'
+import manifest from './manifest.json'
+
+export default defineConfig({
+  clearScreen: false,
+  logLevel: 'error',
+  plugins: [crx({ manifest, contentScripts: { hmr: 'native' } })],
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17478,11 +17478,7 @@ snapshots:
       pretty-format: 26.6.2
       throat: 5.0.0
     transitivePeerDependencies:
-      - bufferutil
-      - canvas
       - supports-color
-      - ts-node
-      - utf-8-validate
 
   jest-jasmine2@27.5.1:
     dependencies:


### PR DESCRIPTION
## Summary

Adds an experimental `contentScripts.hmr: "native"` mode for module content scripts. In this mode, the dev content-script loader imports Vite's native HMR client and the content-script module directly from the Vite dev server instead of using CRXJS's transformed content-script module and custom HMR-port bridge.

This is a proof of concept for #993. It does not remove the existing file-writer path; the current behavior remains the default.

## Compatibility coverage

Native mode is enabled in these existing e2e fixtures as compatibility coverage:

- `mv3-vite-vanilla-content-script-hmr`
- `mv3-vite-vanilla-content-script-seq-hmr`
- `mv3-vite-react-content-script-hmr`
- `mv3-vite-svelte-content-script-hmr`
- `mv3-vite-vue-content-script-hmr`
- `mv3-content-script-manifest-css-hmr`

The dedicated native-mode fixture remains in place as a small direct proof that a content-script module can receive Vite HMR over WebSocket.

## Notes

Native mode still writes the extension shell needed for development, including `manifest.json`, loader files, public assets, HTML placeholders, and IIFE bundles where applicable. The reduction is specifically in the content-script HMR path: native mode no longer needs to write the transformed module content script or patched Vite client files for module content scripts.

The measurable value in this POC is architectural simplification rather than clear speed or memory wins. Small fixture timings and peak RSS were effectively similar between native and file-writer mode.

Some fixtures intentionally remain on file-writer mode because they either assert disk-written virtual CSS files or expose follow-up native-mode gaps:

- `mv3-vite-virtual-css-hmr`
- `mv3-vite-unocss-hmr`
- `mv3-vite-dynamic-content-script-hmr`
- `mv3-vite-react-content-script-seq-hmr`

## Validation

- `pnpm -C packages/vite-plugin run lint:types`
- `pnpm -C packages/vite-plugin exec vitest --run --mode unit src/node/plugin-extensionCors.test.ts`
- `pnpm -C packages/vite-plugin exec vitest --run --mode out tests/out/native-content-script-hmr/serve.test.ts`
- `pnpm -C packages/vite-plugin exec vitest --run --mode e2e tests/e2e/mv3-vite-native-content-script-hmr/vite-serve.test.ts`
- Sequential e2e run of the six existing native-enabled fixtures listed above
