### PR TITLE
fix: Web Components polyfill in content scripts

### DIFF
--- a/.changeset/content-script-clonenode.md
+++ b/.changeset/content-script-clonenode.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+Guard the dev-mode custom-elements polyfill for content scripts so `document.cloneNode(true)` does not throw when `ownerDocument` is null.

--- a/packages/vite-plugin/src/node/plugin-fileWriter-polyfill.test.ts
+++ b/packages/vite-plugin/src/node/plugin-fileWriter-polyfill.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'fs'
+import { createRequire } from 'module'
+import { expect, test } from 'vitest'
+import { patchCustomElementsPolyfill } from './plugin-fileWriter-polyfill'
+import { customElementsId } from './virtualFileIds'
+
+const _require =
+  typeof require === 'undefined' ? createRequire(import.meta.url) : require
+const unguardedOwnerDocumentAccess = /(^|[^&])this\.ownerDocument\.__CE_registry/
+
+test('guards custom elements ownerDocument registry accesses', () => {
+  const code = [
+    'this.ownerDocument.__CE_registry?V(a,this):Q(a,this)',
+    'this.ownerDocument.__CE_registry?V(a,d):Q(a,d)',
+  ].join(';')
+
+  const result = patchCustomElementsPolyfill(code)
+
+  expect(result).not.toMatch(unguardedOwnerDocumentAccess)
+  expect(result).toContain(
+    'this.ownerDocument&&this.ownerDocument.__CE_registry?V(a,this):Q(a,this)',
+  )
+  expect(result).toContain(
+    'this.ownerDocument&&this.ownerDocument.__CE_registry?V(a,d):Q(a,d)',
+  )
+})
+
+test('patches the bundled custom elements polyfill', () => {
+  const customElementsPath = _require.resolve(customElementsId.slice(1))
+  const code = readFileSync(customElementsPath, 'utf8')
+
+  expect(patchCustomElementsPolyfill(code)).not.toMatch(
+    unguardedOwnerDocumentAccess,
+  )
+})

