### PR TITLE
Add opt-in Vite dev bundle writer

### DIFF
--- a/.changeset/clean-rollup-runtime.md
+++ b/.changeset/clean-rollup-runtime.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": minor
+---
+
+Remove the direct Rollup runtime dependency from the Vite plugin package.

--- a/.changeset/clean-rollup-runtime.md
+++ b/.changeset/clean-rollup-runtime.md
@@ -2,4 +2,4 @@
 "@crxjs/vite-plugin": minor
 ---
 
-Remove the direct Rollup runtime dependency from the Vite plugin package.
+Add an opt-in Vite-powered development bundle writer for the Vite plugin while keeping the Rollup writer as the default.

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -79,6 +79,7 @@
   },
   "dependencies": {
     "@webcomponents/custom-elements": "^1.5.0",
+    "acorn": "^8.15.0",
     "acorn-walk": "^8.3.5",
     "convert-source-map": "^1.7.0",
     "debug": "^4.3.3",
@@ -90,7 +91,6 @@
     "node-html-parser": "^7.1.0",
     "pathe": "^2.0.1",
     "picocolors": "^1.1.1",
-    "rollup": "2.80.0",
     "rxjs": "7.5.7"
   },
   "devDependencies": {
@@ -129,6 +129,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "rimraf": "3.0.2",
+    "rollup": "2.80.0",
     "rollup-plugin-dts": "^4.2.0",
     "rollup-plugin-esbuild": "4.10.3",
     "svelte": "^3.48.0",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -91,6 +91,7 @@
     "node-html-parser": "^7.1.0",
     "pathe": "^2.0.1",
     "picocolors": "^1.1.1",
+    "rollup": "2.80.0",
     "rxjs": "7.5.7"
   },
   "devDependencies": {
@@ -129,7 +130,6 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "rimraf": "3.0.2",
-    "rollup": "2.80.0",
     "rollup-plugin-dts": "^4.2.0",
     "rollup-plugin-esbuild": "4.10.3",
     "svelte": "^3.48.0",

--- a/packages/vite-plugin/src/node/compileFileResources.ts
+++ b/packages/vite-plugin/src/node/compileFileResources.ts
@@ -1,8 +1,8 @@
-import { OutputChunk } from 'rollup'
 import { ManifestChunk, ResolvedConfig } from 'vite'
 import { contentScripts } from './contentScripts'
 import { prefix } from './fileWriter-utilities'
 import { relative } from './path'
+import type { CrxOutputChunk } from './types'
 
 interface FileResources {
   assets: Set<string>
@@ -17,7 +17,7 @@ export function compileFileResources(
     files,
     config,
   }: {
-    chunks: Map<string, OutputChunk>
+    chunks: Map<string, CrxOutputChunk>
     files: Map<string, ManifestChunk>
     config: ResolvedConfig
   },

--- a/packages/vite-plugin/src/node/devBundleRunner.test.ts
+++ b/packages/vite-plugin/src/node/devBundleRunner.test.ts
@@ -1,0 +1,138 @@
+import { mkdtemp, readFile, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import type { ViteDevServer } from 'vite'
+import { afterEach, describe, expect, test } from 'vitest'
+import { writeDevBundle } from './devBundleRunner'
+import { join } from './path'
+import type {
+  CrxOutputBundle,
+  CrxPlugin,
+  CrxPluginContext,
+} from './types'
+
+const tempRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  )
+})
+
+async function createRoot() {
+  const root = await mkdtemp(join(tmpdir(), 'crx-dev-bundle-'))
+  tempRoots.push(root)
+  return root
+}
+
+function createServer(root: string): ViteDevServer {
+  return {
+    config: {
+      root,
+      build: {
+        outDir: 'dist',
+        rollupOptions: {
+          output: {
+            assetFileNames: 'assets/[name][extname]',
+            entryFileNames: 'entries/[name].js',
+          },
+        },
+      },
+    },
+    pluginContainer: {
+      resolveId: async (source: string) => ({ id: `/resolved/${source}` }),
+    },
+  } as unknown as ViteDevServer
+}
+
+describe('writeDevBundle', () => {
+  test('runs dev bundle hooks with write semantics and writes emitted files', async () => {
+    const root = await createRoot()
+    const calls: string[] = []
+    let isWrite: boolean | undefined
+    let assetFileName: string | undefined
+    let resolvedId: string | undefined
+
+    const plugin = {
+      name: 'crx:test-dev-bundle',
+      options(this: CrxPluginContext, options: Record<string, unknown>) {
+        calls.push(`options:${options.input}`)
+        return { input: 'stub-input' }
+      },
+      async buildStart(
+        this: CrxPluginContext,
+        options: Record<string, unknown>,
+      ) {
+        calls.push(`buildStart:${options.input}`)
+
+        const parsed = this.parse('export const value = 1')
+        expect(parsed.type).toBe('Program')
+
+        const resolved = await this.resolve('./dep', '/entry.ts', {
+          skipSelf: true,
+        })
+        resolvedId = resolved?.id
+
+        const assetRef = this.emitFile({
+          type: 'asset',
+          name: 'dev-base.txt',
+        })
+        assetFileName = this.getFileName(assetRef)
+        this.setAssetSource(assetRef, 'asset from setAssetSource')
+
+        this.emitFile({
+          type: 'chunk',
+          id: '/entry.ts',
+          name: 'entry',
+        })
+      },
+      load(this: CrxPluginContext, id: string) {
+        calls.push(`load:${id}`)
+        if (id === '/entry.ts') return 'export const value = 1'
+      },
+      transform(this: CrxPluginContext, code: string, id: string) {
+        calls.push(`transform:${id}`)
+        return `${code}\nconsole.log(value)`
+      },
+      generateBundle(
+        this: CrxPluginContext,
+        _options: Record<string, unknown>,
+        bundle: CrxOutputBundle,
+        write: boolean,
+      ) {
+        calls.push(`generateBundle:${write}`)
+        isWrite = write
+
+        expect(bundle['assets/dev-base.txt']?.type).toBe('asset')
+        expect(bundle['entries/entry.js']?.type).toBe('chunk')
+
+        this.emitFile({
+          type: 'asset',
+          fileName: 'late-asset.txt',
+          source: 'asset from generateBundle',
+        })
+      },
+    } as unknown as CrxPlugin
+
+    await writeDevBundle({ server: createServer(root), plugins: [plugin] })
+
+    expect(calls).toEqual([
+      'options:index.html',
+      'buildStart:stub-input',
+      'load:/entry.ts',
+      'transform:/entry.ts',
+      'generateBundle:true',
+    ])
+    expect(isWrite).toBe(true)
+    expect(assetFileName).toBe('assets/dev-base.txt')
+    expect(resolvedId).toBe('/resolved/./dep')
+    await expect(
+      readFile(join(root, 'dist/assets/dev-base.txt'), 'utf8'),
+    ).resolves.toBe('asset from setAssetSource')
+    await expect(
+      readFile(join(root, 'dist/entries/entry.js'), 'utf8'),
+    ).resolves.toBe('export const value = 1\nconsole.log(value)')
+    await expect(
+      readFile(join(root, 'dist/late-asset.txt'), 'utf8'),
+    ).resolves.toBe('asset from generateBundle')
+  })
+})

