### PR TITLE
fix: coalesce file writer readiness waits

### DIFF
--- a/.changeset/warm-files-wait.md
+++ b/.changeset/warm-files-wait.md
@@ -1,0 +1,5 @@
+---
+'@crxjs/vite-plugin': patch
+---
+
+Coalesce file writer readiness waits so large dev-server graph updates do not repeatedly recompute the same dependency traversal. This also fixes late HMR readiness waits that could miss the shared ready event and delay content script updates.

--- a/packages/vite-plugin/src/node/fileWriter-hmr.ts
+++ b/packages/vite-plugin/src/node/fileWriter-hmr.ts
@@ -1,7 +1,6 @@
 import {
   buffer,
   filter,
-  firstValueFrom,
   map,
   mergeMap,
   Observable,
@@ -15,7 +14,7 @@ import {
   UpdatePayload,
 } from 'vite'
 import { update } from './fileWriter'
-import { allFilesReady$ } from './fileWriter-rxjs'
+import { allFilesReady, allFilesReady$ } from './fileWriter-rxjs'
 import { getFileName, getViteUrl, prefix } from './fileWriter-utilities'
 import { _debug } from './helpers'
 import { CrxHMRPayload } from './types'
@@ -113,7 +112,7 @@ export async function prepareVitePayloadForCrx(
       return update(id).map((file) => file.file)
     })
     await Promise.all(pendingFiles)
-    await firstValueFrom(allFilesReady$)
+    await allFilesReady()
   }
 
   return mapVitePayloadForCrx(p)

