### PR TITLE
Add local release workflow override

### DIFF
--- a/.github/workflows/release-new.yml
+++ b/.github/workflows/release-new.yml
@@ -1,0 +1,71 @@
+name: Release New
+
+on:
+  workflow_call:
+    inputs:
+      github-release:
+        required: false
+        type: boolean
+        default: true
+      publish:
+        required: false
+        type: boolean
+        default: false
+      build:
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    permissions:
+      contents: write
+      id-token: write
+
+    env:
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.1
+
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Generate GitHub Changelog
+        run: pnpx changelogithub
+        continue-on-error: true
+        if: ${{ inputs.github-release }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Build
+        run: ${{ inputs.build }}
+        if: ${{ inputs.build && inputs.publish }}
+
+      - name: Publish to NPM
+        run: pnpm -r publish --access public --no-git-checks
+        if: ${{ inputs.publish }}
+        env:
+          NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/vite_plugin_release.yml
+++ b/.github/workflows/vite_plugin_release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    uses: crxjs/workflows/.github/workflows/release.yml@v1
+    uses: ./.github/workflows/release-new.yml
     with:
       publish: true
     permissions:


### PR DESCRIPTION
## Summary

- add a local reusable release workflow that mirrors the shared publish workflow
- update the Vite plugin tag release workflow to call the local workflow instead of `crxjs/workflows`
- keep release installs from downloading Playwright browsers and cap the release job at 20 minutes

## Why

The Vite plugin release currently depends on the shared `crxjs/workflows` repository. The latest release run hung for roughly six hours during setup, before reaching changelog generation or npm publishing. The last useful log line was inside `playwright-chromium` browser installation after the Chromium download reached 100%.

Keeping this release logic local lets this repository unblock releases now while the shared workflow remains unchanged. The workflow still uses GitHub OIDC permissions for npm Trusted Publishing and does not require an npm token secret.

So, after making sure that the release process works, we can move back the working version upstream to the workflows repo

## Validation

- `ruby -e "require 'yaml'; ARGV.each { |f| YAML.load_file(f); puts \"#{f}: yaml ok\" }" .github/workflows/release-new.yml .github/workflows/vite_plugin_release.yml`
- `git diff --check -- .github/workflows/release-new.yml .github/workflows/vite_plugin_release.yml`