### PR TITLE
debug: Add file writer progress diagnostics

### DIFF
--- a/packages/vite-plugin/scripts/bench-ready-recompute.mjs
+++ b/packages/vite-plugin/scripts/bench-ready-recompute.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+import { performance } from 'node:perf_hooks'
+import {
+  debounceTime,
+  filter,
+  firstValueFrom,
+  map,
+  mergeMap,
+  of,
+  ReplaySubject,
+  share,
+  startWith,
+  Subject,
+  switchMap,
+  tap,
+} from 'rxjs'
+
+function parseArgs() {
+  const args = new Map()
+  for (const arg of process.argv.slice(2)) {
+    const [key, value = 'true'] = arg.replace(/^--/, '').split('=')
+    args.set(key, value)
+  }
+  return {
+    mode: args.get('mode') ?? 'old',
+    files: Number(args.get('files') ?? 803),
+    subscribers: Number(args.get('subscribers') ?? 4),
+    fileDelayMs: Number(args.get('file-delay-ms') ?? 20),
+    emitIntervalMs: Number(args.get('emit-interval-ms') ?? 0),
+    debounceMs: Number(args.get('debounce-ms') ?? 100),
+    depsPerFile: Number(args.get('deps-per-file') ?? 0),
+  }
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+class OutputFilesMap extends Map {
+  change$ = new Subject()
+
+  set(key, value) {
+    const result = super.set(key, value)
+    this.change$.next({ type: 'set', key })
+    return result
+  }
+}
+
+async function createFiles(outputFiles, options, metrics) {
+  for (let i = 0; i < options.files; i += 1) {
+    const deps = []
+    for (let depOffset = 1; depOffset <= options.depsPerFile; depOffset += 1) {
+      const dep = outputFiles.get(`file-${i - depOffset}`)
+      if (dep) deps.push(dep)
+    }
+
+    const file = {
+      fileName: `file-${i}`,
+      file: sleep(options.fileDelayMs).then(() => ({ deps })),
+    }
+
+    outputFiles.set(file.fileName, file)
+    metrics.filesCreated += 1
+
+    if (options.emitIntervalMs > 0) await sleep(options.emitIntervalMs)
+  }
+}
+
+function createOldReadyStream({ buildEnd$, outputFiles, metrics }) {
+  return buildEnd$.pipe(
+    switchMap(() => outputFiles.change$.pipe(startWith({ type: 'start' }))),
+    map(() => [...outputFiles.values()]),
+    switchMap(async (files) => {
+      metrics.generations += 1
+      metrics.fileChecks += files.length
+      return Promise.allSettled(files.map(({ file }) => file))
+    }),
+  )
+}
+
+function createOldRecursiveReadyStream({ buildEnd$, outputFiles, metrics }) {
+  return buildEnd$.pipe(
+    switchMap(() => outputFiles.change$.pipe(startWith({ type: 'start' }))),
+    map(() => [...outputFiles.values()]),
+    switchMap(async (files) => {
+      metrics.generations += 1
+      metrics.fileChecks += files.length
+      return Promise.allSettled(files.map((file) => waitForOutputFile(file, metrics)))
+    }),
+  )
+}
+
+function createFixedReadyStream({ buildEnd$, outputFiles, metrics, options }) {
+  let currentGeneration = 0
+  let completedGeneration = 0
+  let lastResults
+
+  const state$ = buildEnd$.pipe(
+    switchMap(() =>
+      outputFiles.change$.pipe(
+        startWith({ type: 'start' }),
+        debounceTime(options.debounceMs),
+      ),
+    ),
+    map(() => ({
+      generation: ++currentGeneration,
+      files: [...outputFiles.values()],
+    })),
+    switchMap(async ({ generation, files }) => {
+      metrics.generations += 1
+      metrics.fileChecks += files.length
+      const seen = new Set()
+      const results = await Promise.allSettled(
+        files.map((file) => waitForOutputFile(file, metrics, seen)),
+      )
+      return { generation, results }
+    }),
+    tap(({ generation, results }) => {
+      completedGeneration = generation
+      lastResults = results
+    }),
+    share(),
+  )
+
+  return {
+    allFilesReady$: state$.pipe(map(({ results }) => results)),
+    async allFilesReady() {
+      const targetGeneration = currentGeneration
+      if (lastResults && completedGeneration >= targetGeneration) {
+        return lastResults
+      }
+      const { results } = await firstValueFrom(
+        state$.pipe(filter(({ generation }) => generation >= targetGeneration)),
+      )
+      return results
+    },
+  }
+}
+
+async function waitForOutputFile(file, metrics, seen = new Set()) {
+  if (seen.has(file)) return
+  seen.add(file)
+  metrics.fileChecks += 1
+  const { deps } = await file.file
+  await Promise.all(deps.map((dep) => waitForOutputFile(dep, metrics, seen)))
+}
+
+async function run() {
+  const options = parseArgs()
+  if (!['old', 'old-recursive', 'fixed'].includes(options.mode)) {
+    throw new Error(`Unknown mode: ${options.mode}`)
+  }
+
+  const outputFiles = new OutputFilesMap()
+  const buildEnd$ = new ReplaySubject(1)
+  const metrics = {
+    mode: options.mode,
+    filesCreated: 0,
+    generations: 0,
+    fileChecks: 0,
+    subscribers: options.subscribers,
+  }
+
+  const ready =
+    options.mode === 'old'
+      ? { allFilesReady$: createOldReadyStream({ buildEnd$, outputFiles, metrics }) }
+      : options.mode === 'old-recursive'
+        ? {
+            allFilesReady$: createOldRecursiveReadyStream({
+              buildEnd$,
+              outputFiles,
+              metrics,
+            }),
+          }
+      : createFixedReadyStream({ buildEnd$, outputFiles, metrics, options })
+
+  const start = performance.now()
+
+  const subscriptions = []
+  const subscriberPromises = []
+  for (let i = 0; i < options.subscribers - 1; i += 1) {
+    subscriberPromises.push(firstValueFrom(ready.allFilesReady$))
+  }
+
+  // Match the plugin's long-lived timestamp/error subscribers.
+  subscriptions.push(
+    ready.allFilesReady$.pipe(mergeMap((results) => of(results.length))).subscribe(),
+  )
+
+  buildEnd$.next({ type: 'build_end' })
+
+  const createPromise = createFiles(outputFiles, options, metrics)
+  const explicitReadyPromise =
+    options.mode === 'fixed'
+      ? ready.allFilesReady()
+      : firstValueFrom(ready.allFilesReady$)
+
+  await createPromise
+  await Promise.all([...subscriberPromises, explicitReadyPromise])
+
+  const elapsedMs = performance.now() - start
+  for (const subscription of subscriptions) subscription.unsubscribe()
+
+  const result = {
+    ...metrics,
+    elapsedMs: Math.round(elapsedMs),
+    files: options.files,
+    depsPerFile: options.depsPerFile,
+    fileDelayMs: options.fileDelayMs,
+    emitIntervalMs: options.emitIntervalMs,
+    debounceMs: options.mode === 'fixed' ? options.debounceMs : 0,
+  }
+  console.log(JSON.stringify(result))
+}
+
+run().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/packages/vite-plugin/scripts/bench-ready-recompute.mjs
+++ b/packages/vite-plugin/scripts/bench-ready-recompute.mjs
@@ -15,20 +15,89 @@ import {
   tap,
 } from 'rxjs'
 
+const presets = {
+  quick: {
+    files: 220,
+    subscribers: 4,
+    fileDelayMs: 10,
+    emitIntervalMs: 0,
+    debounceMs: 100,
+    depsPerFile: 3,
+  },
+  'startup-lag': {
+    files: 375,
+    subscribers: 4,
+    fileDelayMs: 10,
+    emitIntervalMs: 0,
+    debounceMs: 100,
+    depsPerFile: 3,
+  },
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/bench-ready-recompute.mjs --mode=<old|old-recursive|fixed> [options]
+
+Presets:
+  --preset=quick        Multi-second recursive readiness storm.
+  --preset=startup-lag  30s-class recursive readiness storm.
+
+Options:
+  --files=<n>
+  --subscribers=<n>
+  --file-delay-ms=<n>
+  --emit-interval-ms=<n>
+  --debounce-ms=<n>
+  --deps-per-file=<n>
+
+Hyperfine startup-lag comparison:
+  hyperfine --runs 3 \\
+    'node scripts/bench-ready-recompute.mjs --preset=startup-lag --mode=old-recursive' \\
+    'node scripts/bench-ready-recompute.mjs --preset=startup-lag --mode=fixed'
+`)
+}
+
 function parseArgs() {
   const args = new Map()
   for (const arg of process.argv.slice(2)) {
     const [key, value = 'true'] = arg.replace(/^--/, '').split('=')
     args.set(key, value)
   }
+
+  if (args.has('help') || args.has('h')) {
+    printHelp()
+    process.exit(0)
+  }
+
+  const preset = args.get('preset')
+  const presetOptions = typeof preset === 'undefined' ? {} : presets[preset]
+  if (typeof preset !== 'undefined' && typeof presetOptions === 'undefined') {
+    throw new Error(
+      `Unknown preset: ${preset}. Expected one of: ${Object.keys(presets).join(
+        ', ',
+      )}`,
+    )
+  }
+
   return {
+    preset: preset ?? 'custom',
     mode: args.get('mode') ?? 'old',
-    files: Number(args.get('files') ?? 803),
-    subscribers: Number(args.get('subscribers') ?? 4),
-    fileDelayMs: Number(args.get('file-delay-ms') ?? 20),
-    emitIntervalMs: Number(args.get('emit-interval-ms') ?? 0),
-    debounceMs: Number(args.get('debounce-ms') ?? 100),
-    depsPerFile: Number(args.get('deps-per-file') ?? 0),
+    files: Number(args.get('files') ?? presetOptions.files ?? 803),
+    subscribers: Number(
+      args.get('subscribers') ?? presetOptions.subscribers ?? 4,
+    ),
+    fileDelayMs: Number(
+      args.get('file-delay-ms') ?? presetOptions.fileDelayMs ?? 20,
+    ),
+    emitIntervalMs: Number(
+      args.get('emit-interval-ms') ?? presetOptions.emitIntervalMs ?? 0,
+    ),
+    debounceMs: Number(
+      args.get('debounce-ms') ?? presetOptions.debounceMs ?? 100,
+    ),
+    depsPerFile: Number(
+      args.get('deps-per-file') ?? presetOptions.depsPerFile ?? 0,
+    ),
   }
 }
 
@@ -85,7 +154,9 @@ function createOldRecursiveReadyStream({ buildEnd$, outputFiles, metrics }) {
     switchMap(async (files) => {
       metrics.generations += 1
       metrics.fileChecks += files.length
-      return Promise.allSettled(files.map((file) => waitForOutputFile(file, metrics)))
+      return Promise.allSettled(
+        files.map((file) => waitForOutputFile(file, metrics)),
+      )
     }),
   )
 }
@@ -163,15 +234,21 @@ async function run() {
 
   const ready =
     options.mode === 'old'
-      ? { allFilesReady$: createOldReadyStream({ buildEnd$, outputFiles, metrics }) }
+      ? {
+          allFilesReady$: createOldReadyStream({
+            buildEnd$,
+            outputFiles,
+            metrics,
+          }),
+        }
       : options.mode === 'old-recursive'
-        ? {
-            allFilesReady$: createOldRecursiveReadyStream({
-              buildEnd$,
-              outputFiles,
-              metrics,
-            }),
-          }
+      ? {
+          allFilesReady$: createOldRecursiveReadyStream({
+            buildEnd$,
+            outputFiles,
+            metrics,
+          }),
+        }
       : createFixedReadyStream({ buildEnd$, outputFiles, metrics, options })
 
   const start = performance.now()
@@ -184,7 +261,9 @@ async function run() {
 
   // Match the plugin's long-lived timestamp/error subscribers.
   subscriptions.push(
-    ready.allFilesReady$.pipe(mergeMap((results) => of(results.length))).subscribe(),
+    ready.allFilesReady$
+      .pipe(mergeMap((results) => of(results.length)))
+      .subscribe(),
   )
 
   buildEnd$.next({ type: 'build_end' })
@@ -203,6 +282,7 @@ async function run() {
 
   const result = {
     ...metrics,
+    preset: options.preset,
     elapsedMs: Math.round(elapsedMs),
     files: options.files,
     depsPerFile: options.depsPerFile,

--- a/packages/vite-plugin/src/node/fileWriter-hmr.ts
+++ b/packages/vite-plugin/src/node/fileWriter-hmr.ts
@@ -1,7 +1,6 @@
 import {
   buffer,
   filter,
-  firstValueFrom,
   map,
   mergeMap,
   Observable,
@@ -14,7 +13,7 @@ import {
   PrunePayload,
   UpdatePayload,
 } from 'vite'
-import { update } from './fileWriter'
+import { allFilesReady, update } from './fileWriter'
 import { allFilesReady$ } from './fileWriter-rxjs'
 import { getFileName, getViteUrl, prefix } from './fileWriter-utilities'
 import { _debug } from './helpers'
@@ -113,7 +112,7 @@ export async function prepareVitePayloadForCrx(
       return update(id).map((file) => file.file)
     })
     await Promise.all(pendingFiles)
-    await firstValueFrom(allFilesReady$)
+    await allFilesReady()
   }
 
   return mapVitePayloadForCrx(p)

--- a/packages/vite-plugin/src/node/fileWriter-rxjs.test.ts
+++ b/packages/vite-plugin/src/node/fileWriter-rxjs.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, expect, test } from 'vitest'
+import { firstValueFrom } from 'rxjs'
+import { outputFiles, type OutputFile } from './fileWriter-filesMap'
+import { allFilesReady$, fileWriterEvent$ } from './fileWriter-rxjs'
+
+afterEach(() => {
+  outputFiles.clear()
+})
+
+test('shares allFilesReady work across subscribers', async () => {
+  let awaits = 0
+  const file = {
+    id: '/src/content.ts',
+    type: 'module',
+    fileName: 'src/content.ts.js',
+    file: {
+      then(resolve: (value: { deps: OutputFile[] }) => void) {
+        awaits += 1
+        return Promise.resolve({ deps: [] }).then(resolve)
+      },
+    },
+  } as OutputFile
+
+  outputFiles.set(file.fileName, file)
+
+  const first = firstValueFrom(allFilesReady$)
+  const second = firstValueFrom(allFilesReady$)
+
+  fileWriterEvent$.next({ type: 'build_end' })
+
+  await Promise.all([first, second])
+
+  expect(awaits).toBe(1)
+})
+
+test('deduplicates dependency traversal within an allFilesReady generation', async () => {
+  let sharedDepAwaits = 0
+
+  const sharedDep = {
+    id: '/src/shared.ts',
+    type: 'module',
+    fileName: 'src/shared.ts.js',
+    file: {
+      then(resolve: (value: { deps: OutputFile[] }) => void) {
+        sharedDepAwaits += 1
+        return Promise.resolve({ deps: [] }).then(resolve)
+      },
+    },
+  } as OutputFile
+
+  const firstRoot = {
+    id: '/src/content-a.ts',
+    type: 'module',
+    fileName: 'src/content-a.ts.js',
+    file: Promise.resolve({ deps: [sharedDep] }),
+  } as OutputFile
+
+  const secondRoot = {
+    id: '/src/content-b.ts',
+    type: 'module',
+    fileName: 'src/content-b.ts.js',
+    file: Promise.resolve({ deps: [sharedDep] }),
+  } as OutputFile
+
+  outputFiles.set(sharedDep.fileName, sharedDep)
+  outputFiles.set(firstRoot.fileName, firstRoot)
+  outputFiles.set(secondRoot.fileName, secondRoot)
+
+  const ready = firstValueFrom(allFilesReady$)
+  fileWriterEvent$.next({ type: 'build_end' })
+
+  await ready
+
+  expect(sharedDepAwaits).toBe(1)
+})

--- a/packages/vite-plugin/src/node/fileWriter-rxjs.ts
+++ b/packages/vite-plugin/src/node/fileWriter-rxjs.ts
@@ -33,6 +33,7 @@ import convertSourceMap from 'convert-source-map'
 
 const { outputFile } = fsx
 const perfDebug = _debug('file-writer').extend('perf')
+const progressDebug = _debug('file-writer').extend('progress')
 
 function readIntegerEnv(name: string, fallback: number) {
   const value = process.env[name]
@@ -49,9 +50,95 @@ const readyDebounceMs = Math.max(
   0,
   readIntegerEnv('CRX_FILE_WRITER_READY_DEBOUNCE_MS', 100),
 )
+const progressIntervalMs = Math.max(
+  250,
+  readIntegerEnv('CRX_FILE_WRITER_PROGRESS_INTERVAL_MS', 1000),
+)
 
 function shouldLogPerf(ms: number) {
   return perfThresholdMs === 0 || ms >= perfThresholdMs
+}
+
+function formatDurationSeconds(seconds: number) {
+  if (!Number.isFinite(seconds)) return 'unknown'
+  if (seconds < 10) return `${seconds.toFixed(1)}s`
+  return `${Math.round(seconds)}s`
+}
+
+interface ReadyProgressStats {
+  generation: number
+  startTime: number
+  initialFiles: number
+  totalFiles: number
+  seenFiles: number
+  completedFiles: number
+  activeFiles: number
+  rejectedFiles: number
+}
+
+function updateReadyTotal(stats: ReadyProgressStats, seen: Set<OutputFile>) {
+  stats.seenFiles = seen.size
+  stats.totalFiles = Math.max(stats.totalFiles, outputFiles.size, seen.size)
+}
+
+function logReadyProgress(stats: ReadyProgressStats, phase: string) {
+  const elapsedSeconds = Math.max(
+    (performance.now() - stats.startTime) / 1000,
+    0.001,
+  )
+  const totalFiles = Math.max(
+    stats.totalFiles,
+    stats.initialFiles,
+    outputFiles.size,
+  )
+  const percent =
+    totalFiles > 0
+      ? Math.min(100, (stats.completedFiles / totalFiles) * 100)
+      : 0
+  const filesPerSecond = stats.completedFiles / elapsedSeconds
+  const remainingFiles = Math.max(totalFiles - stats.completedFiles, 0)
+  const etaSeconds =
+    filesPerSecond > 0 && remainingFiles > 0
+      ? remainingFiles / filesPerSecond
+      : 0
+
+  progressDebug(
+    'ready phase=%s generation=%d files=%d/%d discovered pct=%s seen=%d active=%d rejected=%d rate=%s/s eta=%s elapsed=%s',
+    phase,
+    stats.generation,
+    stats.completedFiles,
+    totalFiles,
+    `${percent.toFixed(1)}%`,
+    stats.seenFiles,
+    stats.activeFiles,
+    stats.rejectedFiles,
+    filesPerSecond.toFixed(1),
+    formatDurationSeconds(etaSeconds),
+    formatDurationSeconds(elapsedSeconds),
+  )
+}
+
+function startReadyProgressTimer(stats: ReadyProgressStats) {
+  if (!progressDebug.enabled) return
+  let logged = false
+  let stopped = false
+  const timer = setInterval(() => {
+    if (stats.generation !== currentAllFilesReadyGeneration) {
+      stopped = true
+      clearInterval(timer)
+      return
+    }
+    logged = true
+    logReadyProgress(stats, 'waiting')
+  }, progressIntervalMs)
+  timer.unref?.()
+  return (phase: string) => {
+    if (stopped) return
+    stopped = true
+    clearInterval(timer)
+    if (stats.generation === currentAllFilesReadyGeneration && logged)
+      logReadyProgress(stats, phase)
+  }
 }
 
 const getIifeGlobalName = (fileName: string) => {
@@ -136,9 +223,23 @@ const allFilesReadyState$ = buildEnd$.pipe(
   switchMap(async ({ generation, files }) => {
     const start = performance.now()
     const seen = new Set<OutputFile>()
+    const stats = progressDebug.enabled
+      ? {
+          generation,
+          startTime: start,
+          initialFiles: files.length,
+          totalFiles: files.length,
+          seenFiles: 0,
+          completedFiles: 0,
+          activeFiles: 0,
+          rejectedFiles: 0,
+        }
+      : undefined
+    const stopProgress = stats && startReadyProgressTimer(stats)
     const results = await Promise.allSettled(
-      files.map((file) => waitForOutputFile(file, seen)),
+      files.map((file) => waitForOutputFile(file, seen, stats)),
     )
+    if (stats) stats.rejectedFiles = results.filter(isRejected).length
     const totalMs = performance.now() - start
     if (shouldLogPerf(totalMs)) {
       perfDebug(
@@ -149,6 +250,7 @@ const allFilesReadyState$ = buildEnd$.pipe(
         results.filter(isRejected).length,
       )
     }
+    stopProgress?.('ready')
     return { generation, results }
   }),
   tap(({ generation, results }) => {
@@ -165,11 +267,25 @@ export const allFilesReady$ = allFilesReadyState$.pipe(
 async function waitForOutputFile(
   file: OutputFile,
   seen = new Set<OutputFile>(),
+  stats?: ReadyProgressStats,
 ): Promise<void> {
   if (seen.has(file)) return
   seen.add(file)
-  const { deps } = await file.file
-  await Promise.all(deps.map((dep) => waitForOutputFile(dep, seen)))
+  if (stats) {
+    stats.activeFiles += 1
+    updateReadyTotal(stats, seen)
+  }
+  try {
+    const { deps } = await file.file
+    if (stats) updateReadyTotal(stats, seen)
+    await Promise.all(deps.map((dep) => waitForOutputFile(dep, seen, stats)))
+  } finally {
+    if (stats) {
+      stats.activeFiles -= 1
+      stats.completedFiles += 1
+      updateReadyTotal(stats, seen)
+    }
+  }
 }
 
 const timestamp$ = new BehaviorSubject(Date.now())

--- a/packages/vite-plugin/src/node/fileWriter-rxjs.ts
+++ b/packages/vite-plugin/src/node/fileWriter-rxjs.ts
@@ -1,10 +1,12 @@
 import * as lexer from 'es-module-lexer'
 import fsx from 'fs-extra'
 import { readFile } from 'fs/promises'
+import { performance } from 'perf_hooks'
 import MagicString from 'magic-string'
 import { OutputAsset, OutputChunk } from 'rollup'
 import {
   BehaviorSubject,
+  debounceTime,
   filter,
   first,
   firstValueFrom,
@@ -14,19 +16,43 @@ import {
   of,
   ReplaySubject,
   retry,
+  share,
   startWith,
   switchMap,
   takeUntil,
+  tap,
   toArray,
 } from 'rxjs'
 import { build as viteBuild, ErrorPayload, ViteDevServer } from 'vite'
 import { OutputFile, outputFiles } from './fileWriter-filesMap'
 import { getFileName, getOutputPath, getViteUrl } from './fileWriter-utilities'
+import { _debug } from './helpers'
 import { join } from './path'
 import { CrxDevAssetId, CrxDevScriptId, CrxPlugin } from './types'
 import convertSourceMap from 'convert-source-map'
 
 const { outputFile } = fsx
+const perfDebug = _debug('file-writer').extend('perf')
+
+function readIntegerEnv(name: string, fallback: number) {
+  const value = process.env[name]
+  if (!value) return fallback
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+
+const perfThresholdMs = Math.max(
+  0,
+  readIntegerEnv('CRX_FILE_WRITER_PERF_THRESHOLD_MS', 250),
+)
+const readyDebounceMs = Math.max(
+  0,
+  readIntegerEnv('CRX_FILE_WRITER_READY_DEBOUNCE_MS', 100),
+)
+
+function shouldLogPerf(ms: number) {
+  return perfThresholdMs === 0 || ms >= perfThresholdMs
+}
 
 const getIifeGlobalName = (fileName: string) => {
   const base = fileName.split('/').pop() ?? fileName
@@ -91,13 +117,49 @@ export const buildStart$ = fileWriterEvent$.pipe(
   switchMap((e) => of(e)),
 )
 
+let currentAllFilesReadyGeneration = 0
+let completedAllFilesReadyGeneration = 0
+let lastAllFilesReadyResults: PromiseSettledResult<void>[] | undefined
+
 /** Emit when all script files are written */
-export const allFilesReady$ = buildEnd$.pipe(
-  switchMap(() => outputFiles.change$.pipe(startWith({ type: 'start' }))),
-  map(() => [...outputFiles.values()]),
-  switchMap((files) =>
-    Promise.allSettled(files.map((file) => waitForOutputFile(file))),
+const allFilesReadyState$ = buildEnd$.pipe(
+  switchMap(() =>
+    outputFiles.change$.pipe(
+      startWith({ type: 'start' }),
+      debounceTime(readyDebounceMs),
+    ),
   ),
+  map(() => ({
+    generation: ++currentAllFilesReadyGeneration,
+    files: [...outputFiles.values()],
+  })),
+  switchMap(async ({ generation, files }) => {
+    const start = performance.now()
+    const seen = new Set<OutputFile>()
+    const results = await Promise.allSettled(
+      files.map((file) => waitForOutputFile(file, seen)),
+    )
+    const totalMs = performance.now() - start
+    if (shouldLogPerf(totalMs)) {
+      perfDebug(
+        'ready generation: generation=%d files=%d ms=%d rejected=%d',
+        generation,
+        files.length,
+        Math.round(totalMs),
+        results.filter(isRejected).length,
+      )
+    }
+    return { generation, results }
+  }),
+  tap(({ generation, results }) => {
+    completedAllFilesReadyGeneration = generation
+    lastAllFilesReadyResults = results
+  }),
+  share(),
+)
+
+export const allFilesReady$ = allFilesReadyState$.pipe(
+  map(({ results }) => results),
 )
 
 async function waitForOutputFile(
@@ -185,10 +247,35 @@ function prepScript(
           const module = await server.moduleGraph.getModuleByUrl(originalViteUrl)
           if (module) server.moduleGraph.invalidateModule(module)
         }
-        const transformResult = await server.transformRequest(viteUrl)
+        const transformStart = performance.now()
+        let transformResult: Awaited<
+          ReturnType<typeof server.transformRequest>
+        >
+        try {
+          transformResult = await server.transformRequest(viteUrl)
+        } catch (error) {
+          perfDebug(
+            'transform failed: id=%s url=%s ms=%d',
+            script.id,
+            viteUrl,
+            Math.round(performance.now() - transformStart),
+          )
+          throw error
+        }
         if (!transformResult)
           throw new TypeError(`Unable to load "${script.id}" from server.`)
         const { deps = [], dynamicDeps = [], map } = transformResult
+        const transformMs = performance.now() - transformStart
+        if (shouldLogPerf(transformMs)) {
+          perfDebug(
+            'transform: id=%s url=%s ms=%d deps=%d dynamicDeps=%d',
+            script.id,
+            viteUrl,
+            Math.round(transformMs),
+            deps.length,
+            dynamicDeps.length,
+          )
+        }
         let { code } = transformResult
         try {
           if (map && server.config.build.sourcemap === 'inline') {
@@ -254,6 +341,7 @@ async function bundleIife(
   // Use Vite's build API instead of raw Rollup to avoid plugin compatibility issues
   // (Vite 6+ plugins are tracked in WeakMaps and can't be reused in separate Rollup builds)
   // We use configFile: false to avoid loading user's config which may have incompatible settings
+  const buildStart = performance.now()
   const result = await viteBuild({
     root: server.config.root,
     mode: server.config.mode,
@@ -282,6 +370,16 @@ async function bundleIife(
       copyPublicDir: false,
     },
   })
+  const buildMs = performance.now() - buildStart
+  if (shouldLogPerf(buildMs)) {
+    perfDebug(
+      'iife build: id=%s input=%s fileName=%s ms=%d',
+      script.id,
+      input,
+      fileName,
+      Math.round(buildMs),
+    )
+  }
 
   // viteBuild with write: false returns RollupOutput or RollupOutput[]
   const outputs = Array.isArray(result) ? result : [result]
@@ -363,13 +461,32 @@ function prepIifeScript(
 }
 
 /** Resolves when all existing files in scriptFiles are written. */
+async function waitForAllFilesReadyResults(): Promise<
+  PromiseSettledResult<void>[]
+> {
+  const targetGeneration = currentAllFilesReadyGeneration
+  if (
+    lastAllFilesReadyResults &&
+    completedAllFilesReadyGeneration >= targetGeneration
+  ) {
+    return lastAllFilesReadyResults
+  }
+
+  const { results } = await firstValueFrom(
+    allFilesReadyState$.pipe(
+      filter(({ generation }) => generation >= targetGeneration),
+    ),
+  )
+  return results
+}
+
 export async function allFilesReady(): Promise<void> {
-  await firstValueFrom(allFilesReady$)
+  await waitForAllFilesReadyResults()
 }
 
 /** Resolves when all existing files in scriptFiles are written. */
 export async function allFilesSuccess(): Promise<void> {
-  const result = await firstValueFrom(allFilesReady$)
+  const result = await waitForAllFilesReadyResults()
   const reason = result.find(isRejected)?.reason
   if (typeof reason === 'undefined') return
   if (reason instanceof Error) throw reason

--- a/packages/vite-plugin/src/node/fileWriter.ts
+++ b/packages/vite-plugin/src/node/fileWriter.ts
@@ -19,6 +19,7 @@ import {
   prefix,
 } from './fileWriter-utilities'
 import { _debug } from './helpers'
+import { isAbsolute, join } from './path'
 import { CrxDevAssetId, CrxDevScriptId, CrxPlugin } from './types'
 
 export { allFilesReady, fileReady }
@@ -26,6 +27,235 @@ export { allFilesReady, fileReady }
 const { outputFile } = fsx
 
 const debug = _debug('file-writer')
+const perfDebug = debug.extend('perf')
+const progressDebug = debug.extend('progress')
+function readIntegerEnv(name: string, fallback: number) {
+  const value = process.env[name]
+  if (!value) return fallback
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) ? parsed : fallback
+}
+const maxConcurrentWrites = Math.max(
+  1,
+  readIntegerEnv('CRX_FILE_WRITER_CONCURRENCY', 16),
+)
+const perfThresholdMs = Math.max(
+  0,
+  readIntegerEnv('CRX_FILE_WRITER_PERF_THRESHOLD_MS', 250),
+)
+const progressIntervalMs = Math.max(
+  250,
+  readIntegerEnv('CRX_FILE_WRITER_PROGRESS_INTERVAL_MS', 1000),
+)
+let activeWrites = 0
+const pendingWriteSlots: Array<() => void> = []
+
+interface WriterStats {
+  bytes: number
+  outputWrites: number
+  viteDepBytes: number
+  viteDepWrites: number
+  viteDepChunks: number
+  viteDepHashes: Set<string>
+  queuedWrites: number
+  maxQueueDepth: number
+  maxSlotWaitMs: number
+  maxSlotWaitId: string
+  maxOutputWriteMs: number
+  maxOutputWriteId: string
+  maxWriteMs: number
+  maxWriteId: string
+  writesCompleted: number
+}
+
+const writerStats: WriterStats = {
+  bytes: 0,
+  outputWrites: 0,
+  viteDepBytes: 0,
+  viteDepWrites: 0,
+  viteDepChunks: 0,
+  viteDepHashes: new Set(),
+  queuedWrites: 0,
+  maxQueueDepth: 0,
+  maxSlotWaitMs: 0,
+  maxSlotWaitId: '',
+  maxOutputWriteMs: 0,
+  maxOutputWriteId: '',
+  maxWriteMs: 0,
+  maxWriteId: '',
+  writesCompleted: 0,
+}
+
+function shouldLogPerf(ms: number) {
+  return perfThresholdMs === 0 || ms >= perfThresholdMs
+}
+
+function resetWriterStats() {
+  writerStats.bytes = 0
+  writerStats.outputWrites = 0
+  writerStats.viteDepBytes = 0
+  writerStats.viteDepWrites = 0
+  writerStats.viteDepChunks = 0
+  writerStats.viteDepHashes.clear()
+  writerStats.queuedWrites = 0
+  writerStats.maxQueueDepth = 0
+  writerStats.maxSlotWaitMs = 0
+  writerStats.maxSlotWaitId = ''
+  writerStats.maxOutputWriteMs = 0
+  writerStats.maxOutputWriteId = ''
+  writerStats.maxWriteMs = 0
+  writerStats.maxWriteId = ''
+  writerStats.writesCompleted = 0
+}
+
+function formatFileId(fileId: CrxDevAssetId | CrxDevScriptId) {
+  return `${fileId.type}:${fileId.id}`
+}
+
+function getViteDepHash(id: string) {
+  if (!id.includes('/node_modules/.vite/deps/')) return
+  return /[?&]v=([^&]+)/.exec(id)?.[1] ?? 'no-v'
+}
+
+function isViteDepChunk(id: string) {
+  return id.includes('/node_modules/.vite/deps/chunk-')
+}
+
+function formatBytes(bytes: number) {
+  if (bytes < 1024) return `${bytes}B`
+  const kib = bytes / 1024
+  if (kib < 1024) return `${kib.toFixed(1)}KiB`
+  return `${(kib / 1024).toFixed(1)}MiB`
+}
+
+function formatDurationSeconds(seconds: number) {
+  if (!Number.isFinite(seconds)) return 'unknown'
+  if (seconds < 10) return `${seconds.toFixed(1)}s`
+  return `${Math.round(seconds)}s`
+}
+
+function logProgress(startTime: number, phase: string) {
+  const elapsedSeconds = Math.max((performance.now() - startTime) / 1000, 0.001)
+  const discoveredFiles = outputFiles.size
+  const completedWrites = writerStats.writesCompleted
+  const percent =
+    discoveredFiles > 0
+      ? Math.min(100, (completedWrites / discoveredFiles) * 100)
+      : 0
+  const writesPerSecond = completedWrites / elapsedSeconds
+  const remainingWrites = Math.max(discoveredFiles - completedWrites, 0)
+  const etaSeconds =
+    writesPerSecond > 0 && remainingWrites > 0
+      ? remainingWrites / writesPerSecond
+      : 0
+
+  progressDebug(
+    'phase=%s files=%d/%d discovered pct=%s active=%d queued=%d bytes=%s viteDeps=%d chunks=%d rate=%s/s eta=%s elapsed=%s',
+    phase,
+    completedWrites,
+    discoveredFiles,
+    `${percent.toFixed(1)}%`,
+    activeWrites,
+    pendingWriteSlots.length,
+    formatBytes(writerStats.bytes),
+    writerStats.viteDepWrites,
+    writerStats.viteDepChunks,
+    writesPerSecond.toFixed(1),
+    formatDurationSeconds(etaSeconds),
+    formatDurationSeconds(elapsedSeconds),
+  )
+}
+
+function startProgressTimer(startTime: number, getPhase: () => string) {
+  if (!progressDebug.enabled) return
+  progressDebug(
+    'begin: interval=%dms note=%s',
+    progressIntervalMs,
+    'total is discovered files and may grow during graph discovery',
+  )
+  const timer = setInterval(
+    () => logProgress(startTime, getPhase()),
+    progressIntervalMs,
+  )
+  timer.unref?.()
+  return (phase = getPhase()) => {
+    clearInterval(timer)
+    logProgress(startTime, phase)
+  }
+}
+
+interface ViteDepsMetadata {
+  hash?: string
+  browserHash?: string
+  optimized?: Record<string, unknown>
+  chunks?: Record<string, unknown>
+}
+
+async function logViteDepsMetadata(server: ViteDevServer) {
+  const { cacheDir, root } = server.config
+  const metadataPath = join(
+    isAbsolute(cacheDir) ? cacheDir : join(root, cacheDir),
+    'deps',
+    '_metadata.json',
+  )
+  try {
+    const metadata = (await fsx.readJson(metadataPath)) as ViteDepsMetadata
+    perfDebug(
+      'vite deps metadata: hash=%s browserHash=%s optimized=%d chunks=%d path=%s',
+      metadata.hash ?? 'n/a',
+      metadata.browserHash ?? 'n/a',
+      Object.keys(metadata.optimized ?? {}).length,
+      Object.keys(metadata.chunks ?? {}).length,
+      metadataPath,
+    )
+  } catch (error) {
+    perfDebug(
+      'vite deps metadata: unavailable path=%s error=%s',
+      metadataPath,
+      error instanceof Error ? error.message : String(error),
+    )
+  }
+}
+
+async function withWriteSlot<T>(
+  fileId: CrxDevAssetId | CrxDevScriptId,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const queuedAt = performance.now()
+  const queuedDepth = pendingWriteSlots.length + 1
+  let waited = false
+  if (activeWrites >= maxConcurrentWrites) {
+    waited = true
+    writerStats.queuedWrites += 1
+    writerStats.maxQueueDepth = Math.max(writerStats.maxQueueDepth, queuedDepth)
+    await new Promise<void>((resolve) => pendingWriteSlots.push(resolve))
+  }
+
+  const waitMs = performance.now() - queuedAt
+  if (waited && waitMs > writerStats.maxSlotWaitMs) {
+    writerStats.maxSlotWaitMs = waitMs
+    writerStats.maxSlotWaitId = formatFileId(fileId)
+  }
+  if (waited && shouldLogPerf(waitMs)) {
+    perfDebug(
+      'slot wait: id=%s type=%s wait=%dms active=%d max=%d queued=%d',
+      fileId.id,
+      fileId.type,
+      Math.round(waitMs),
+      activeWrites,
+      maxConcurrentWrites,
+      queuedDepth,
+    )
+  }
+
+  activeWrites += 1
+  try {
+    return await fn()
+  } finally {
+    activeWrites -= 1
+    pendingWriteSlots.shift()?.()
+  }
+}
 
 function queueWrite(
   script: CrxDevAssetId | CrxDevScriptId,
@@ -52,12 +282,24 @@ export async function start({
 }: {
   server: ViteDevServer
 }): Promise<void> {
+  const startTime = performance.now()
+  let phase = 'base-build'
+  const stopProgress = startProgressTimer(startTime, () => phase)
+  resetWriterStats()
   serverEvent$.next({ type: 'start', server })
 
   const plugins = server.config.plugins.filter((p): p is CrxPlugin =>
     p.name?.startsWith('crx:'),
   )
   const { rollupOptions, outDir } = server.config.build
+  perfDebug(
+    'startup begin: concurrency=%d threshold=%dms root=%s outDir=%s',
+    maxConcurrentWrites,
+    perfThresholdMs,
+    server.config.root,
+    outDir,
+  )
+  await logViteDepsMetadata(server)
   const inputOptions: RollupOptions = {
     input: 'index.html',
     ...rollupOptions,
@@ -75,8 +317,42 @@ export async function start({
   const build = await rollup(inputOptions)
   await build.write(outputOptions)
   fileWriterEvent$.next({ type: 'build_end' })
+  phase = 'writing'
+  perfDebug(
+    'start: base build completed in %dms',
+    Math.round(performance.now() - startTime),
+  )
 
-  await allFilesReady()
+  try {
+    await allFilesReady()
+    phase = 'ready'
+  } finally {
+    stopProgress?.(phase)
+  }
+  perfDebug(
+    'start: all files ready in %dms files=%d',
+    Math.round(performance.now() - startTime),
+    outputFiles.size,
+  )
+  perfDebug(
+    'startup summary: files=%d writes=%d outputWrites=%d bytes=%d viteDepWrites=%d viteDepChunks=%d viteDepBytes=%d viteDepHashes=%s queuedWrites=%d maxQueueDepth=%d maxSlotWait=%dms maxSlotWaitId=%s maxWrite=%dms maxWriteId=%s maxOutputWrite=%dms maxOutputWriteId=%s',
+    outputFiles.size,
+    writerStats.writesCompleted,
+    writerStats.outputWrites,
+    writerStats.bytes,
+    writerStats.viteDepWrites,
+    writerStats.viteDepChunks,
+    writerStats.viteDepBytes,
+    [...writerStats.viteDepHashes].sort().join(',') || 'n/a',
+    writerStats.queuedWrites,
+    writerStats.maxQueueDepth,
+    Math.round(writerStats.maxSlotWaitMs),
+    writerStats.maxSlotWaitId || 'n/a',
+    Math.round(writerStats.maxWriteMs),
+    writerStats.maxWriteId || 'n/a',
+    Math.round(writerStats.maxOutputWriteMs),
+    writerStats.maxOutputWriteId || 'n/a',
+  )
 }
 
 /** Signals write() to abandon operations. */
@@ -168,32 +444,87 @@ export async function write(
   fileId: CrxDevAssetId | CrxDevScriptId,
 ): Promise<{ start: number; close: number; deps: OutputFile[] }> {
   const start = performance.now()
-  const deps = await firstValueFrom(
-    // wait for start event
-    start$.pipe(
-      // prepare either asset or script contents
-      prepFileData(fileId),
-      // output file and add dependencies to file writer
-      mergeMap(async ({ target, source, deps }) => {
-        const files = deps
-          .map((id: string) => {
-            const r = [add({ id, type: 'module' })]
-            if (id.includes('?import')) {
-              const [imported] = id.split('?import')
-              r.push(add({ id: imported, type: 'asset' }))
-            }
-            return r
-          })
-          .flat()
-        if (source instanceof Uint8Array) await outputFile(target, source)
-        else await outputFile(target, source, { encoding: 'utf8' })
-        return files
-      }),
-      // abort write operation on close event
-      takeUntil(close$),
-      concatWith(of([])),
+  const deps = await withWriteSlot(fileId, () =>
+    firstValueFrom(
+      // wait for start event
+      start$.pipe(
+        // prepare either asset or script contents
+        prepFileData(fileId),
+        // output file and add dependencies to file writer
+        mergeMap(async ({ target, source, deps }) => {
+          const addDepsStart = performance.now()
+          const files = deps
+            .map((id: string) => {
+              const r = [add({ id, type: 'module' })]
+              if (id.includes('?import')) {
+                const [imported] = id.split('?import')
+                r.push(add({ id: imported, type: 'asset' }))
+              }
+              return r
+            })
+            .flat()
+          const addDepsMs = performance.now() - addDepsStart
+          if (shouldLogPerf(addDepsMs)) {
+            perfDebug(
+              'deps add: id=%s type=%s deps=%d files=%d ms=%d',
+              fileId.id,
+              fileId.type,
+              deps.length,
+              files.length,
+              Math.round(addDepsMs),
+            )
+          }
+
+          const outputStart = performance.now()
+          if (source instanceof Uint8Array) await outputFile(target, source)
+          else await outputFile(target, source, { encoding: 'utf8' })
+          const outputMs = performance.now() - outputStart
+          writerStats.outputWrites += 1
+          writerStats.bytes += source.length
+          const viteDepHash = getViteDepHash(fileId.id)
+          if (viteDepHash) {
+            writerStats.viteDepWrites += 1
+            writerStats.viteDepBytes += source.length
+            writerStats.viteDepHashes.add(viteDepHash)
+            if (isViteDepChunk(fileId.id)) writerStats.viteDepChunks += 1
+          }
+          if (outputMs > writerStats.maxOutputWriteMs) {
+            writerStats.maxOutputWriteMs = outputMs
+            writerStats.maxOutputWriteId = formatFileId(fileId)
+          }
+          if (shouldLogPerf(outputMs)) {
+            perfDebug(
+              'output write: id=%s type=%s bytes=%d ms=%d target=%s',
+              fileId.id,
+              fileId.type,
+              source.length,
+              Math.round(outputMs),
+              target,
+            )
+          }
+          return files
+        }),
+        // abort write operation on close event
+        takeUntil(close$),
+        concatWith(of([])),
+      ),
     ),
   )
   const close = performance.now()
+  const totalMs = close - start
+  writerStats.writesCompleted += 1
+  if (totalMs > writerStats.maxWriteMs) {
+    writerStats.maxWriteMs = totalMs
+    writerStats.maxWriteId = formatFileId(fileId)
+  }
+  if (shouldLogPerf(totalMs)) {
+    perfDebug(
+      'write complete: id=%s type=%s total=%dms deps=%d',
+      fileId.id,
+      fileId.type,
+      Math.round(totalMs),
+      deps.length,
+    )
+  }
   return { start, close, deps }
 }

--- a/packages/vite-plugin/src/node/fileWriter.ts
+++ b/packages/vite-plugin/src/node/fileWriter.ts
@@ -150,7 +150,7 @@ function logProgress(startTime: number, phase: string) {
       : 0
 
   progressDebug(
-    'phase=%s files=%d/%d discovered pct=%s active=%d queued=%d bytes=%s viteDeps=%d chunks=%d rate=%s/s eta=%s elapsed=%s',
+    'writes phase=%s files=%d/%d discovered pct=%s active=%d queued=%d bytes=%s viteDeps=%d chunks=%d rate=%s/s eta=%s elapsed=%s',
     phase,
     completedWrites,
     discoveredFiles,
@@ -169,7 +169,7 @@ function logProgress(startTime: number, phase: string) {
 function startProgressTimer(startTime: number, getPhase: () => string) {
   if (!progressDebug.enabled) return
   progressDebug(
-    'begin: interval=%dms note=%s',
+    'writes begin: interval=%dms note=%s',
     progressIntervalMs,
     'total is discovered files and may grow during graph discovery',
   )


### PR DESCRIPTION
## What changed

This fixes a dev-server startup / branch-switch regression in the Vite plugin file writer readiness path. The regression came from recursively waiting through the discovered output-file dependency graph on every readiness generation, which can explode into repeated graph traversal while files are still being discovered.

- Coalesces `allFilesReady$` recomputation with a configurable debounce.
- Shares readiness work across subscribers instead of recomputing per subscriber.
- Deduplicates recursive dependency traversal with one shared `seen` set per readiness generation.
- Updates HMR to use the shared `allFilesReady()` helper instead of independently subscribing to `allFilesReady$`.
- Adds focused tests for shared readiness work and dependency traversal deduping.
- Adds opt-in `crx:file-writer:progress` and `crx:file-writer:perf` logs so large graph processing is visible when diagnosing slow startups.
- Adds a `startup-lag` benchmark preset that reproduces a 30s-class readiness storm.

## Regression

The startup lag was introduced by `5ce528adafd75c6b83be558a013da7cccc227952` (`Fix IIFE compatibility e2e failures`). That commit changed readiness from waiting direct file promises to recursively walking each output file's dependencies:

```ts
Promise.allSettled(files.map((file) => waitForOutputFile(file)))
```

That was functionally useful for dependency correctness, but it made every readiness generation and every subscriber repeat recursive graph work while the graph was still growing.

This PR keeps recursive dependency correctness while making the work coalesced, shared, and deduped per generation.

## Reproducer / benchmark

The benchmark isolates the readiness recomputation behavior seen during startup and large HMR/branch-switch update storms:

```bash
cd packages/vite-plugin
hyperfine --runs 3 \
  'node scripts/bench-ready-recompute.mjs --preset=startup-lag --mode=old-recursive' \
  'node scripts/bench-ready-recompute.mjs --preset=startup-lag --mode=fixed'
```

Local result:

```text
old-recursive: 37.723 s ± 4.826 s  (range 34.566 s..43.278 s)
fixed:          0.169 s ± 0.011 s  (range 0.161 s..0.182 s)
speedup:        223.26x ± 32.15x
```

A direct single run of the same preset also reproduced a 30s+ stall shape:

```text
old-recursive: elapsedMs=45486 generations=1505 fileChecks=35790875
fixed:         elapsedMs=104   generations=1    fileChecks=750
```

## Diagnostics

The diagnostics are intentionally opt-in. They are included because before this PR a large graph wait could look like a stuck dev server.

```bash
DEBUG=crx:file-writer:progress npm run dev
```

Example write progress line:

```text
crx:file-writer:progress writes phase=writing files=379/558 discovered pct=67.9% active=16 queued=163 bytes=9.3MiB viteDeps=170 chunks=115 rate=68.7/s eta=2.6s elapsed=5.5s
```

Example readiness progress line:

```text
crx:file-writer:progress ready phase=waiting generation=21 files=381/598 discovered pct=63.7% seen=566 active=185 rejected=0 rate=375.3/s eta=0.6s elapsed=1.0s
```

The total is intentionally labeled as discovered files because the full graph is not known up front and can grow while modules are transformed.

For deeper diagnosis:

```bash
DEBUG=crx:file-writer:progress,crx:file-writer:perf npm run dev
```

## Panel Pro validation

Panel Pro is my downstream Chrome extension project that uses `@crxjs/vite-plugin`; it is not part of this repository and is not an upstream fixture. I used it here as a real large-app validation target because it is where this startup/branch-switch lag was observed.

In Panel Pro, the progress logs showed that Vite optimized deps dominate the emitted bytes after cache invalidation:

```text
files=803
bytes=24317305
viteDepWrites=265
viteDepChunks=127
viteDepBytes=19673178
```

I also ran a live branch-switch A/B against Panel Pro with both worktrees at the same app commit and the same branch-switch target:

```text
Target extension diff: 202 files changed, 4835 insertions(+), 10282 deletions(-)
Scenario: start dev on main, wait for dist to stabilize, git switch to target, wait for dist to change and stabilize for 4s
```

Results:

```text
@crxjs/vite-plugin 2.0.0: 16.243s, 14.949s switch-to-stable; avg 15.596s
fixed local branch:          9.827s,  9.583s switch-to-stable; avg  9.705s
reduction: 37.8% faster wall time, 1.61x speedup
```

Both sides emitted the same file counts for that comparison (`810 -> 813`), so this is the cleanest Panel Pro A/B so far. It still does not reproduce the original 30s-2min whole-app worst case; it shows a material improvement on a large real branch switch and provides a separate 30s-class synthetic reproducer for the readiness storm.

## Validation

```bash
pnpm exec vitest --run src/node/fileWriter-rxjs.test.ts src/node/fileWriter-hmr.test.ts src/node/fileWriter-utilities.test.ts
pnpm run build:js
git diff --check
node scripts/bench-ready-recompute.mjs --help
node scripts/bench-ready-recompute.mjs --preset=quick --mode=fixed
hyperfine --runs 3 \
  'node scripts/bench-ready-recompute.mjs --preset=startup-lag --mode=old-recursive' \
  'node scripts/bench-ready-recompute.mjs --preset=startup-lag --mode=fixed'
```