--- a/packages/vite-plugin/src/node/fileWriter-rxjs.ts
+++ b/packages/vite-plugin/src/node/fileWriter-rxjs.ts
@@ -5,6 +5,7 @@ import MagicString from 'magic-string'
 import { OutputAsset, OutputChunk } from 'rollup'
 import {
   BehaviorSubject,
+  debounceTime,
   filter,
   first,
   firstValueFrom,
@@ -14,9 +15,11 @@ import {
   of,
   ReplaySubject,
   retry,
+  share,
   startWith,
   switchMap,
   takeUntil,
+  tap,
   toArray,
 } from 'rxjs'
 import { build as viteBuild, ErrorPayload, ViteDevServer } from 'vite'
@@ -91,13 +94,42 @@ export const buildStart$ = fileWriterEvent$.pipe(
   switchMap((e) => of(e)),
 )
 
+const allFilesReadyDebounceMs = 100
+let currentAllFilesReadyGeneration = 0
+let completedAllFilesReadyGeneration = 0
+let lastAllFilesReadyResults: PromiseSettledResult<void>[] | undefined
+
 /** Emit when all script files are written */
-export const allFilesReady$ = buildEnd$.pipe(
-  switchMap(() => outputFiles.change$.pipe(startWith({ type: 'start' }))),
-  map(() => [...outputFiles.values()]),
-  switchMap((files) =>
-    Promise.allSettled(files.map((file) => waitForOutputFile(file))),
+const allFilesReadyState$ = buildEnd$.pipe(
+  switchMap(() =>
+    outputFiles.change$.pipe(
+      startWith({ type: 'start' }),
+      tap(() => {
+        currentAllFilesReadyGeneration += 1
+      }),
+      debounceTime(allFilesReadyDebounceMs),
+    ),
   ),
+  map(() => ({
+    generation: currentAllFilesReadyGeneration,
+    files: [...outputFiles.values()],
+  })),
+  switchMap(async ({ generation, files }) => {
+    const seen = new Set<OutputFile>()
+    const results = await Promise.allSettled(
+      files.map((file) => waitForOutputFile(file, seen)),
+    )
+    return { generation, results }
+  }),
+  tap(({ generation, results }) => {
+    completedAllFilesReadyGeneration = generation
+    lastAllFilesReadyResults = results
+  }),
+  share(),
+)
+
+export const allFilesReady$ = allFilesReadyState$.pipe(
+  map(({ results }) => results),
 )
 
 async function waitForOutputFile(
@@ -108,6 +140,25 @@ async function waitForOutputFile(
   seen.add(file)
   const { deps } = await file.file
   await Promise.all(deps.map((dep) => waitForOutputFile(dep, seen)))
+}
+
+async function waitForAllFilesReadyResults(): Promise<
+  PromiseSettledResult<void>[]
+> {
+  const targetGeneration = currentAllFilesReadyGeneration
+  if (
+    lastAllFilesReadyResults &&
+    completedAllFilesReadyGeneration >= targetGeneration
+  ) {
+    return lastAllFilesReadyResults
+  }
+
+  const { results } = await firstValueFrom(
+    allFilesReadyState$.pipe(
+      filter(({ generation }) => generation >= targetGeneration),
+    ),
+  )
+  return results
 }
 
 const timestamp$ = new BehaviorSubject(Date.now())
@@ -364,12 +415,12 @@ function prepIifeScript(
 
 /** Resolves when all existing files in scriptFiles are written. */
 export async function allFilesReady(): Promise<void> {
-  await firstValueFrom(allFilesReady$)
+  await waitForAllFilesReadyResults()
 }
 
 /** Resolves when all existing files in scriptFiles are written. */
 export async function allFilesSuccess(): Promise<void> {
-  const result = await firstValueFrom(allFilesReady$)
+  const result = await waitForAllFilesReadyResults()
   const reason = result.find(isRejected)?.reason
   if (typeof reason === 'undefined') return
   if (reason instanceof Error) throw reason

--- a/packages/vite-plugin/tests/e2e/mv3-two-entrypoints-at-once/manifest.json
+++ b/packages/vite-plugin/tests/e2e/mv3-two-entrypoints-at-once/manifest.json
@@ -1,0 +1,16 @@
+{
+  "description": "test extension",
+  "manifest_version": 3,
+  "name": "test extension",
+  "content_scripts": [
+    {
+      "matches": ["https://example.com/*"],
+      "js": ["src/one-main.jsx"]
+    },
+    {
+      "matches": ["https://example.com/*"],
+      "js": ["src/two-main.jsx"]
+    }
+  ],
+  "version": "1.0.0"
+}

--- a/packages/vite-plugin/tests/e2e/mv3-two-entrypoints-at-once/src1/Shared.jsx
+++ b/packages/vite-plugin/tests/e2e/mv3-two-entrypoints-at-once/src1/Shared.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export function Shared({ entry, page }) {
+  return (
+    <div id={`${page}-app`}>
+      {page} ready: {entry}: shared v1
+    </div>
+  )
+}

--- a/packages/vite-plugin/tests/e2e/mv3-two-entrypoints-at-once/src1/one-main.jsx
+++ b/packages/vite-plugin/tests/e2e/mv3-two-entrypoints-at-once/src1/one-main.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { One } from './one.jsx'
+
+const root = document.createElement('div')
+root.id = 'one-root'
+document.body.appendChild(root)
+
+ReactDOM.render(<One />, root)

--- a/packages/vite-plugin/tests/e2e/mv3-two-entrypoints-at-once/src1/one.jsx
+++ b/packages/vite-plugin/tests/e2e/mv3-two-entrypoints-at-once/src1/one.jsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import { Shared } from './Shared.jsx'
+
+export function One() {
+  return <Shared entry="entry v1" page="one" />
+}

--- a/packages/vite-plugin/tests/e2e/mv3-two-entrypoints-at-once/src1/two-main.jsx
+++ b/packages/vite-plugin/tests/e2e/mv3-two-entrypoints-at-once/src1/two-main.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { Two } from './two.jsx'
+
+const root = document.createElement('div')
+root.id = 'two-root'
+document.body.appendChild(root)
+
+ReactDOM.render(<Two />, root)

--- a/packages/vite-plugin/tests/e2e/mv3-two-entrypoints-at-once/src1/two.jsx
+++ b/packages/vite-plugin/tests/e2e/mv3-two-entrypoints-at-once/src1/two.jsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import { Shared } from './Shared.jsx'
+
+export function Two() {
+  return <Shared entry="entry v1" page="two" />
+}

--- a/packages/vite-plugin/tests/e2e/mv3-two-entrypoints-at-once/src2/Shared.jsx
+++ b/packages/vite-plugin/tests/e2e/mv3-two-entrypoints-at-once/src2/Shared.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export function Shared({ entry, page }) {
+  return (
+    <div id={`${page}-app`}>
+      {page} ready: {entry}: shared v2
+    </div>
+  )
+}

--- a/packages/vite-plugin/tests/e2e/mv3-two-entrypoints-at-once/src2/one.jsx
+++ b/packages/vite-plugin/tests/e2e/mv3-two-entrypoints-at-once/src2/one.jsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import { Shared } from './Shared.jsx'
+
+export function One() {
+  return <Shared entry="entry v2" page="one" />
+}

--- a/packages/vite-plugin/tests/e2e/mv3-two-entrypoints-at-once/src2/two.jsx
+++ b/packages/vite-plugin/tests/e2e/mv3-two-entrypoints-at-once/src2/two.jsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import { Shared } from './Shared.jsx'
+
+export function Two() {
+  return <Shared entry="entry v2" page="two" />
+}

--- a/packages/vite-plugin/tests/e2e/mv3-two-entrypoints-at-once/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-two-entrypoints-at-once/vite-serve.test.ts
@@ -1,0 +1,37 @@
+import fs from 'fs-extra'
+import path from 'pathe'
+import { expect, test } from 'vitest'
+import { createUpdate } from '../helpers'
+import { serve } from '../runners'
+
+test('hmr updates two content scripts and a shared dependency at once', async () => {
+  const src = path.join(__dirname, 'src')
+  const src1 = path.join(__dirname, 'src1')
+  const src2 = path.join(__dirname, 'src2')
+
+  await fs.remove(src)
+  await fs.copy(src1, src, { recursive: true })
+
+  const { browser } = await serve(__dirname)
+  const page = await browser.newPage()
+  const update = createUpdate({ target: src, src: src2 })
+
+  await page.goto('https://example.com')
+
+  const oneApp = page.locator('#one-app')
+  const twoApp = page.locator('#two-app')
+  await oneApp.filter({ hasText: 'one ready: entry v1: shared v1' }).waitFor()
+  await twoApp.filter({ hasText: 'two ready: entry v1: shared v1' }).waitFor()
+
+  let reloaded = false
+  page.on('framenavigated', () => {
+    reloaded = true
+  })
+
+  await update('jsx')
+
+  await oneApp.filter({ hasText: 'one ready: entry v2: shared v2' }).waitFor()
+  await twoApp.filter({ hasText: 'two ready: entry v2: shared v2' }).waitFor()
+
+  expect(reloaded).toBe(false)
+})

--- a/packages/vite-plugin/tests/e2e/mv3-two-entrypoints-at-once/vite.config.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-two-entrypoints-at-once/vite.config.ts
@@ -1,0 +1,13 @@
+import react from '@vitejs/plugin-react'
+import { crx } from '../../plugin-testOptionsProvider'
+import { defineConfig } from 'vite'
+import manifest from './manifest.json'
+
+const { preambleCode } = react
+
+export default defineConfig({
+  build: { minify: false },
+  clearScreen: false,
+  logLevel: 'error',
+  plugins: [crx({ manifest, contentScripts: { preambleCode } }), react()],
+})


### PR DESCRIPTION
## Summary

This is the minimal hotfix version of the file writer readiness fix, without the diagnostics and benchmark work from #1192.

- Coalesces file-writer readiness recomputation after output-file discovery bursts.
- Shares recursive readiness traversal across subscribers and dedupes dependency traversal per generation.
- Makes late readiness waits use the cached completed generation instead of subscribing to `allFilesReady$` after the relevant emission has already happened.
- Updates HMR payload preparation to use the cache-aware `allFilesReady()` helper.
- Adds an e2e fixture with two React content scripts and one shared dependency updated at the same time.

## Root Cause

The 2.6.0 startup / branch-switch lag came from repeatedly walking a large output-file dependency graph while the graph was still being discovered.

The first shared/debounced readiness fix also exposed one important edge case: callers that subscribe to `allFilesReady$` after a shared emission can miss the relevant readiness event. `allFilesReady()` and HMR payload preparation now use the cached generation-aware wait path instead.

## Related PRs

- #1192 is the broader diagnostics/progress PR. This PR intentionally keeps only the runtime fix and regression coverage.
- #1188 is related to large dev-file-writer pressure, but fixes a different concurrency/OOM path.

## Validation

```bash
pnpm exec vitest --run src/node/fileWriter-hmr.test.ts src/node/fileWriter-utilities.test.ts tests/e2e/mv3-two-entrypoints-at-once/vite-serve.test.ts
pnpm exec vitest --run --mode e2e tests/e2e/mv3-vite-react-content-script-hmr/vite-serve.test.ts tests/e2e/mv3-vite-react-content-script-seq-hmr/vite-serve.test.ts tests/e2e/mv3-two-entrypoints-at-once/vite-serve.test.ts
pnpm run build:js
git diff --check
```
