### PR TITLE
fix(vite-plugin): handle self imports in content script hmr

### DIFF
--- a/.github/workflows/vite-plugin.yml
+++ b/.github/workflows/vite-plugin.yml
@@ -133,6 +133,10 @@ jobs:
         if: matrix.vite-version != '3'
         run: pnpm add -D vite@${{ matrix.vite-version }} --ignore-scripts
 
+      - name: Install React plugin for Vite 8
+        if: matrix.vite-version == '8'
+        run: pnpm add -D @vitejs/plugin-react@5.2.0 --ignore-scripts
+
       - name: Verify Vite version
         run: echo "Testing with Vite $(pnpm exec vite --version)"
 
@@ -181,6 +185,10 @@ jobs:
       - name: Install Vite ${{ matrix.vite-version }} for testing
         if: matrix.vite-version != '3'
         run: pnpm add -D vite@${{ matrix.vite-version }} --ignore-scripts
+
+      - name: Install React plugin for Vite 8
+        if: matrix.vite-version == '8'
+        run: pnpm add -D @vitejs/plugin-react@5.2.0 --ignore-scripts
 
       - name: Verify Vite version
         run: echo "Testing with Vite $(pnpm exec vite --version)"

--- a/packages/vite-plugin/scripts/run-vite-matrix.mjs
+++ b/packages/vite-plugin/scripts/run-vite-matrix.mjs
@@ -299,6 +299,15 @@ async function main() {
         ])
       }
 
+      if (majorVersion === '8') {
+        await run(PNPM, [
+          'add',
+          '-D',
+          '@vitejs/plugin-react@5.2.0',
+          '--ignore-scripts',
+        ])
+      }
+
       const viteVersion = await capture(PNPM, ['exec', 'vite', '--version'])
       console.log(`[vite-matrix] Testing with ${viteVersion}`)
 

--- a/packages/vite-plugin/src/node/fileWriter-rxjs.ts
+++ b/packages/vite-plugin/src/node/fileWriter-rxjs.ts
@@ -274,16 +274,20 @@ function prepScript(
       mergeMap(async ({ target, code, deps }) => {
         await lexer.init
         const [imports] = lexer.parse(code, fileName)
-        const depSet = new Set<string>(deps)
+        const isSelfDependency = (id: string) =>
+          getFileName({ type: 'module', id }) === fileName
+        // @vitejs/plugin-react >=5.0.4 can create React Refresh self-imports.
+        // Keep the import rewrite, but do not wait on this file as its own dependency.
+        const depSet = new Set<string>(deps.filter((id) => !isSelfDependency(id)))
         const magic = new MagicString(code)
         for (const i of imports)
           if (i.n) {
-            depSet.add(i.n)
-            const fileName = getFileName({ type: 'module', id: i.n })
+            const depFileName = getFileName({ type: 'module', id: i.n })
+            if (!isSelfDependency(i.n)) depSet.add(i.n)
 
             // NOTE: Temporary fix for this bug: https://github.com/guybedford/es-module-lexer/issues/144
             const fullImport = code.substring(i.s, i.e)
-            magic.overwrite(i.s, i.e, fullImport.replace(i.n, `/${fileName}`))
+            magic.overwrite(i.s, i.e, fullImport.replace(i.n, `/${depFileName}`))
 
             // NOTE: use this once the bug is fixed
             // magic.overwrite(i.s, i.e, `/${fileName}`)

--- a/packages/vite-plugin/tests/out/vite-react-fast-refresh/vite-8-react-refresh-self-import.test.ts
+++ b/packages/vite-plugin/tests/out/vite-react-fast-refresh/vite-8-react-refresh-self-import.test.ts
@@ -1,0 +1,29 @@
+import fs from 'fs-extra'
+import { createRequire } from 'module'
+import path from 'pathe'
+import { allFilesSuccess } from 'src/fileWriter-rxjs'
+import { serve } from 'tests/runners'
+import { expect, test } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const viteVersion = (require('vite/package.json') as { version: string }).version
+const testIfVite8 = viteVersion.startsWith('8.') ? test : test.skip
+
+testIfVite8('serve emits React Refresh self import for Vite 8', async () => {
+  const result = await serve(__dirname)
+
+  try {
+    await allFilesSuccess()
+
+    const appModule = await fs.readFile(
+      path.join(result.outDir, 'src/App.tsx.js'),
+      'utf-8',
+    )
+
+    expect(appModule).toContain(
+      'import * as __vite_react_currentExports from "/src/App.tsx.js"',
+    )
+  } finally {
+    result.server.close()
+  }
+})


### PR DESCRIPTION
Fixes #1204

## What changed

- Skip self-imported modules when collecting file-writer dependencies for served extension modules.
- Keep rewriting those imports to extension file URLs so runtime behavior is unchanged.
- Test Vite 8 against @vitejs/plugin-react@5.2.0, the React plugin line that supports Vite 8.
- Extend the existing React content-script HMR e2e test to assert that React Refresh generated a self-import boundary.

## Why

Newer @vitejs/plugin-react versions generate a React Refresh boundary that imports the current module exports from the same output module. With Vite 8 and plugin-react 5.2.0 this appears as an import like /src/App.jsx.js inside /src/App.jsx.js. CRXJS still needs to rewrite that import, but it should not wait on the module as its own dependency. Otherwise the file writer can block the content-script HMR payload from being forwarded.

## Validation

- pnpm exec vitest --run --mode e2e tests/e2e/mv3-vite-react-content-script-hmr/vite-serve.test.ts
- pnpm test:vite-matrix -- --vite 8 --mode e2e -- tests/e2e/mv3-vite-react-content-script-hmr/vite-serve.test.ts
- pnpm exec eslint src/node/fileWriter-rxjs.ts tests/e2e/mv3-vite-react-content-script-hmr/vite-serve.test.ts
- node --check scripts/run-vite-matrix.mjs
