### PR TITLE
fix(vite-plugin): shorten outside-root dev filenames

### DIFF
--- a/.changeset/short-fs-paths.md
+++ b/.changeset/short-fs-paths.md
@@ -1,0 +1,6 @@
+---
+'@crxjs/vite-plugin': patch
+---
+
+Shorten dev-mode filenames for outside-root Vite modules to avoid Windows path
+length failures.

--- a/packages/vite-plugin/src/node/fileWriter-utilities.test.ts
+++ b/packages/vite-plugin/src/node/fileWriter-utilities.test.ts
@@ -44,6 +44,58 @@ describe('getFileName', () => {
     expect(result).toMatch(/^vendor\//)
   })
 
+  test('bounds filenames for modules served from outside the Vite root', () => {
+    const result = getFileName({
+      type: 'module',
+      id: '/@fs/D:/Work11Space/Pro20260126/app-monorepo/packages/ui/tiptap-editor/src/components/primitives/toolbar/ToolbarButton.vue?vue&type=style&index=0&scoped=eb58e4f8&lang.scss',
+    })
+
+    expect(result).toMatch(/^vendor\/fs-[A-Za-z0-9]{12}\.js$/)
+    expect(result).not.toContain('Work11Space')
+  })
+
+  test('keeps existing vendor names for outside-root node_modules', () => {
+    const result = getFileName({
+      type: 'module',
+      id: '/@fs/D:/workspace/node_modules/vite/dist/client/env.mjs',
+    })
+
+    expect(result).toBe('vendor/vite-dist-client-env.mjs.js')
+  })
+
+  test('preserves extensions for assets served from outside the Vite root', () => {
+    const result = getFileName({
+      type: 'asset',
+      id: '/@fs/D:/workspace/packages/ui/src/assets/icon.png',
+    })
+
+    expect(result).toMatch(/^vendor\/fs-[A-Za-z0-9]{12}\.png$/)
+  })
+
+  test('includes the full Vite query when hashing outside-root modules', () => {
+    const vueFile =
+      '/@fs/D:/workspace/packages/ui/src/components/ToolbarButton.vue'
+    const style = getFileName({
+      type: 'module',
+      id: `${vueFile}?vue&type=style&index=0&scoped=eb58e4f8&lang.scss`,
+    })
+    const script = getFileName({
+      type: 'module',
+      id: `${vueFile}?vue&type=script&setup=true&lang.ts`,
+    })
+
+    expect(style).not.toBe(script)
+  })
+
+  test('ignores HMR timestamps when hashing outside-root modules', () => {
+    const id =
+      '/@fs/D:/workspace/packages/ui/src/components/ToolbarButton.vue?vue&type=style&index=0&scoped=eb58e4f8&lang.scss'
+
+    expect(
+      getFileName({ type: 'module', id: id.replace('?', '?t=123&') }),
+    ).toBe(getFileName({ type: 'module', id }))
+  })
+
   test('sanitizes colons for Windows compatibility', () => {
     const result = getFileName({
       type: 'module',

--- a/packages/vite-plugin/src/node/fileWriter-utilities.ts
+++ b/packages/vite-plugin/src/node/fileWriter-utilities.ts
@@ -1,7 +1,7 @@
 import { ViteDevServer } from 'vite'
 import { outputFiles } from './fileWriter-filesMap'
-import { _debug } from './helpers'
-import { basename, dirname, isAbsolute, join } from './path'
+import { _debug, hash } from './helpers'
+import { basename, dirname, extname, isAbsolute, join } from './path'
 import { CrxDevAssetId, CrxDevScriptId } from './types'
 
 const debug = _debug('file-writer').extend('utilities')
@@ -65,6 +65,7 @@ export function formatFileData<
  * Converts ScriptId to filename:
  *
  * - Filenames never start with a slash
+ * - Outside-root IDs use bounded, deterministic filenames
  * - URL queries are converted to underscores and dashes
  * - Filenames starting with '_' are sanitized (Chrome Extensions reserve them)
  */
@@ -73,10 +74,18 @@ export function getFileName({ type, id }: FileWriterId): string {
     .replace(/t=\d+&/, '') // filenames do not contain timestamps
     .replace(/\?t=\d+$/, '') // filenames do not contain timestamps
     .replace(/^\//, '') // filenames do not start with a slash
-    .replace(/\?/g, '__') // convert url queries
-    .replace(/&/g, '_')
-    .replace(/=/g, '--')
-    .replace(/:/g, '-') // colons are illegal on Windows
+
+  if (fileName.startsWith('@fs/') && !fileName.includes('node_modules/')) {
+    const extension = type === 'asset' ? extname(fileName.split('?')[0]) : ''
+    fileName = `vendor/fs-${hash(fileName, 12)}${extension}`
+  } else {
+    fileName = fileName
+      .replace(/\?/g, '__') // convert url queries
+      .replace(/&/g, '_')
+      .replace(/=/g, '--')
+      .replace(/:/g, '-') // colons are illegal on Windows
+  }
+
   if (fileName.includes('node_modules/')) {
     fileName = `vendor/${fileName
       .split('node_modules/')
@@ -140,7 +149,9 @@ export function getViteUrl(
   } else if (type === 'iife') {
     // IIFE scripts are bundled separately (see plugin-contentScripts_iife + fileWriter-rxjs)
     // and do not go through Vite's transform pipeline for dev.
-    throw new Error(`File type "iife" is handled via dedicated IIFE bundler, not Vite transform.`)
+    throw new Error(
+      `File type "iife" is handled via dedicated IIFE bundler, not Vite transform.`,
+    )
   } else if (type === 'loader') {
     throw new Error('Vite does not transform loader files.')
   } else if (type === 'module') {

--- a/packages/vite-plugin/tests/out/vite-vue-outside-root-shared/src/components/primitives/toolbar/ToolbarButton.vue
+++ b/packages/vite-plugin/tests/out/vite-vue-outside-root-shared/src/components/primitives/toolbar/ToolbarButton.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+defineProps<{ label: string }>()
+</script>
+
+<template>
+  <button class="toolbar-button">{{ label }}</button>
+</template>
+
+<style scoped>
+.toolbar-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+</style>

--- a/packages/vite-plugin/tests/out/vite-vue-outside-root/manifest.config.ts
+++ b/packages/vite-plugin/tests/out/vite-vue-outside-root/manifest.config.ts
@@ -1,0 +1,13 @@
+import { defineManifest } from '../../plugin-testOptionsProvider'
+
+export default defineManifest({
+  manifest_version: 3,
+  content_scripts: [
+    {
+      matches: ['http://*/*'],
+      js: ['src/content.ts'],
+    },
+  ],
+  name: 'outside-root Vue extension',
+  version: '1.0.0',
+})

--- a/packages/vite-plugin/tests/out/vite-vue-outside-root/serve.test.ts
+++ b/packages/vite-plugin/tests/out/vite-vue-outside-root/serve.test.ts
@@ -1,0 +1,33 @@
+import fs from 'fs-extra'
+import { join } from 'pathe'
+import { allFileWriterErrors } from 'src/fileWriter-rxjs'
+import { glob } from 'tinyglobby'
+import { expect, test } from 'vitest'
+import { serve } from '../../runners'
+
+test('shortens Vue virtual modules served from outside the Vite root', async () => {
+  const result = await serve(__dirname)
+  const outsideRootModules = await glob('vendor/fs-*', {
+    cwd: result.outDir,
+  })
+
+  expect(outsideRootModules.length).toBeGreaterThanOrEqual(2)
+  expect(outsideRootModules).toEqual(
+    expect.arrayContaining([
+      expect.stringMatching(/^vendor\/fs-[A-Za-z0-9]{12}\.js$/),
+    ]),
+  )
+  expect(outsideRootModules.every((fileName) => fileName.length === 25)).toBe(
+    true,
+  )
+
+  const contentScript = await fs.readFile(
+    join(result.outDir, 'src/content.ts.js'),
+    'utf8',
+  )
+  expect(contentScript).toMatch(/\/vendor\/fs-[A-Za-z0-9]{12}\.js/)
+  expect(contentScript).not.toContain('vite-vue-outside-root-shared')
+
+  await result.server.close()
+  expect(await allFileWriterErrors).toEqual([])
+})

--- a/packages/vite-plugin/tests/out/vite-vue-outside-root/src/content.ts
+++ b/packages/vite-plugin/tests/out/vite-vue-outside-root/src/content.ts
@@ -1,0 +1,3 @@
+import ToolbarButton from '../../vite-vue-outside-root-shared/src/components/primitives/toolbar/ToolbarButton.vue'
+
+console.log(ToolbarButton)

--- a/packages/vite-plugin/tests/out/vite-vue-outside-root/src/vite-env.d.ts
+++ b/packages/vite-plugin/tests/out/vite-vue-outside-root/src/vite-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+declare module '*.vue' {
+  const component: unknown
+  export default component
+}

--- a/packages/vite-plugin/tests/out/vite-vue-outside-root/vite.config.ts
+++ b/packages/vite-plugin/tests/out/vite-vue-outside-root/vite.config.ts
@@ -1,0 +1,10 @@
+import vue from '@vitejs/plugin-vue'
+import { defineConfig } from 'vite'
+import { crx } from '../../plugin-testOptionsProvider'
+import manifest from './manifest.config'
+
+export default defineConfig({
+  clearScreen: false,
+  logLevel: 'error',
+  plugins: [crx({ manifest }), vue()],
+})

--- a/packages/vite-plugin/tests/out/vite-workspace-assets/serve.test.ts
+++ b/packages/vite-plugin/tests/out/vite-workspace-assets/serve.test.ts
@@ -9,12 +9,15 @@ test('serves assets imported by a workspace package outside the Vite root', asyn
 
   try {
     const files = await glob('**/*', { cwd: result.outDir })
-    const assetFile = files.find((file) => file.endsWith('badge.svg'))
+    const assetContents = await Promise.all(
+      files
+        .filter((file) => file.endsWith('.svg'))
+        .map((file) => fs.readFile(join(result.outDir, file), 'utf8')),
+    )
 
-    expect(assetFile).toBeDefined()
-    await expect(
-      fs.readFile(join(result.outDir, assetFile!), 'utf8'),
-    ).resolves.toContain('workspace asset')
+    expect(
+      assetContents.some((content) => content.includes('workspace asset')),
+    ).toBe(true)
   } finally {
     await result.server.close()
   }


### PR DESCRIPTION
## Summary

- shorten dev output filenames for `/@fs/` modules outside the Vite root with a deterministic 12-character hash
- keep the complete module ID and Vue query in the hash while ignoring transient HMR timestamps
- preserve asset extensions and existing `node_modules` vendor filenames
- add unit coverage and a serve-mode Vue SFC fixture imported from a workspace package outside the extension root
- add a patch changeset for `@crxjs/vite-plugin`

## Root cause

The dev file writer flattened complete `/@fs/` absolute paths and virtual-module queries into physical filenames. On Windows, sufficiently deep workspace paths could therefore exceed the effective path-length limit and fail to load from the extension origin.

## Validation

- `pnpm -C packages/vite-plugin run test:run:out` — 118 passed, 1 skipped
- `pnpm -C packages/vite-plugin run lint`
- `pnpm -C packages/vite-plugin run build`
- Prettier and `git diff --check`

Closes #1223