--- a/packages/vite-plugin/src/node/plugin-fileWriter-polyfill.ts
+++ b/packages/vite-plugin/src/node/plugin-fileWriter-polyfill.ts
@@ -10,10 +10,37 @@ import {
 
 const _require =
   typeof require === 'undefined' ? createRequire(import.meta.url) : require
-// customElementsId starts with a slash, remove it for require.
-const customElementsPath = _require.resolve(customElementsId.slice(1))
-const customElementsCode = readFileSync(customElementsPath, 'utf8')
-const customElementsMap = readFileSync(`${customElementsPath}.map`, 'utf8')
+
+const unsafeOwnerDocumentRegistryAccess = 'this.ownerDocument.__CE_registry'
+const safeOwnerDocumentRegistryAccess =
+  'this.ownerDocument&&this.ownerDocument.__CE_registry'
+
+interface CustomElementsPolyfill {
+  code: string
+  map: string
+}
+
+let customElementsPolyfill: CustomElementsPolyfill | undefined
+
+export function patchCustomElementsPolyfill(code: string): string {
+  return code
+    .split(unsafeOwnerDocumentRegistryAccess)
+    .join(safeOwnerDocumentRegistryAccess)
+}
+
+function loadCustomElementsPolyfill(): CustomElementsPolyfill {
+  if (customElementsPolyfill) return customElementsPolyfill
+
+  // customElementsId starts with a slash, remove it for require.
+  const customElementsPath = _require.resolve(customElementsId.slice(1))
+
+  customElementsPolyfill = {
+    code: patchCustomElementsPolyfill(readFileSync(customElementsPath, 'utf8')),
+    map: readFileSync(`${customElementsPath}.map`, 'utf8'),
+  }
+
+  return customElementsPolyfill
+}
 
 /**
  * Adds polyfills for content scripts:
@@ -43,7 +70,7 @@ export const pluginFileWriterPolyfill: CrxPluginFn = () => {
     },
     load(id) {
       if (id === customElementsId) {
-        return { code: customElementsCode, map: customElementsMap }
+        return loadCustomElementsPolyfill()
       }
     },
     renderCrxDevScript(code, { type, id }) {

--- a/packages/vite-plugin/tests/e2e/mv3-vite-webcomponents-polyfill/manifest.json
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-webcomponents-polyfill/manifest.json
@@ -1,0 +1,12 @@
+{
+  "description": "Web Components polyfill content script regression",
+  "manifest_version": 3,
+  "name": "Web Components polyfill regression",
+  "content_scripts": [
+    {
+      "matches": ["https://example.com/*"],
+      "js": ["source/content.ts"]
+    }
+  ],
+  "version": "1.0.0"
+}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-webcomponents-polyfill/source/content.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-webcomponents-polyfill/source/content.ts
@@ -1,0 +1,38 @@
+const tagName = 'crx-clone-node-test'
+
+if (!customElements.get(tagName)) {
+  customElements.define(
+    tagName,
+    class extends HTMLElement {
+      connectedCallback() {
+        this.dataset.upgraded = 'true'
+        this.textContent = 'upgraded'
+      }
+    },
+  )
+}
+
+const element = document.createElement(tagName)
+element.id = 'custom-element-result'
+document.body.append(element)
+
+const result = document.createElement('div')
+result.id = 'document-clone-node-result'
+
+try {
+  const clone = document.cloneNode(true)
+
+  result.dataset.status =
+    element.dataset.upgraded === 'true' &&
+    clone instanceof Document &&
+    clone.documentElement?.nodeName === 'HTML'
+      ? 'ok'
+      : 'invalid-clone'
+} catch (error) {
+  result.dataset.status = 'error'
+  result.textContent = error instanceof Error ? error.message : String(error)
+}
+
+document.body.append(result)
+
+export {}

--- a/packages/vite-plugin/tests/e2e/mv3-vite-webcomponents-polyfill/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-webcomponents-polyfill/vite-serve.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'vitest'
+import { serve } from '../runners'
+
+test('Web Components polyfill supports content scripts in dev mode', async () => {
+  const { browser } = await serve(__dirname)
+  const page = await browser.newPage()
+
+  await page.goto('https://example.com')
+
+  const customElement = page.locator('#custom-element-result')
+  await customElement.waitFor({ state: 'attached' })
+
+  expect(await customElement.getAttribute('data-upgraded')).toBe('true')
+  expect(await customElement.textContent()).toBe('upgraded')
+
+  const result = page.locator('#document-clone-node-result')
+  await result.waitFor({ state: 'attached' })
+
+  expect(await result.getAttribute('data-status')).toBe('ok')
+  expect(await result.textContent()).toBe('')
+})

--- a/packages/vite-plugin/tests/e2e/mv3-vite-webcomponents-polyfill/vite.config.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-webcomponents-polyfill/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite'
+import { crx } from '../../plugin-testOptionsProvider'
+import manifest from './manifest.json'
+
+export default defineConfig({
+  build: { minify: false },
+  clearScreen: false,
+  logLevel: 'error',
+  plugins: [crx({ manifest })],
+})


### PR DESCRIPTION
## Summary

- Patch the dev-mode `@webcomponents/custom-elements` bundle before CRXJS serves it to content scripts.
- Guard the polyfill `ownerDocument.__CE_registry` access so `document.cloneNode(true)` does not throw for `Document` nodes.
- Add unit coverage for the bundle patch and an MV3 e2e fixture that defines/upgrades a custom element and clones the document in a real content script.

Fixes #577.

## Validation

- `pnpm -C packages/vite-plugin exec vitest --run src/node/plugin-fileWriter-polyfill.test.ts --mode unit`
- `pnpm -C packages/vite-plugin exec vitest --run tests/e2e/mv3-vite-webcomponents-polyfill/vite-serve.test.ts --mode e2e`
- `pnpm -C packages/vite-plugin run lint:types`
- `pnpm -C packages/vite-plugin run lint:eslint`
- `pnpm -C packages/vite-plugin run build`
