### PR TITLE
fix: serve declared IIFE content scripts without dev loader

### DIFF
--- a/.changeset/spotty-donuts-repeat.md
+++ b/.changeset/spotty-donuts-repeat.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+Serve manifest-declared IIFE content scripts (`.iife.*` files and `contentScripts.standaloneFiles`) as real IIFE bundles in dev mode instead of routing them through the async dev loader. This makes their execution timing consistent with build output and with dynamically registered IIFE scripts (#1225).

--- a/packages/vite-plugin/src/node/plugin-manifest.ts
+++ b/packages/vite-plugin/src/node/plugin-manifest.ts
@@ -272,6 +272,15 @@ export const pluginManifest: CrxPluginFn = () => {
           // Clear and register CSS entries for synthetic content scripts
           clearContentCssEntries()
 
+          const opts = await getOptions({
+            plugins: config.plugins,
+          } as UserConfig)
+          const standaloneFiles = (
+            opts.contentScripts?.standaloneFiles || []
+          ).map((f: string) => f.replace(/^\//, ''))
+          const isStandaloneFile = (file: string) =>
+            standaloneFiles.includes(file.replace(/^\//, ''))
+
           // vite serve file writer only emits content scripts
           // - html files come directly from vite dev server
           // - service worker comes from vite dev server via loader file
@@ -306,15 +315,22 @@ export const pluginManifest: CrxPluginFn = () => {
               }
 
               // Register regular JS content scripts
+              // IIFE scripts skip the dev loader so they execute
+              // synchronously, matching build output and dynamically
+              // registered IIFE scripts
               for (const id of js) {
+                const type =
+                  isIifeContentScript(id) || isStandaloneFile(id)
+                    ? ('iife' as const)
+                    : ('loader' as const)
                 contentScripts.set(
                   prefix('/', id),
                   formatFileData({
-                    type: 'loader',
+                    type,
                     id,
                     matches,
-                    refId: hashScriptId({ type: 'loader', id }),
-                    fileName: getFileName({ type: 'loader', id }),
+                    refId: hashScriptId({ type, id }),
+                    fileName: getFileName({ type, id }),
                   }),
                 )
               }
@@ -410,10 +426,13 @@ export const pluginManifest: CrxPluginFn = () => {
               const script = manifest.content_scripts[i]
               const cssEntry = cssEntryMap.get(i)
 
-              // Transform JS paths to loader file names
-              const jsLoaders = (script.js || []).map((id) =>
-                getFileName({ id, type: 'loader' }),
-              )
+              // Transform JS paths to emitted file names: dev loaders for
+              // module scripts, the bundled file itself for IIFE scripts
+              const jsLoaders = (script.js || []).map((id) => {
+                const registered =
+                  contentScripts.get(prefix('/', id)) ?? contentScripts.get(id)
+                return registered?.fileName ?? getFileName({ id, type: 'loader' })
+              })
 
               // Prepend synthetic CSS entry loader if CSS exists for this entry
               if (cssEntry) {

--- a/packages/vite-plugin/tests/e2e/mv3-content-script-iife/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-content-script-iife/vite-serve.test.ts
@@ -14,7 +14,7 @@ test('IIFE content scripts work in dev mode', async () => {
   await fs.emptyDir(src)
   await fs.copy(src1, src, { overwrite: true })
 
-  const { browser } = await serve(__dirname)
+  const { browser, outDir } = await serve(__dirname)
 
   await waitForRegisteredContentScripts(browser, [
     dynamicRegularId,
@@ -25,8 +25,21 @@ test('IIFE content scripts work in dev mode', async () => {
   const page = await browser.newPage()
   await page.goto('https://example.com')
 
-  // In dev mode, .iife.ts files are served as ESM (IIFE bundling only happens in build)
-  // but should still execute and create their markers.
+  // In dev mode, declared IIFE scripts skip the async dev loader and are
+  // referenced directly in the manifest so they execute synchronously,
+  // like build output and dynamically registered IIFE scripts (#1225).
+  const manifest = await fs.readJson(path.join(outDir, 'manifest.json'))
+  const declaredJs: string[] = manifest.content_scripts.flatMap(
+    (script: { js?: string[] }) => script.js ?? [],
+  )
+  expect(declaredJs).toContain('src/content-iife.iife.ts.iife.js')
+  expect(declaredJs).toContain('src/content-standalone.ts.iife.js')
+  expect(declaredJs).toContain('src/content-regular.ts-loader.js')
+  for (const fileName of declaredJs.filter((f) => f.endsWith('.iife.js'))) {
+    const code = await fs.readFile(path.join(outDir, fileName), 'utf8')
+    expect(code).toMatch(/^\(function\(\)/)
+  }
+
   await page.waitForSelector(`#${regularContentId}`, { timeout: 10000 })
   await page.waitForSelector(`#${iifeContentId}`, { timeout: 10000 })
   await page.waitForSelector(`#${standaloneIifeScriptId}`, { timeout: 10000 })


### PR DESCRIPTION
## What changed

In dev mode, manifest-declared content scripts matching the `.iife.*` filename convention or listed in `contentScripts.standaloneFiles` are now registered as type `iife` instead of `loader`. The file writer emits a real synchronous IIFE bundle for them, and the dev manifest references that bundle directly instead of an async `-loader.js`.

## Why

Fixes #1225.

Declared content scripts always ran through a dev loader that loads the real code with an async `import()`, while dynamically registered IIFE scripts pointed straight at a synchronous bundle. At `document_start` the dynamic script therefore always executed first in dev, inverting the order seen in build output and making dev-mode debugging misleading.

With this change, declared and dynamic IIFE scripts behave identically in dev and build: both execute synchronously from a real IIFE bundle. Regular (module) declared scripts keep their dev loader, which they need for the Vite module graph.

## Notes for reviewers

- The serve subscription in `plugin-contentScripts.ts` already handled `type === 'iife'` (used by dynamic `?iife` imports), so no new emission machinery was needed — only the registration in `plugin-manifest.ts` and the manifest path rewrite changed.
- HMR already has a dedicated IIFE branch in `plugin-hmr.ts` (rebuild + runtime reload) keyed off the registration type, so declared IIFE scripts get rebuild-and-reload on change. Trade-off: `.iife.ts` files are no longer served as Vite-transformed ESM in dev, so they get a full runtime reload instead of module-graph HMR — same as dynamically registered IIFE scripts today.
- Added regression assertions to `mv3-content-script-iife/vite-serve.test.ts`: the dev manifest must reference `.iife.js` bundles directly (not loaders) and the emitted files must start with `(function()`.

## Testing

- `src/node` unit tests: 54 passed
- All `tests/out` snapshot tests: no snapshot changes
- IIFE e2e tests (`mv3-content-script-iife`, `mv3-dynamic-script-iife`, build + serve, real Chromium): all pass