--- a/packages/vite-plugin/src/node/devBundleRunner.ts
+++ b/packages/vite-plugin/src/node/devBundleRunner.ts
@@ -188,7 +188,7 @@ class DevBundleRunner {
           this.context,
           this.outputOptions,
           this.bundle,
-          false,
+          true,
         )
       }
     }

--- a/packages/vite-plugin/src/node/devBundleRunner.ts
+++ b/packages/vite-plugin/src/node/devBundleRunner.ts
@@ -1,0 +1,365 @@
+import { parse as parseAst } from 'acorn'
+import { createHash } from 'crypto'
+import fsx from 'fs-extra'
+import type { ResolvedConfig, ViteDevServer } from 'vite'
+import { basename, extname, isAbsolute, join } from './path'
+import type {
+  CrxEmittedFile,
+  CrxOutputBundle,
+  CrxPlugin,
+  CrxPluginContext,
+} from './types'
+
+const { outputFile } = fsx
+
+type HookHandler<T> = T | { handler: T }
+type DevInputOptions = Record<string, unknown>
+type DevOutputOptions = {
+  dir: string
+  format: 'es'
+  assetFileNames?: string | ((assetInfo: unknown) => string)
+  entryFileNames?: string | ((chunkInfo: unknown) => string)
+  chunkFileNames?: string | ((chunkInfo: unknown) => string)
+}
+
+type TransformResult = string | { code: string; map?: unknown } | null | void
+type LoadResult =
+  | string
+  | Uint8Array
+  | { code: string; map?: unknown }
+  | null
+  | void
+
+interface EmittedFileData {
+  file: CrxEmittedFile
+  fileName: string
+  source?: string | Uint8Array
+  processed?: boolean
+}
+
+function getHook<T>(hook: HookHandler<T> | undefined): T | undefined {
+  if (!hook) return undefined
+  if (typeof hook === 'object' && 'handler' in hook) return hook.handler
+  return hook
+}
+
+function firstOutputOptions(config: ResolvedConfig): DevOutputOptions {
+  const { rollupOptions, outDir } = config.build
+  const rollupOutputOptions = [rollupOptions.output].flat()[0] ?? {}
+  return {
+    ...rollupOutputOptions,
+    dir: isAbsolute(outDir) ? outDir : join(config.root, outDir),
+    format: 'es',
+  } as DevOutputOptions
+}
+
+function hash(source: string | Uint8Array | undefined): string {
+  return createHash('sha256')
+    .update(source ?? '')
+    .digest('hex')
+    .slice(0, 8)
+}
+
+function renderPattern(
+  pattern: string,
+  {
+    name,
+    source,
+  }: {
+    name: string
+    source?: string | Uint8Array
+  },
+) {
+  const extName = extname(name)
+  const baseName = basename(name, extName)
+  const ext = extName.startsWith('.') ? extName.slice(1) : extName
+  const digest = hash(source)
+
+  return pattern
+    .replace(/\[name\]/g, baseName)
+    .replace(/\[extname\]/g, extName)
+    .replace(/\[ext\]/g, ext)
+    .replace(/\[hash(?::(\d+))?\]/g, (_match, length?: string) =>
+      length ? digest.slice(0, Number(length)) : digest,
+    )
+}
+
+function normalizeLoadResult(result: LoadResult): {
+  code: string
+  map?: unknown
+} | null {
+  if (typeof result === 'string') return { code: result }
+  if (result instanceof Uint8Array)
+    return { code: Buffer.from(result).toString('utf8') }
+  if (result && typeof result === 'object' && typeof result.code === 'string')
+    return { code: result.code, map: result.map }
+  return null
+}
+
+function normalizeTransformResult(
+  result: TransformResult,
+): { code: string; map?: unknown } | null {
+  if (typeof result === 'string') return { code: result }
+  if (result && typeof result === 'object' && typeof result.code === 'string')
+    return { code: result.code, map: result.map }
+  return null
+}
+
+class DevBundleRunner {
+  readonly bundle: CrxOutputBundle = {}
+  readonly context: CrxPluginContext
+
+  private readonly emitted = new Map<string, EmittedFileData>()
+  private refIndex = 0
+
+  constructor(
+    private readonly server: ViteDevServer,
+    private readonly outputOptions: DevOutputOptions,
+  ) {
+    this.context = {
+      emitFile: (file) => this.emitFile(file),
+      getFileName: (refId) => this.getFileName(refId),
+      setAssetSource: (refId, source) => this.setAssetSource(refId, source),
+      parse: (code) =>
+        parseAst(code, {
+          ecmaVersion: 'latest',
+          sourceType: 'module',
+        }),
+      addWatchFile: () => undefined,
+      warn: (warning) => console.warn(warning),
+      error: (error) => {
+        if (error instanceof Error) throw error
+        throw new Error(String(error))
+      },
+      resolve: async (source, importer, options) => {
+        const resolved = await this.server.pluginContainer.resolveId(
+          source,
+          importer,
+          options as Parameters<
+            ViteDevServer['pluginContainer']['resolveId']
+          >[2],
+        )
+        return resolved ? { id: resolved.id } : null
+      },
+    }
+  }
+
+  async run(plugins: CrxPlugin[]) {
+    let inputOptions: DevInputOptions = {
+      input: 'index.html',
+      ...this.server.config.build.rollupOptions,
+      plugins,
+    }
+
+    for (const plugin of plugins) {
+      const options = getHook(plugin.options)
+      if (!options) continue
+      const runOptions = options as unknown as (
+        this: CrxPluginContext,
+        options: DevInputOptions,
+      ) => DevInputOptions | null | void | Promise<DevInputOptions | null | void>
+      const result = await runOptions.call(this.context, inputOptions)
+      if (result) inputOptions = { ...inputOptions, ...result }
+    }
+
+    for (const plugin of plugins) {
+      const buildStart = getHook(plugin.buildStart)
+      if (buildStart) {
+        const runBuildStart = buildStart as unknown as (
+          this: CrxPluginContext,
+          options: DevInputOptions,
+        ) => void | Promise<void>
+        await runBuildStart.call(this.context, inputOptions)
+      }
+    }
+
+    await this.processEmittedChunks(plugins)
+
+    for (const plugin of plugins) {
+      const generateBundle = getHook(plugin.generateBundle)
+      if (generateBundle) {
+        const runGenerateBundle = generateBundle as unknown as (
+          this: CrxPluginContext,
+          options: DevOutputOptions,
+          bundle: CrxOutputBundle,
+          isWrite: boolean,
+        ) => void | Promise<void>
+        await runGenerateBundle.call(
+          this.context,
+          this.outputOptions,
+          this.bundle,
+          false,
+        )
+      }
+    }
+
+    await this.writeBundle()
+  }
+
+  private emitFile(file: CrxEmittedFile): string {
+    const refId = `crx:${file.type}:${this.refIndex++}`
+    const fileName = this.resolveFileName(file)
+    const data: EmittedFileData = { file, fileName }
+    this.emitted.set(refId, data)
+
+    if (file.type === 'asset' && typeof file.source !== 'undefined') {
+      data.source = file.source
+      this.bundle[fileName] = {
+        type: 'asset',
+        fileName,
+        name: file.name,
+        source: file.source,
+      }
+    }
+
+    return refId
+  }
+
+  private getFileName(refId: string): string {
+    const data = this.emitted.get(refId)
+    if (!data) throw new Error(`Unable to get file name for "${refId}"`)
+    return data.fileName
+  }
+
+  private setAssetSource(refId: string, source: string | Uint8Array): void {
+    const data = this.emitted.get(refId)
+    if (!data) throw new Error(`Unable to set asset source for "${refId}"`)
+    if (data.file.type !== 'asset')
+      throw new Error(`Cannot set asset source for chunk "${refId}"`)
+
+    data.source = source
+    this.bundle[data.fileName] = {
+      type: 'asset',
+      fileName: data.fileName,
+      name: data.file.name,
+      source,
+    }
+  }
+
+  private resolveFileName(file: CrxEmittedFile): string {
+    if (file.fileName) return file.fileName
+
+    if (file.type === 'asset') {
+      const name = file.name ?? 'asset'
+      const assetFileNames = this.outputOptions.assetFileNames
+      if (typeof assetFileNames === 'function') {
+        return assetFileNames({
+          name,
+          source: file.source,
+          type: 'asset',
+        })
+      }
+
+      return renderPattern(assetFileNames ?? 'assets/[name]-[hash][extname]', {
+        name,
+        source: file.source,
+      })
+    }
+
+    const name = file.name ?? basename(file.id)
+    const entryFileNames = this.outputOptions.entryFileNames
+    if (typeof entryFileNames === 'function') {
+      return entryFileNames({
+        name,
+        facadeModuleId: file.id,
+        type: 'chunk',
+      })
+    }
+
+    if (entryFileNames) return renderPattern(entryFileNames, { name })
+    return name.endsWith('.js') ? name : `${name}.js`
+  }
+
+  private async processEmittedChunks(plugins: CrxPlugin[]) {
+    for (const data of this.emitted.values()) {
+      if (data.file.type !== 'chunk' || data.processed) continue
+      data.processed = true
+
+      const loaded = await this.load(data.file.id, plugins)
+      if (!loaded)
+        throw new Error(`Unable to load emitted chunk "${data.file.id}"`)
+
+      const transformed = await this.transform(loaded.code, data.file.id, plugins)
+      const code = transformed?.code ?? loaded.code
+      const map = transformed?.map ?? loaded.map
+
+      this.bundle[data.fileName] = {
+        type: 'chunk',
+        fileName: data.fileName,
+        code,
+        facadeModuleId: data.file.id,
+        imports: [],
+        dynamicImports: [],
+        exports: [],
+        modules: { [data.file.id]: {} },
+        isEntry: true,
+        map,
+      }
+    }
+  }
+
+  private async load(id: string, plugins: CrxPlugin[]) {
+    for (const plugin of plugins) {
+      const load = getHook(plugin.load)
+      if (!load) continue
+      const runLoad = load as unknown as (
+        this: CrxPluginContext,
+        id: string,
+      ) => LoadResult | Promise<LoadResult>
+      const result = normalizeLoadResult(await runLoad.call(this.context, id))
+      if (result) return result
+    }
+    return null
+  }
+
+  private async transform(code: string, id: string, plugins: CrxPlugin[]) {
+    let current = code
+    let map: unknown
+
+    for (const plugin of plugins) {
+      const transform = getHook(plugin.transform)
+      if (!transform) continue
+      const runTransform = transform as unknown as (
+        this: CrxPluginContext,
+        code: string,
+        id: string,
+      ) => TransformResult | Promise<TransformResult>
+      const result = normalizeTransformResult(
+        await runTransform.call(this.context, current, id),
+      )
+      if (result) {
+        current = result.code
+        map = result.map
+      }
+    }
+
+    return { code: current, map }
+  }
+
+  private async writeBundle() {
+    for (const item of Object.values(this.bundle)) {
+      const target = join(this.outputOptions.dir, item.fileName)
+      if (item.type === 'asset') {
+        await output(item.source, target)
+      } else {
+        await output(item.code, target)
+      }
+    }
+  }
+}
+
+async function output(source: string | Uint8Array, target: string) {
+  if (source instanceof Uint8Array) await outputFile(target, source)
+  else await outputFile(target, source, { encoding: 'utf8' })
+}
+
+export async function writeDevBundle({
+  server,
+  plugins,
+}: {
+  server: ViteDevServer
+  plugins: CrxPlugin[]
+}) {
+  const runner = new DevBundleRunner(server, firstOutputOptions(server.config))
+  await runner.run(plugins)
+}

