### PR TITLE
Fix pnpm lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9095,6 +9095,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uvu@0.5.6:
@@ -12709,8 +12710,8 @@ snapshots:
   '@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.9)
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
@@ -14037,9 +14038,9 @@ snapshots:
     optionalDependencies:
       ajv: 8.18.0
 
-  ajv-formats@3.0.1(ajv@8.17.1):
+  ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
-      ajv: 8.17.1
+      ajv: 8.18.0
 
   ajv-keywords@3.5.2(ajv@6.12.6):
     dependencies:


### PR DESCRIPTION
## Summary

Fixes the broken pnpm lockfile by updating stale peer-resolution entries that still pointed at `ajv@8.17.1` after the workspace dependency moved to `ajv@8.18.0`.

## Root cause

The lockfile contained snapshot entries for `@modelcontextprotocol/sdk` and `ajv-formats` that referenced `ajv@8.17.1`, but there was no corresponding `ajv@8.17.1` package entry in `pnpm-lock.yaml`, causing frozen installs to fail with `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY`.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm install --frozen-lockfile --lockfile-only`
- `git diff --check`
