### PR TITLE
fix: HRM and service script loader causes modules to be loaded twice with vite

### DIFF
--- a/packages/vite-plugin/src/node/plugin-background.ts
+++ b/packages/vite-plugin/src/node/plugin-background.ts
@@ -1,12 +1,25 @@
 import workerHmrClient from 'client/es/hmr-client-worker.ts'
+import fs from 'fs-extra'
 import type { ResolvedConfig } from 'vite'
 import { defineClientValues } from './defineClientValues'
-import { getFileName } from './fileWriter-utilities'
+import { getFileName, getOutputPath } from './fileWriter-utilities'
 import { getCrxHmrToken } from './hmrToken'
+import { isImporter } from './isImporter'
 import { ChromeManifestBackground, FirefoxManifestBackground } from './manifest'
+import { join, normalize } from './path'
 import { getOptions } from './plugin-optionsProvider'
 import type { Browser, CrxPluginFn, ResolvedConfigWithHMRToken } from './types'
 import { workerClientId } from './virtualFileIds'
+
+function addTimestamp(url: string, timestamp?: number): string {
+  if (!timestamp) return url
+  const [pathname, query] = url.replace(/[?&]t=\d+/, '').split('?')
+  return `${pathname}?t=${timestamp}${query ? `&${query}` : ''}`
+}
+
+function escapeRegExp(text: string) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
 
 /**
  * This plugin enables HMR during Vite serve mode by intercepting fetch requests
@@ -26,6 +39,9 @@ export const pluginBackground: CrxPluginFn = () => {
   let config: ResolvedConfig
   let browser: Browser
   let liveReload = true
+  let devBackgroundLoader:
+    | { worker: string; fileName: string }
+    | undefined
 
   return [
     {
@@ -52,6 +68,38 @@ export const pluginBackground: CrxPluginFn = () => {
             config,
           )
         }
+      },
+    },
+    {
+      name: 'crx:background-loader-hmr',
+      apply: 'serve',
+      enforce: 'pre',
+      async handleHotUpdate({ file, modules, server, timestamp }) {
+        if (!devBackgroundLoader) return
+
+        const background = join(server.config.root, devBackgroundLoader.worker)
+        const isBackgroundUpdate =
+          normalize(file) === normalize(background) ||
+          modules.some(isImporter(background))
+
+        if (!isBackgroundUpdate) return
+
+        const proto = server.config.server.https ? 'https' : 'http'
+        const port = server.config.server.port?.toString()
+        if (typeof port === 'undefined') return
+
+        const loaderFile = getOutputPath(server, devBackgroundLoader.fileName)
+        const workerUrl = `${proto}://localhost:${port}/${devBackgroundLoader.worker}`
+        const timestampedWorkerUrl = addTimestamp(workerUrl, timestamp)
+        const loader = await fs.readFile(loaderFile, 'utf8')
+        await fs.outputFile(
+          loaderFile,
+          loader.replace(
+            new RegExp(`${escapeRegExp(workerUrl)}(?:[?&]t=\\d+)?`, 'g'),
+            timestampedWorkerUrl,
+          ),
+          'utf8',
+        )
       },
     },
     {
@@ -113,15 +161,20 @@ export const pluginBackground: CrxPluginFn = () => {
           fileName: getFileName({ type: 'loader', id: 'service-worker' }),
           source: loader,
         })
+        const loaderFileName = this.getFileName(refId)
+        devBackgroundLoader =
+          config.command === 'serve' && worker
+            ? { worker, fileName: loaderFileName }
+            : undefined
 
         if (browser !== 'firefox') {
           manifest.background = {
-            service_worker: this.getFileName(refId),
+            service_worker: loaderFileName,
             type: 'module',
           }
         } else {
           manifest.background = {
-            scripts: [this.getFileName(refId)],
+            scripts: [loaderFileName],
             type: 'module',
           }
         }

--- a/packages/vite-plugin/tests/e2e/mv3-vite-background-module-cache/manifest.json
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-background-module-cache/manifest.json
@@ -1,0 +1,13 @@
+{
+  "description": "test extension",
+  "manifest_version": 3,
+  "name": "test extension",
+  "background": { "service_worker": "src/background.ts" },
+  "content_scripts": [
+    {
+      "matches": ["https://example.com/*"],
+      "js": ["src/content.ts"]
+    }
+  ],
+  "version": "1.0.0"
+}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-background-module-cache/src1/background.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-background-module-cache/src1/background.ts
@@ -1,0 +1,16 @@
+import { getProgressMessage } from './progress'
+
+export function getBackgroundMarker() {
+  return 'background entry'
+}
+
+chrome.runtime.onMessage.addListener((message, sender) => {
+  if (message?.type !== 'start-progress' || !sender.tab?.id) return
+
+  chrome.tabs.sendMessage(sender.tab.id, {
+    type: 'progress',
+    message: getProgressMessage(),
+  })
+})
+
+export {}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-background-module-cache/src1/content.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-background-module-cache/src1/content.ts
@@ -1,0 +1,19 @@
+let count = 0
+
+const app = document.createElement('div')
+app.id = 'app'
+app.dataset.count = String(count)
+app.textContent = `progress: ${count}`
+document.body.append(app)
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message?.type !== 'progress') return
+
+  count++
+  app.dataset.count = String(count)
+  app.textContent = `progress: ${count}`
+})
+
+chrome.runtime.sendMessage({ type: 'start-progress' })
+
+export {}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-background-module-cache/src1/progress.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-background-module-cache/src1/progress.ts
@@ -1,0 +1,5 @@
+import { getBackgroundMarker } from './background'
+
+export function getProgressMessage() {
+  return `first ${getBackgroundMarker()}`
+}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-background-module-cache/src2/background.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-background-module-cache/src2/background.ts
@@ -1,0 +1,16 @@
+import { getProgressMessage } from './progress'
+
+export function getBackgroundMarker() {
+  return 'background entry'
+}
+
+chrome.runtime.onMessage.addListener((message, sender) => {
+  if (message?.type !== 'start-progress' || !sender.tab?.id) return
+
+  chrome.tabs.sendMessage(sender.tab.id, {
+    type: 'progress',
+    message: getProgressMessage(),
+  })
+})
+
+export {}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-background-module-cache/src2/progress.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-background-module-cache/src2/progress.ts
@@ -1,0 +1,5 @@
+import { getBackgroundMarker } from './background'
+
+export function getProgressMessage() {
+  return `second ${getBackgroundMarker()}`
+}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-background-module-cache/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-background-module-cache/vite-serve.test.ts
@@ -1,0 +1,44 @@
+import fs from 'fs-extra'
+import path from 'pathe'
+import type { Page } from 'playwright-chromium'
+import { firstValueFrom } from 'rxjs'
+import { expect, test } from 'vitest'
+import { createUpdate } from '../helpers'
+import { serve } from '../runners'
+
+async function waitForProgressCount(page: Page, expected: number) {
+  const app = page.locator('#app')
+  const expectedCount = String(expected)
+
+  for (let i = 0; i < 150; i++) {
+    const count = await app.getAttribute('data-count')
+    if (count === expectedCount) return
+    if (count && Number(count) > expected) break
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+
+  expect(await app.getAttribute('data-count')).toBe(expectedCount)
+}
+
+test('background dependency update does not duplicate service worker modules', async () => {
+  const src = path.join(__dirname, 'src')
+  const src1 = path.join(__dirname, 'src1')
+  const src2 = path.join(__dirname, 'src2')
+
+  await fs.remove(src)
+  await fs.copy(src1, src, { recursive: true })
+
+  const { browser, routes } = await serve(__dirname)
+  const page = await browser.newPage()
+  const update = createUpdate({ target: src, src: src2 })
+
+  await page.goto('https://example.com')
+  await waitForProgressCount(page, 1)
+
+  await update('progress.ts')
+  await firstValueFrom(routes)
+  await waitForProgressCount(page, 1)
+
+  await new Promise((resolve) => setTimeout(resolve, 500))
+  expect(await page.locator('#app').getAttribute('data-count')).toBe('1')
+})

--- a/packages/vite-plugin/tests/e2e/mv3-vite-background-module-cache/vite.config.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-background-module-cache/vite.config.ts
@@ -1,0 +1,10 @@
+import { crx } from '../../plugin-testOptionsProvider'
+import { defineConfig } from 'vite'
+import manifest from './manifest.json'
+
+export default defineConfig({
+  build: { minify: false },
+  clearScreen: false,
+  logLevel: 'error',
+  plugins: [crx({ manifest })],
+})


### PR DESCRIPTION
Fixes #869.

## Summary
- Update the dev background loader on background hot updates so the worker entry URL receives Vite's HMR timestamp.
- Add an MV3 serve-mode regression fixture for the circular background module graph that previously registered duplicate listeners.

## Root cause
During a dev reload, the service worker loader kept importing the unversioned background entry while Vite rewrote the circular dependency graph with a `?t=...` timestamp. The browser treated those as distinct module URLs, so background entry side effects could run twice in one worker instance.

## Validation
- `pnpm --dir packages/vite-plugin exec vitest --run --mode e2e tests/e2e/mv3-vite-background-module-cache/vite-serve.test.ts tests/e2e/mv3-vite-live-reload-default/vite-serve.test.ts tests/e2e/mv3-vite-live-reload-disabled/vite-serve.test.ts tests/e2e/mv3-vite-hmr-background-define/vite-serve.test.ts`
- `pnpm --dir packages/vite-plugin run lint:types`
- `pnpm --dir packages/vite-plugin run lint:eslint`
