### PR TITLE
Use npm CLI for trusted publishing

### DIFF
--- a/.github/workflows/release-new.yml
+++ b/.github/workflows/release-new.yml
@@ -39,16 +39,13 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
         with:
           version: 10.11.1
-
-      - name: Update npm
-        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install
@@ -65,7 +62,6 @@ jobs:
         if: ${{ inputs.build && inputs.publish }}
 
       - name: Publish to NPM
-        run: pnpm -r publish --access public --no-git-checks
+        working-directory: packages/vite-plugin
+        run: npm publish --access public --provenance
         if: ${{ inputs.publish }}
-        env:
-          NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Setup PNPM


### PR DESCRIPTION
## Summary

- switch release workflows to Node 24 so the bundled npm CLI supports npm Trusted Publishing/OIDC
- switch the local tag release publish step from `pnpm -r publish` to `npm publish --provenance`
- publish from `packages/vite-plugin` without introducing an `NPM_TOKEN` secret

## Why

The failed `release.yml` run used Node 22 with npm 10.9.8. npm Trusted Publishing requires npm CLI 11.5.1 or later, so the workflow could see that OIDC was available but still failed during publish with a misleading `E404`.

Using Node 24 gives the workflow a supported npm CLI without manually installing npm globally. The tag release path also uses the official `npm publish` command for the final publish step, which is the documented OIDC path.

## Validation

- `ruby -e "require 'yaml'; ARGV.each { |f| YAML.load_file(f); puts \"#{f}: yaml ok\" }" .github/workflows/release.yml .github/workflows/release-new.yml .github/workflows/vite_plugin_release.yml`
- `git diff --check -- .github/workflows/release.yml .github/workflows/release-new.yml .github/workflows/vite_plugin_release.yml`