### PR TITLE
fix(vite-plugin): resolve @fs asset paths in dev mode for monorepo workspace packages

### DIFF
--- a/.changeset/fix-prepasset-at-fs-path.md
+++ b/.changeset/fix-prepasset-at-fs-path.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+Fix dev server crash when a monorepo workspace package imports assets (images, SVGs, etc.) from its own source tree outside the Vite root. `prepAsset` was reading the file with `join(server.config.root, id)`, but `pathe.join` does not treat a `/@fs/…` Vite URL as an absolute path and produces an incorrect path like `<root>/@fs/<abs-path>`. Strip the `/@fs` prefix to recover the real absolute filesystem path before calling `readFile`.

--- a/packages/vite-plugin/src/node/fileWriter-rxjs.ts
+++ b/packages/vite-plugin/src/node/fileWriter-rxjs.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from 'url'
 import * as lexer from 'es-module-lexer'
 import fsx from 'fs-extra'
 import { readFile } from 'fs/promises'
@@ -211,7 +212,7 @@ function prepAsset(
       mergeMap(async ({ server }) => {
         const target = getOutputPath(server, fileName)
         const filePath = id.startsWith('/@fs/')
-          ? id.slice('/@fs/'.length - 1)
+          ? fileURLToPath('file://' + id.slice('/@fs'.length))
           : join(server.config.root, id)
         return {
           target,

--- a/packages/vite-plugin/src/node/fileWriter-rxjs.ts
+++ b/packages/vite-plugin/src/node/fileWriter-rxjs.ts
@@ -210,9 +210,12 @@ function prepAsset(
     $.pipe(
       mergeMap(async ({ server }) => {
         const target = getOutputPath(server, fileName)
+        const filePath = id.startsWith('/@fs/')
+          ? id.slice('/@fs/'.length - 1)
+          : join(server.config.root, id)
         return {
           target,
-          source: source ?? (await readFile(join(server.config.root, id))),
+          source: source ?? (await readFile(filePath)),
           deps: [],
         }
       }),

--- a/packages/vite-plugin/tests/out/vite-workspace-assets-shared/badge.svg
+++ b/packages/vite-plugin/tests/out/vite-workspace-assets-shared/badge.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" aria-label="workspace asset">
+  <circle cx="8" cy="8" r="8" />
+</svg>

--- a/packages/vite-plugin/tests/out/vite-workspace-assets-shared/index.ts
+++ b/packages/vite-plugin/tests/out/vite-workspace-assets-shared/index.ts
@@ -1,0 +1,3 @@
+import badgeUrl from './badge.svg'
+
+export { badgeUrl }

--- a/packages/vite-plugin/tests/out/vite-workspace-assets/manifest.json
+++ b/packages/vite-plugin/tests/out/vite-workspace-assets/manifest.json
@@ -1,0 +1,11 @@
+{
+  "content_scripts": [
+    {
+      "js": ["src/content.ts"],
+      "matches": ["<all_urls>"]
+    }
+  ],
+  "manifest_version": 3,
+  "name": "workspace assets test",
+  "version": "1.0.0"
+}

--- a/packages/vite-plugin/tests/out/vite-workspace-assets/serve.test.ts
+++ b/packages/vite-plugin/tests/out/vite-workspace-assets/serve.test.ts
@@ -1,0 +1,21 @@
+import fs from 'fs-extra'
+import { join } from 'pathe'
+import { glob } from 'tinyglobby'
+import { serve } from 'tests/runners'
+import { expect, test } from 'vitest'
+
+test('serves assets imported by a workspace package outside the Vite root', async () => {
+  const result = await serve(__dirname)
+
+  try {
+    const files = await glob('**/*', { cwd: result.outDir })
+    const assetFile = files.find((file) => file.endsWith('badge.svg'))
+
+    expect(assetFile).toBeDefined()
+    await expect(
+      fs.readFile(join(result.outDir, assetFile!), 'utf8'),
+    ).resolves.toContain('workspace asset')
+  } finally {
+    await result.server.close()
+  }
+})

--- a/packages/vite-plugin/tests/out/vite-workspace-assets/src/content.ts
+++ b/packages/vite-plugin/tests/out/vite-workspace-assets/src/content.ts
@@ -1,0 +1,3 @@
+import { badgeUrl } from '@workspace/shared-assets'
+
+console.log(badgeUrl)

--- a/packages/vite-plugin/tests/out/vite-workspace-assets/src/workspace.d.ts
+++ b/packages/vite-plugin/tests/out/vite-workspace-assets/src/workspace.d.ts
@@ -1,0 +1,3 @@
+declare module '@workspace/shared-assets' {
+  export const badgeUrl: string
+}

--- a/packages/vite-plugin/tests/out/vite-workspace-assets/vite.config.ts
+++ b/packages/vite-plugin/tests/out/vite-workspace-assets/vite.config.ts
@@ -1,0 +1,24 @@
+import { fileURLToPath } from 'url'
+import { dirname, resolve } from 'pathe'
+import { defineConfig } from 'vite'
+import { crx } from '../../plugin-testOptionsProvider'
+import manifest from './manifest.json'
+
+const root = dirname(fileURLToPath(import.meta.url))
+const sharedAssetsRoot = resolve(root, '../vite-workspace-assets-shared')
+
+export default defineConfig({
+  clearScreen: false,
+  logLevel: 'error',
+  plugins: [crx({ manifest })],
+  resolve: {
+    alias: {
+      '@workspace/shared-assets': sharedAssetsRoot,
+    },
+  },
+  server: {
+    fs: {
+      allow: [root, sharedAssetsRoot],
+    },
+  },
+})


### PR DESCRIPTION
## Problem

In a pnpm monorepo, when a workspace package (e.g. `packages/shared-assets`) imports image/SVG assets from its own source tree, Vite serves those files via `/@fs/<absolute-path>` URLs because they live outside the extension app's Vite root.

During `pnpm dev`, CRXJS calls `prepAsset` to read and write these files to the output directory. The file read used:

```ts
readFile(join(server.config.root, id))
```

`pathe.join` (like Node's `path.join`) does **not** treat a path starting with `/@fs/…` as absolute — it concatenates, producing:

```
<root>/@fs/<absolute-path-to-asset>   ← file does not exist → crash
```

### Reproduction

Structure:
- `apps/extension` — CRXJS + Vite extension app (Vite root)
- `packages/shared-assets` — source-only workspace package; its `index.tsx` imports `badge.svg` and `tile.png` from `./assets/`

`pnpm dev` crashes immediately after Vite starts. The failing path is rooted under the extension app:
```
apps/extension/@fs/…/packages/shared-assets/src/assets/badge.svg
```
instead of the real absolute path.

## Fix

Mirror the existing `resolveScriptInput` helper (used for IIFE bundling) — strip the `/@fs` prefix to recover the absolute filesystem path:

```ts
const filePath = id.startsWith('/@fs/')
  ? id.slice('/@fs/'.length - 1)
  : join(server.config.root, id)
```

`'/@fs/'.length - 1` = 4, so `slice(4)` on `/@fs/Users/…` yields `/Users/…` (preserves the leading `/` for an absolute POSIX path). All other id forms fall through to the original logic unchanged.

## Verification

Tested with a minimal pnpm monorepo reproducer: <https://github.com/benhaooo/repro-crxjs-monorepo-assets>

`pnpm dev` runs without crashing and correctly writes the asset files.