--- a/packages/vite-plugin/src/node/fileWriter-rxjs.ts
+++ b/packages/vite-plugin/src/node/fileWriter-rxjs.ts
@@ -2,7 +2,6 @@ import * as lexer from 'es-module-lexer'
 import fsx from 'fs-extra'
 import { readFile } from 'fs/promises'
 import MagicString from 'magic-string'
-import { OutputAsset, OutputChunk } from 'rollup'
 import {
   BehaviorSubject,
   debounceTime,
@@ -26,7 +25,13 @@ import { build as viteBuild, ErrorPayload, ViteDevServer } from 'vite'
 import { OutputFile, outputFiles } from './fileWriter-filesMap'
 import { getFileName, getOutputPath, getViteUrl } from './fileWriter-utilities'
 import { join } from './path'
-import { CrxDevAssetId, CrxDevScriptId, CrxPlugin } from './types'
+import {
+  CrxDevAssetId,
+  CrxDevScriptId,
+  CrxOutputAsset,
+  CrxOutputChunk,
+  CrxPlugin,
+} from './types'
 import convertSourceMap from 'convert-source-map'
 
 const { outputFile } = fsx
@@ -43,10 +48,14 @@ const resolveScriptInput = (server: ViteDevServer, id: string) => {
   return id
 }
 
-const isOutputChunk = (item: OutputChunk | OutputAsset): item is OutputChunk =>
+const isOutputChunk = (
+  item: CrxOutputChunk | CrxOutputAsset,
+): item is CrxOutputChunk =>
   item.type === 'chunk'
 
-const isOutputAsset = (item: OutputChunk | OutputAsset): item is OutputAsset =>
+const isOutputAsset = (
+  item: CrxOutputChunk | CrxOutputAsset,
+): item is CrxOutputAsset =>
   item.type === 'asset'
 
 /* ----------------- SERVER EVENTS ----------------- */
@@ -334,17 +343,20 @@ async function bundleIife(
     },
   })
 
