### PR TITLE
fix: expose dynamic import css to content scripts

### DIFF
--- a/.changeset/bright-css-waves.md
+++ b/.changeset/bright-css-waves.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+Expose CSS imported by dynamic content script chunks as web-accessible resources so Chrome can load those styles at runtime.

--- a/packages/vite-plugin/src/node/compileFileResources.ts
+++ b/packages/vite-plugin/src/node/compileFileResources.ts
@@ -8,6 +8,8 @@ interface FileResources {
   assets: Set<string>
   css: Set<string>
   imports: Set<string>
+  // CSS from chunks loaded through dynamic imports. Vite loads these at runtime.
+  runtimeCss: Set<string>
 }
 
 export function compileFileResources(
@@ -25,21 +27,40 @@ export function compileFileResources(
     assets: new Set(),
     css: new Set(),
     imports: new Set(),
+    runtimeCss: new Set(),
   },
   processedFiles = new Set(),
+  includeCssInRuntime = false,
 ): FileResources {
-  if (processedFiles.has(fileName)) {
+  const processedKey = `${
+    includeCssInRuntime ? 'runtime' : 'static'
+  }:${fileName}`
+  if (processedFiles.has(processedKey)) {
     return resources
   }
-  processedFiles.add(fileName)
+  processedFiles.add(processedKey)
 
   const chunk = chunks.get(fileName)
   if (chunk) {
     const { modules, facadeModuleId, imports, dynamicImports } = chunk
     for (const x of imports) resources.imports.add(x)
     for (const x of dynamicImports) resources.imports.add(x)
-    for (const x of [...imports, ...dynamicImports])
-      compileFileResources(x, { chunks, files, config }, resources, processedFiles)
+    for (const x of imports)
+      compileFileResources(
+        x,
+        { chunks, files, config },
+        resources,
+        processedFiles,
+        includeCssInRuntime,
+      )
+    for (const x of dynamicImports)
+      compileFileResources(
+        x,
+        { chunks, files, config },
+        resources,
+        processedFiles,
+        true,
+      )
     for (const m of Object.keys(modules))
       if (m !== facadeModuleId) {
         const key = prefix('/', relative(config.root, m.split('?')[0]))
@@ -54,6 +75,7 @@ export function compileFileResources(
               { chunks, files, config },
               resources,
               processedFiles,
+              includeCssInRuntime,
             )
           }
       }
@@ -62,7 +84,10 @@ export function compileFileResources(
   if (file) {
     const { assets = [], css = [] } = file
     for (const x of assets) resources.assets.add(x)
-    for (const x of css) resources.css.add(x)
+    for (const x of css) {
+      resources.css.add(x)
+      if (includeCssInRuntime) resources.runtimeCss.add(x)
+    }
   }
   return resources
 }

--- a/packages/vite-plugin/src/node/plugin-webAccessibleResources.ts
+++ b/packages/vite-plugin/src/node/plugin-webAccessibleResources.ts
@@ -148,10 +148,12 @@ export const pluginWebAccessibleResources: CrxPluginFn = () => {
                     `Content script filename is undefined for "${id}"`,
                   )
                 } else {
-                  const { assets, css, imports } = compileFileResources(
-                    fileName,
-                    { chunks: bundleChunks, files: viteFiles, config },
-                  )
+                  const { assets, css, imports, runtimeCss } =
+                    compileFileResources(fileName, {
+                      chunks: bundleChunks,
+                      files: viteFiles,
+                      config,
+                    })
 
                   // update content script resources for use by css plugin
                   contentScripts.get(key)!.css = [...css]
@@ -172,9 +174,9 @@ export const pluginWebAccessibleResources: CrxPluginFn = () => {
                       : false,
                   }
 
-                  if (isDynamicScript || !injectCss) {
-                    resource.resources.push(...css)
-                  }
+                  const cssResources =
+                    isDynamicScript || !injectCss ? css : runtimeCss
+                  resource.resources.push(...cssResources)
 
                   if (resource.resources.length)
                     if (type === 'module') {

--- a/packages/vite-plugin/tests/out/vite-content-script-dynamic-import-css/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/vite-content-script-dynamic-import-css/__snapshots__/build.test.ts.snap
@@ -1,0 +1,137 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`build fs output > _00 manifest.json 1`] = `
+Object {
+  "content_scripts": Array [
+    Object {
+      "css": Array [
+        "assets/entry.hash1.css",
+        "assets/content.hash2.css",
+      ],
+      "js": Array [
+        "assets/content.ts-loader.hash0.js",
+      ],
+      "matches": Array [
+        "http://*/*",
+        "https://*/*",
+      ],
+    },
+  ],
+  "manifest_version": 3,
+  "name": "test extension",
+  "version": "0.1.0",
+  "web_accessible_resources": Array [
+    Object {
+      "matches": Array [
+        "http://*/*",
+        "https://*/*",
+      ],
+      "resources": Array [
+        "assets/content.ts.hash3.js",
+        "assets/entry.hash4.js",
+        "assets/entry.hash1.css",
+      ],
+      "use_dynamic_url": false,
+    },
+  ],
+}
+`;
+
+exports[`build fs output > _01 output files 1`] = `
+Array [
+  "assets/content.hash2.css",
+  "assets/content.ts-loader.hash0.js",
+  "assets/content.ts.hash3.js",
+  "assets/entry.hash1.css",
+  "assets/entry.hash4.js",
+  "manifest.json",
+]
+`;
+
+exports[`build fs output > assets/content.hash2.css 1`] = `
+"body {
+  color: red;
+}
+"
+`;
+
+exports[`build fs output > assets/content.ts.hash3.js 1`] = `
+"const scriptRel = \\"modulepreload\\";
+const assetsURL = function(dep) {
+  return \\"/\\" + dep;
+};
+const seen = {};
+const __vitePreload = function preload(baseModule, deps, importerUrl) {
+  if (!deps || deps.length === 0) {
+    return baseModule();
+  }
+  const links = document.getElementsByTagName(\\"link\\");
+  return Promise.all(deps.map((dep) => {
+    dep = assetsURL(dep);
+    if (dep in seen)
+      return;
+    seen[dep] = true;
+    const isCss = dep.endsWith(\\".css\\");
+    const cssSelector = isCss ? '[rel=\\"stylesheet\\"]' : \\"\\";
+    const isBaseRelative = !!importerUrl;
+    if (isBaseRelative) {
+      for (let i = links.length - 1; i >= 0; i--) {
+        const link2 = links[i];
+        if (link2.href === dep && (!isCss || link2.rel === \\"stylesheet\\")) {
+          return;
+        }
+      }
+    } else if (document.querySelector(\`link[href=\\"\${dep}\\"]\${cssSelector}\`)) {
+      return;
+    }
+    const link = document.createElement(\\"link\\");
+    link.rel = isCss ? \\"stylesheet\\" : scriptRel;
+    if (!isCss) {
+      link.as = \\"script\\";
+      link.crossOrigin = \\"\\";
+    }
+    link.href = dep;
+    document.head.appendChild(link);
+    if (isCss) {
+      return new Promise((res, rej) => {
+        link.addEventListener(\\"load\\", res);
+        link.addEventListener(\\"error\\", () => rej(new Error(\`Unable to preload CSS for \${dep}\`)));
+      });
+    }
+  })).then(() => baseModule());
+};
+const content = \\"\\";
+console.log(\\"content.ts\\");
+__vitePreload(() => import(\\"./entry.hash4.js\\"), true ? [\\"assets/entry.hash4.js\\",\\"assets/entry.hash1.css\\"] : void 0);
+"
+`;
+
+exports[`build fs output > assets/content.ts-loader.hash0.js 1`] = `
+"(function () {
+  'use strict';
+
+  const injectTime = performance.now();
+  (async () => {
+    const { onExecute } = await import(
+      /* @vite-ignore */
+      chrome.runtime.getURL(\\"assets/content.ts.hash3.js\\")
+    );
+    onExecute?.({ perf: { injectTime, loadTime: performance.now() - injectTime } });
+  })().catch(console.error);
+
+})();
+"
+`;
+
+exports[`build fs output > assets/entry.hash1.css 1`] = `
+".entry {
+  color: blue;
+}
+"
+`;
+
+exports[`build fs output > assets/entry.hash4.js 1`] = `
+"const entry = \\"\\";
+console.log(\\"entry.ts\\");
+"
+`;

--- a/packages/vite-plugin/tests/out/vite-content-script-dynamic-import-css/build.test.ts
+++ b/packages/vite-plugin/tests/out/vite-content-script-dynamic-import-css/build.test.ts
@@ -1,0 +1,8 @@
+import { build } from 'tests/runners'
+import { testOutput } from 'tests/testOutput'
+import { test } from 'vitest'
+
+test('build fs output', async () => {
+  const result = await build(__dirname)
+  await testOutput(result)
+})

--- a/packages/vite-plugin/tests/out/vite-content-script-dynamic-import-css/manifest.json
+++ b/packages/vite-plugin/tests/out/vite-content-script-dynamic-import-css/manifest.json
@@ -1,0 +1,11 @@
+{
+  "manifest_version": 3,
+  "content_scripts": [
+    {
+      "matches": ["http://*/*", "https://*/*"],
+      "js": ["src/content.ts"]
+    }
+  ],
+  "name": "test extension",
+  "version": "0.1.0"
+}

--- a/packages/vite-plugin/tests/out/vite-content-script-dynamic-import-css/src/content.css
+++ b/packages/vite-plugin/tests/out/vite-content-script-dynamic-import-css/src/content.css
@@ -1,0 +1,3 @@
+body {
+  color: red;
+}

--- a/packages/vite-plugin/tests/out/vite-content-script-dynamic-import-css/src/content.ts
+++ b/packages/vite-plugin/tests/out/vite-content-script-dynamic-import-css/src/content.ts
@@ -1,0 +1,5 @@
+import './content.css'
+
+console.log('content.ts')
+
+import('./entry')

--- a/packages/vite-plugin/tests/out/vite-content-script-dynamic-import-css/src/entry.css
+++ b/packages/vite-plugin/tests/out/vite-content-script-dynamic-import-css/src/entry.css
@@ -1,0 +1,3 @@
+.entry {
+  color: blue;
+}

--- a/packages/vite-plugin/tests/out/vite-content-script-dynamic-import-css/src/entry.ts
+++ b/packages/vite-plugin/tests/out/vite-content-script-dynamic-import-css/src/entry.ts
@@ -1,0 +1,3 @@
+import './entry.css'
+
+console.log('entry.ts')

--- a/packages/vite-plugin/tests/out/vite-content-script-dynamic-import-css/vite.config.ts
+++ b/packages/vite-plugin/tests/out/vite-content-script-dynamic-import-css/vite.config.ts
@@ -1,0 +1,19 @@
+import { crx } from '../../plugin-testOptionsProvider'
+import { defineConfig } from 'vite'
+import manifest from './manifest.json'
+
+export default defineConfig({
+  build: {
+    minify: false,
+    rollupOptions: {
+      output: {
+        assetFileNames: 'assets/[name].hash[hash].[ext]',
+        chunkFileNames: 'assets/[name].hash[hash].js',
+        entryFileNames: 'assets/[name].hash[hash].js',
+      },
+    },
+  },
+  clearScreen: false,
+  logLevel: 'error',
+  plugins: [crx({ manifest })],
+})


### PR DESCRIPTION
## What changed

- Track CSS that belongs to chunks reached through dynamic imports separately from the full content-script CSS set.
- Add only that runtime-loaded CSS to `web_accessible_resources` when content-script CSS injection is enabled.
- Keep existing behavior for dynamic scripts and `injectCss: false`, where all collected CSS remains web-accessible.
- Add an output fixture covering a content script with static CSS plus a dynamically imported module with its own CSS.

## Why

Vite can generate runtime CSS loading/preload code for CSS attached to dynamically imported chunks. In Chrome extension content scripts, those CSS assets must be listed in `web_accessible_resources`; otherwise Chrome blocks the runtime CSS request.

The previous behavior kept imported CSS out of WAR whenever `injectCss` was enabled, which is correct for statically injected content-script CSS but misses CSS loaded at runtime by Vite.

Fixes #1115.

## Validation

- `pnpm --dir packages/vite-plugin run lint:types`
- `pnpm --dir packages/vite-plugin run test:run:out`
- `pnpm --dir packages/vite-plugin run lint:eslint`
- Packed the local plugin and verified the issue repro build includes the dynamic import CSS in WAR.
