### PR TITLE
fix: Vite 8 Rollup option warnings

### DIFF
--- a/.changeset/vite8-rollup-options.md
+++ b/.changeset/vite8-rollup-options.md
@@ -1,0 +1,5 @@
+---
+'@crxjs/vite-plugin': patch
+---
+
+Filter Vite 8/Rolldown-only options before the dev file writer calls Rollup, removing `Unknown input options: platform` warnings.

--- a/packages/vite-plugin/src/node/fileWriter.test.ts
+++ b/packages/vite-plugin/src/node/fileWriter.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest'
+import { getRollupInputOptions } from './fileWriter'
+
+describe('getRollupInputOptions', () => {
+  test('removes Rolldown-only options before calling CRXJS bundled Rollup', () => {
+    // CRXJS calls its own Rollup dependency here, regardless of which Vite
+    // version the user has installed.
+    const rollupOptions = getRollupInputOptions({
+      input: 'index.html',
+      output: {
+        format: 'es',
+      },
+      platform: 'browser',
+      resolve: {},
+      transform: {},
+      moduleTypes: {},
+      optimization: {},
+      experimental: {},
+      cwd: '/project',
+    } as Parameters<typeof getRollupInputOptions>[0])
+
+    expect(rollupOptions).toEqual({
+      input: 'index.html',
+      output: {
+        format: 'es',
+      },
+    })
+  })
+})

--- a/packages/vite-plugin/src/node/fileWriter.ts
+++ b/packages/vite-plugin/src/node/fileWriter.ts
@@ -27,6 +27,33 @@ const { outputFile } = fsx
 
 const debug = _debug('file-writer')
 
+type RollupOptionsWithRolldownDefaults = RollupOptions & {
+  platform?: unknown
+  resolve?: unknown
+  transform?: unknown
+  moduleTypes?: unknown
+  optimization?: unknown
+  experimental?: unknown
+  cwd?: unknown
+}
+
+export function getRollupInputOptions(options: RollupOptions): RollupOptions {
+  // Vite 8 aliases build.rollupOptions to Rolldown options, but this writer
+  // still calls Rollup directly.
+  const {
+    platform: _platform,
+    resolve: _resolve,
+    transform: _transform,
+    moduleTypes: _moduleTypes,
+    optimization: _optimization,
+    experimental: _experimental,
+    cwd: _cwd,
+    ...rollupOptions
+  } = options as RollupOptionsWithRolldownDefaults
+
+  return rollupOptions
+}
+
 function queueWrite(
   script: CrxDevAssetId | CrxDevScriptId,
   previous?: OutputFile,
@@ -58,9 +85,10 @@ export async function start({
     p.name?.startsWith('crx:'),
   )
   const { rollupOptions, outDir } = server.config.build
+  const rollupInputOptions = getRollupInputOptions(rollupOptions)
   const inputOptions: RollupOptions = {
     input: 'index.html',
-    ...rollupOptions,
+    ...rollupInputOptions,
     plugins,
   }
   // handle the various output option types

--- a/packages/vite-plugin/src/node/plugin-contentScripts.ts
+++ b/packages/vite-plugin/src/node/plugin-contentScripts.ts
@@ -165,11 +165,8 @@ export const pluginContentScripts: CrxPluginFn = () => {
         await findWorldMainIds(config, env)
 
         return {
-          ...config,
           build: {
-            ...config.build,
             rollupOptions: {
-              ...config.build?.rollupOptions,
               // keep exports for content script module api
               preserveEntrySignatures:
                 config.build?.rollupOptions?.preserveEntrySignatures ??

--- a/packages/vite-plugin/src/node/plugin-hmr.ts
+++ b/packages/vite-plugin/src/node/plugin-hmr.ts
@@ -66,7 +66,7 @@ export const pluginHMR: CrxPluginFn = () => {
         server.hmr = server.hmr ?? {}
         server.hmr.host = 'localhost'
 
-        return { server, ...config }
+        return { server }
       },
       // server should ignore outdir
       configResolved(_config) {

--- a/packages/vite-plugin/src/node/plugin-manifest.ts
+++ b/packages/vite-plugin/src/node/plugin-manifest.ts
@@ -124,9 +124,7 @@ export const pluginManifest: CrxPluginFn = () => {
           for (const x of [js, sw, html].flat()) set.add(x)
 
           return {
-            ...config,
             optimizeDeps: {
-              ...config.optimizeDeps,
               entries: [...set],
             },
           }

--- a/packages/vite-plugin/src/node/plugin-webAccessibleResources.ts
+++ b/packages/vite-plugin/src/node/plugin-webAccessibleResources.ts
@@ -84,7 +84,7 @@ export const pluginWebAccessibleResources: CrxPluginFn = () => {
         userWantsViteManifest = build?.manifest
 
         // Only force manifest generation if we're building - we need it to derive content script resources
-        return { ...config, build: { ...build, manifest: command === 'build' } }
+        return { build: { manifest: command === 'build' } }
       },
       configResolved(_config) {
         config = _config


### PR DESCRIPTION
Fixes #1145

## Summary

- Avoid returning full resolved Vite config objects from CRX config hooks; return only the fields CRX changes.
- Strip Vite 8/Rolldown-only root options before the dev file writer calls the CRXJS bundled Rollup dependency.
- Add regression coverage for filtering Rolldown-only options from the internal Rollup call.

## Validation

- pnpm -C packages/vite-plugin run lint:types
- pnpm -C packages/vite-plugin exec vitest --run --mode compat
- pnpm -C packages/vite-plugin exec vitest --run --mode out
- pnpm -C packages/vite-plugin test:vite-matrix -- --vite 8 --mode compat
- Focused Vite 8 dev-server repro with build.rollupOptions.input, confirming the platform warning is gone.