-  // viteBuild with write: false returns RollupOutput or RollupOutput[]
+  // viteBuild with write: false returns bundler output objects. Cast to the
+  // local output shape so this package doesn't expose Rollup types.
   const outputs = Array.isArray(result) ? result : [result]
   const firstOutput = outputs[0]
-  const output = 'output' in firstOutput ? firstOutput.output : undefined
+  const output = (
+    'output' in firstOutput ? firstOutput.output : undefined
+  ) as (CrxOutputChunk | CrxOutputAsset)[] | undefined
 
   if (!output) {
     throw new Error(`Unable to generate IIFE bundle for "${script.id}"`)
   }
 
   const entryChunk = output.find(
-    (item): item is OutputChunk => isOutputChunk(item) && item.isEntry,
+    (item): item is CrxOutputChunk => isOutputChunk(item) && item.isEntry,
   )
   if (!entryChunk) {
     throw new Error(`Unable to generate IIFE bundle for "${script.id}"`)
@@ -357,7 +369,7 @@ async function bundleIife(
       !asset.fileName.startsWith('.vite/'),
   )
   const extraChunks = output.filter(
-    (item): item is OutputChunk => isOutputChunk(item) && !item.isEntry,
+    (item): item is CrxOutputChunk => isOutputChunk(item) && !item.isEntry,
   )
 
   return {

--- a/packages/vite-plugin/src/node/fileWriter.ts
+++ b/packages/vite-plugin/src/node/fileWriter.ts
@@ -1,8 +1,8 @@
 import fsx from 'fs-extra'
 import { performance } from 'perf_hooks'
-import { OutputOptions, rollup, RollupOptions } from 'rollup'
 import { concatWith, firstValueFrom, mergeMap, of, takeUntil } from 'rxjs'
 import { ViteDevServer } from 'vite'
+import { writeDevBundle } from './devBundleRunner'
 import { OutputFile, outputFiles } from './fileWriter-filesMap'
 import {
   allFilesReady,
@@ -42,10 +42,10 @@ function queueWrite(
  * Starts the file writer.
  *
  * - Signals write() to start by providing the Vite Dev Server.
- * - Runs Rollup with internal plugins to output the CRX base.
+ * - Runs CRX internal plugins to output the dev CRX base.
  * - CRX base includes: manifest, loader files, and public folder.
  * - Output is pure assets, no actual scripts.
- * - Resolves when Rollup completes.
+ * - Resolves when the dev bundle writer completes.
  */
 export async function start({
   server,
@@ -57,23 +57,8 @@ export async function start({
   const plugins = server.config.plugins.filter((p): p is CrxPlugin =>
     p.name?.startsWith('crx:'),
   )
-  const { rollupOptions, outDir } = server.config.build
-  const inputOptions: RollupOptions = {
-    input: 'index.html',
-    ...rollupOptions,
-    plugins,
-  }
-  // handle the various output option types
-  const rollupOutputOptions = [rollupOptions.output].flat()[0]
-  const outputOptions: OutputOptions = {
-    ...rollupOutputOptions,
-    dir: outDir,
-    format: 'es',
-  }
-
   fileWriterEvent$.next({ type: 'build_start' })
-  const build = await rollup(inputOptions)
-  await build.write(outputOptions)
+  await writeDevBundle({ server, plugins })
   fileWriterEvent$.next({ type: 'build_end' })
 
   await allFilesReady()

--- a/packages/vite-plugin/src/node/fileWriter.ts
+++ b/packages/vite-plugin/src/node/fileWriter.ts
@@ -1,5 +1,6 @@
 import fsx from 'fs-extra'
 import { performance } from 'perf_hooks'
+import { rollup, type OutputOptions, type RollupOptions } from 'rollup'
 import { concatWith, firstValueFrom, mergeMap, of, takeUntil } from 'rxjs'
 import { ViteDevServer } from 'vite'
 import { writeDevBundle } from './devBundleRunner'
@@ -19,6 +20,7 @@ import {
   prefix,
 } from './fileWriter-utilities'
 import { _debug } from './helpers'
+import { getOptions } from './plugin-optionsProvider'
 import { CrxDevAssetId, CrxDevScriptId, CrxPlugin } from './types'
 
 export { allFilesReady, fileReady }
@@ -26,6 +28,30 @@ export { allFilesReady, fileReady }
 const { outputFile } = fsx
 
 const debug = _debug('file-writer')
+
+async function writeRollupDevBundle({
+  server,
+  plugins,
+}: {
+  server: ViteDevServer
+  plugins: CrxPlugin[]
+}) {
+  const { rollupOptions, outDir } = server.config.build
+  const inputOptions: RollupOptions = {
+    input: 'index.html',
+    ...rollupOptions,
+    plugins,
+  }
+  const rollupOutputOptions = [rollupOptions.output].flat()[0]
+  const outputOptions: OutputOptions = {
+    ...rollupOutputOptions,
+    dir: outDir,
+    format: 'es',
+  }
+
+  const build = await rollup(inputOptions)
+  await build.write(outputOptions)
+}
 
 function queueWrite(
   script: CrxDevAssetId | CrxDevScriptId,
@@ -57,8 +83,13 @@ export async function start({
   const plugins = server.config.plugins.filter((p): p is CrxPlugin =>
     p.name?.startsWith('crx:'),
   )
+  const options = await getOptions({ plugins: [...server.config.plugins] })
   fileWriterEvent$.next({ type: 'build_start' })
-  await writeDevBundle({ server, plugins })
+  if (options.experimental?.viteDevBundle) {
+    await writeDevBundle({ server, plugins })
+  } else {
+    await writeRollupDevBundle({ server, plugins })
+  }
   fileWriterEvent$.next({ type: 'build_end' })
 
   await allFilesReady()

--- a/packages/vite-plugin/src/node/helpers.ts
+++ b/packages/vite-plugin/src/node/helpers.ts
@@ -1,7 +1,7 @@
 import { simple } from 'acorn-walk'
 import { createHash as _hash } from 'crypto'
 import debug from 'debug'
-import { AcornNode, OutputBundle, PluginContext } from 'rollup'
+import type { Node as AcornNode } from 'acorn'
 import type {
   ManifestV3,
   WebAccessibleResourceById,
@@ -12,6 +12,8 @@ import type {
   AcornLiteral,
   AcornMemberExpression,
   AcornTemplateElement,
+  CrxOutputBundle,
+  CrxPluginContext,
 } from './types'
 
 export const _debug = (id: string) => debug('crx').extend(id)
@@ -55,7 +57,10 @@ export function isIdentifier(n: AcornNode): n is AcornIdentifier {
   return n.type === 'Identifier'
 }
 
-export function decodeManifest(this: PluginContext, code: string): ManifestV3 {
+export function decodeManifest(
+  this: Pick<CrxPluginContext, 'parse'>,
+  code: string,
+): ManifestV3 {
   const tree = this.parse(code)
 
   let literal: AcornLiteral | undefined
@@ -84,7 +89,7 @@ export function encodeManifest(manifest: ManifestV3): string {
   return `export default ${json}`
 }
 
-export function parseJsonAsset<T>(bundle: OutputBundle, key: string): T {
+export function parseJsonAsset<T>(bundle: CrxOutputBundle, key: string): T {
   const asset = bundle[key]
 
   if (typeof asset === 'undefined')

--- a/packages/vite-plugin/src/node/plugin-contentScripts.ts
+++ b/packages/vite-plugin/src/node/plugin-contentScripts.ts
@@ -1,6 +1,5 @@
 import contentHmrPort from 'client/es/hmr-content-port.ts'
 import { filter, Subscription } from 'rxjs'
-import type { OutputBundle, PluginContext } from 'rollup'
 import { ConfigEnv, UserConfig, ViteDevServer } from 'vite'
 import {
   contentScripts,
@@ -15,7 +14,12 @@ import { getCrxHmrToken } from './hmrToken'
 import { getOptions } from './plugin-optionsProvider'
 import { basename, dirname, relative } from './path'
 import { RxMap } from './RxMap'
-import { CrxPluginFn, ResolvedConfigWithHMRToken } from './types'
+import {
+  CrxOutputBundle,
+  CrxPluginContext,
+  CrxPluginFn,
+  ResolvedConfigWithHMRToken,
+} from './types'
 import { contentHmrPortId, preambleId, viteClientId } from './virtualFileIds'
 import colors from 'picocolors'
 
@@ -279,8 +283,8 @@ export const pluginContentScripts: CrxPluginFn = () => {
  * replacement happen in different post-build hooks across Vite versions.
  */
 export function finalizeBuildContentScripts(
-  context: Pick<PluginContext, 'emitFile' | 'getFileName'>,
-  bundle: OutputBundle,
+  context: Pick<CrxPluginContext, 'emitFile' | 'getFileName'>,
+  bundle: CrxOutputBundle,
   worldMainIds = new Set<string>(),
 ) {
   const processed = new Set<object>()

--- a/packages/vite-plugin/src/node/plugin-contentScripts_iife.ts
+++ b/packages/vite-plugin/src/node/plugin-contentScripts_iife.ts
@@ -1,17 +1,15 @@
-import type {
-  OutputAsset,
-  OutputChunk,
-  PluginContext,
-  RollupOutput,
-  RollupWatcher,
-} from 'rollup'
 import { build, mergeConfig, InlineConfig, ResolvedConfig, UserConfig } from 'vite'
 import { contentScripts, type ContentScript } from './contentScripts'
 import { formatFileData } from './fileWriter-utilities'
 import type { ManifestV3 } from './manifest'
 import { basename, dirname, join } from './path'
 import { getOptions } from './plugin-optionsProvider'
-import { CrxPluginFn } from './types'
+import {
+  CrxOutputAsset,
+  CrxOutputChunk,
+  CrxPluginContext,
+  CrxPluginFn,
+} from './types'
 import colors from 'picocolors'
 
 type IifeEntry = {
@@ -20,8 +18,11 @@ type IifeEntry = {
   matches: string[]
 }
 
-type IifeBuildResult = RollupOutput | RollupOutput[] | RollupWatcher
-type IifeBuildOutput = OutputAsset | OutputChunk
+type IifeBuildResult =
+  | { output: IifeBuildOutput[] }
+  | { output: IifeBuildOutput[] }[]
+  | { on: (...args: unknown[]) => unknown }
+type IifeBuildOutput = CrxOutputAsset | CrxOutputChunk
 
 /**
  * Check if a content script file should be built as IIFE based on its filename.
@@ -117,7 +118,7 @@ export const pluginContentScriptsIife: CrxPluginFn = () => {
           try {
             const iifeConfig = createIifeConfig(config, entry.id, outputFileName)
             const result = await build(iifeConfig)
-            const outputs = getBuildOutputs(result, entry.file)
+            const outputs = getBuildOutputs(result as IifeBuildResult, entry.file)
             emitIifeOutputs(this, outputs, entry.file, outputFileName)
             registerIifeContentScript(entry, outputFileName)
 
@@ -195,13 +196,13 @@ function getBuildOutputs(
 }
 
 function emitIifeOutputs(
-  context: Pick<PluginContext, 'emitFile'>,
+  context: Pick<CrxPluginContext, 'emitFile'>,
   outputs: IifeBuildOutput[],
   entryFile: string,
   outputFileName: string,
 ): void {
   const entryChunk = outputs.find(
-    (output): output is OutputChunk =>
+    (output): output is CrxOutputChunk =>
       output.type === 'chunk' && output.isEntry,
   )
   if (!entryChunk) {

--- a/packages/vite-plugin/src/node/plugin-manifest.ts
+++ b/packages/vite-plugin/src/node/plugin-manifest.ts
@@ -2,7 +2,6 @@ import loadingPageScript from 'client/es/loading-page-script.ts'
 import loadingPageHtml from 'client/html/loading-page.html'
 import { existsSync, promises as fs } from 'fs'
 import colors from 'picocolors'
-import { OutputAsset, OutputChunk } from 'rollup'
 import { ResolvedConfig, UserConfig, version as ViteVersion } from 'vite'
 import { contentScripts, hashScriptId } from './contentScripts'
 import { formatFileData, getFileName, prefix } from './fileWriter-utilities'
@@ -11,7 +10,13 @@ import { decodeManifest, encodeManifest, isString } from './helpers'
 import { ManifestV3 } from './manifest'
 import { basename, isAbsolute, join, normalize, relative } from './path'
 import { getOptions } from './plugin-optionsProvider'
-import { CrxPlugin, CrxPluginFn, ManifestFiles } from './types'
+import {
+  CrxOutputAsset,
+  CrxOutputChunk,
+  CrxPlugin,
+  CrxPluginFn,
+  ManifestFiles,
+} from './types'
 import {
   clearContentCssEntries,
   getContentCssEntries,
@@ -395,7 +400,7 @@ export const pluginManifest: CrxPluginFn = () => {
       },
       async generateBundle(options, bundle) {
         const manifestName = this.getFileName(refId)
-        const manifestJs = bundle[manifestName] as OutputChunk
+        const manifestJs = bundle[manifestName] as CrxOutputChunk
         let manifest = decodeManifest.call(this, manifestJs.code)
 
         /* ----------- UPDATE EMITTED FILE NAMES ----------- */
@@ -576,7 +581,7 @@ Public dir: "${config.publicDir}"`,
         /* -------------- OUTPUT MANIFEST FILE ------------- */
 
         // overwrite vite manifest.json after render hooks
-        const manifestJson = bundle['manifest.json'] as OutputAsset
+        const manifestJson = bundle['manifest.json'] as CrxOutputAsset
         if (typeof manifestJson === 'undefined') {
           this.emitFile({
             type: 'asset',

--- a/packages/vite-plugin/src/node/plugin-webAccessibleResources.ts
+++ b/packages/vite-plugin/src/node/plugin-webAccessibleResources.ts
@@ -1,4 +1,3 @@
-import { OutputChunk } from 'rollup'
 import {
   Manifest as ViteManifest,
   ResolvedConfig,
@@ -18,7 +17,7 @@ import {
   WebAccessibleResourceByMatch,
 } from './manifest'
 import { getOptions } from './plugin-optionsProvider'
-import type { CrxPluginFn, Browser } from './types'
+import type { Browser, CrxOutputChunk, CrxPluginFn } from './types'
 
 const debug = _debug('web-acc-res')
 
@@ -127,7 +126,7 @@ export const pluginWebAccessibleResources: CrxPluginFn = () => {
             viteFiles.set(file.file, file)
           if (viteFiles.size === 0) return null
 
-          const bundleChunks = new Map<string, OutputChunk>()
+          const bundleChunks = new Map<string, CrxOutputChunk>()
           for (const chunk of Object.values(bundle))
             if (chunk.type === 'chunk') bundleChunks.set(chunk.fileName, chunk)
 
@@ -235,7 +234,7 @@ export const pluginWebAccessibleResources: CrxPluginFn = () => {
           for (const res of war.resources) {
             resourcesWithMaps.push(res)
             if (bundle[res]?.type === 'chunk') {
-              const chunk = bundle[res] as OutputChunk & {
+              const chunk = bundle[res] as CrxOutputChunk & {
                 // OutputChunk.sourcemapFileName available in Vite >=5 (Rollup 3.29).
                 sourcemapFileName: string
               }

--- a/packages/vite-plugin/src/node/types.ts
+++ b/packages/vite-plugin/src/node/types.ts
@@ -1,8 +1,7 @@
 import type { Node as AcornNode } from 'acorn'
 import type { GlobOptions } from 'tinyglobby'
-import type { OutputBundle, PluginContext } from 'rollup'
 import type { HMRPayload, ResolvedConfig, Plugin as VitePlugin } from 'vite'
-import { ManifestV3 } from './manifest'
+import type { ManifestV3 } from './manifest'
 
 export interface AcornLiteral extends AcornNode {
   type: 'Literal'
@@ -50,13 +49,68 @@ export type CrxDevScriptId = {
   type: 'module' | 'iife'
 }
 
+export type CrxOutputAsset = {
+  type: 'asset'
+  fileName: string
+  source: string | Uint8Array
+  name?: string
+}
+
+export type CrxOutputChunk = {
+  type: 'chunk'
+  fileName: string
+  code: string
+  facadeModuleId: string | null
+  imports: string[]
+  dynamicImports: string[]
+  exports: string[]
+  modules: Record<string, unknown>
+  isEntry: boolean
+  map?: unknown
+  sourcemapFileName?: string
+}
+
+export type CrxOutputBundle = Record<string, CrxOutputAsset | CrxOutputChunk>
+
+export type CrxEmittedAsset = {
+  type: 'asset'
+  name?: string
+  fileName?: string
+  source?: string | Uint8Array
+}
+
+export type CrxEmittedChunk = {
+  type: 'chunk'
+  id: string
+  name?: string
+  fileName?: string
+  preserveSignature?: false | 'strict' | 'exports-only' | 'allow-extension'
+}
+
+export type CrxEmittedFile = CrxEmittedAsset | CrxEmittedChunk
+
+export interface CrxPluginContext {
+  emitFile(file: CrxEmittedFile): string
+  getFileName(refId: string): string
+  setAssetSource(refId: string, source: string | Uint8Array): void
+  parse(code: string): AcornNode
+  addWatchFile(id: string): void
+  warn(warning: unknown): void
+  error(error: unknown): never
+  resolve(
+    source: string,
+    importer?: string,
+    options?: { skipSelf?: boolean },
+  ): Promise<{ id: string } | null>
+}
+
 export interface CrxPlugin extends VitePlugin {
   /**
    * Runs during the transform hook for the manifest. Filenames use input
    * filenames.
    */
   transformCrxManifest?: (
-    this: PluginContext,
+    this: CrxPluginContext,
     manifest: ManifestV3,
   ) => Promise<ManifestV3 | null | undefined> | ManifestV3 | null | undefined
   /**
@@ -64,9 +118,9 @@ export interface CrxPlugin extends VitePlugin {
    * filenames.
    */
   renderCrxManifest?: (
-    this: PluginContext,
+    this: CrxPluginContext,
     manifest: ManifestV3,
-    bundle: OutputBundle,
+    bundle: CrxOutputBundle,
   ) => Promise<ManifestV3 | null | undefined> | ManifestV3 | null | undefined
   /**
    * Runs in the file writer on content scripts during development. `script.id`

--- a/packages/vite-plugin/src/node/types.ts
+++ b/packages/vite-plugin/src/node/types.ts
@@ -134,6 +134,15 @@ export interface CrxPlugin extends VitePlugin {
 
 // change this to an interface when you want to add options
 export interface CrxOptions {
+  experimental?: {
+    /**
+     * Use the Vite plugin container instead of Rollup to write the development
+     * extension base files.
+     *
+     * This is opt-in while the Rollup-compatible path remains the default.
+     */
+    viteDevBundle?: boolean
+  }
   contentScripts?: {
     preambleCode?: string | false
     hmrTimeout?: number

--- a/packages/vite-plugin/tests/out/with-web-accessible-html/vite.config.ts
+++ b/packages/vite-plugin/tests/out/with-web-accessible-html/vite.config.ts
@@ -25,6 +25,9 @@ export default defineConfig({
   logLevel: 'error',
   plugins: [
     crx({
+      experimental: {
+        viteDevBundle: true,
+      },
       manifest: {
         manifest_version: 3,
         version: '1.0.0',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,6 +239,9 @@ importers:
       '@webcomponents/custom-elements':
         specifier: ^1.5.0
         version: 1.6.0
+      acorn:
+        specifier: ^8.15.0
+        version: 8.15.0
       acorn-walk:
         specifier: ^8.3.5
         version: 8.3.5
@@ -269,9 +272,6 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
-      rollup:
-        specifier: 2.80.0
-        version: 2.80.0
       rxjs:
         specifier: 7.5.7
         version: 7.5.7
@@ -384,6 +384,9 @@ importers:
       rimraf:
         specifier: 3.0.2
         version: 3.0.2
+      rollup:
+        specifier: 2.80.0
+        version: 2.80.0
       rollup-plugin-dts:
         specifier: ^4.2.0
         version: 4.2.3(rollup@2.80.0)(typescript@4.9.5)
@@ -10882,6 +10885,7 @@ snapshots:
   '@crxjs/vite-plugin@file:packages/vite-plugin(vite@6.4.1(@types/node@22.19.5)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2))':
     dependencies:
       '@webcomponents/custom-elements': 1.6.0
+      acorn: 8.15.0
       acorn-walk: 8.3.5
       convert-source-map: 1.9.0
       debug: 4.4.3
@@ -10892,7 +10896,6 @@ snapshots:
       node-html-parser: 7.1.0
       pathe: 2.0.3
       picocolors: 1.1.1
-      rollup: 2.80.0
       rxjs: 7.5.7
       tinyglobby: 0.2.17
       vite: 6.4.1(@types/node@22.19.5)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,6 +272,9 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+      rollup:
+        specifier: 2.80.0
+        version: 2.80.0
       rxjs:
         specifier: 7.5.7
         version: 7.5.7
@@ -384,9 +387,6 @@ importers:
       rimraf:
         specifier: 3.0.2
         version: 3.0.2
-      rollup:
-        specifier: 2.80.0
-        version: 2.80.0
       rollup-plugin-dts:
         specifier: ^4.2.0
         version: 4.2.3(rollup@2.80.0)(typescript@4.9.5)
@@ -10896,6 +10896,7 @@ snapshots:
       node-html-parser: 7.1.0
       pathe: 2.0.3
       picocolors: 1.1.1
+      rollup: 2.80.0
       rxjs: 7.5.7
       tinyglobby: 0.2.17
       vite: 6.4.1(@types/node@22.19.5)(jiti@2.6.1)(terser@5.44.1)(yaml@2.8.2)


### PR DESCRIPTION
## Summary
- add an opt-in Vite-powered development bundle writer behind `experimental.viteDevBundle`
- keep the existing Rollup writer as the default path for compatibility
- keep `rollup` as a runtime dependency until the Vite writer becomes the default in a future release
- cover the Vite writer with a direct unit test and an output fixture that uses HTML entries in `rollupOptions.input`

## Feature flag

The new writer is disabled by default. Projects can opt in explicitly:

```ts
crx({
  experimental: {
    viteDevBundle: true,
  },
  manifest,
})
```

When the flag is omitted or set to `false`, development output continues to use the existing Rollup writer.

## Validation
- `pnpm -C packages/vite-plugin exec vitest --run tests/out/with-web-accessible-html/serve.test.ts`
- `pnpm -C packages/vite-plugin exec tsc --noEmit`
- `pnpm -C packages/vite-plugin run lint:eslint`
- `pnpm -C packages/vite-plugin run build`
- `pnpm -C packages/vite-plugin exec vitest --run --mode out`