### PR TITLE
fix(vite-plugin): replace all live reload placeholders

### DIFF
--- a/.changeset/calm-workers-reconnect.md
+++ b/.changeset/calm-workers-reconnect.md
@@ -1,0 +1,6 @@
+---
+'@crxjs/vite-plugin': patch
+---
+
+Replace every live reload placeholder in the background worker client so it can
+reconnect after a dev server restart.

--- a/packages/vite-plugin/src/node/plugin-background.test.ts
+++ b/packages/vite-plugin/src/node/plugin-background.test.ts
@@ -1,0 +1,43 @@
+import type { PluginContext } from 'rollup'
+import type { ResolvedConfig } from 'vite'
+import { expect, test } from 'vitest'
+import { pluginBackground } from './plugin-background'
+import type { CrxPlugin } from './types'
+import { workerClientId } from './virtualFileIds'
+
+test('replaces every live reload placeholder in the worker client', async () => {
+  const plugins = pluginBackground()
+  if (!Array.isArray(plugins)) {
+    throw new Error('Expected background plugins')
+  }
+
+  const clientPlugin = plugins.find(
+    (plugin): plugin is CrxPlugin => plugin.name === 'crx:background-client',
+  )
+  if (!clientPlugin) throw new Error('Unable to find background client plugin')
+
+  const loaderPlugin = plugins.find(
+    (plugin): plugin is CrxPlugin =>
+      plugin.name === 'crx:background-loader-file',
+  )
+  if (!loaderPlugin) throw new Error('Unable to find background loader plugin')
+
+  const configResolved = loaderPlugin.configResolved
+  if (typeof configResolved !== 'function') {
+    throw new Error('Unable to find configResolved hook')
+  }
+  await configResolved({
+    base: '/',
+    define: {},
+    mode: 'development',
+    server: { hmr: {}, https: false, port: 5173 },
+    webSocketToken: 'test-token',
+  } as unknown as ResolvedConfig)
+
+  const load = clientPlugin.load
+  if (typeof load !== 'function') throw new Error('Unable to find load hook')
+
+  const client = await load.call({} as PluginContext, workerClientId)
+  expect(client).toBeTypeOf('string')
+  expect(client).not.toContain('__LIVE_RELOAD__')
+})

--- a/packages/vite-plugin/src/node/plugin-background.ts
+++ b/packages/vite-plugin/src/node/plugin-background.ts
@@ -42,7 +42,7 @@ export const pluginBackground: CrxPluginFn = () => {
           return defineClientValues(
             workerHmrClient
               .replace('__BASE__', JSON.stringify(base))
-              .replace('__LIVE_RELOAD__', JSON.stringify(liveReload))
+              .replace(/__LIVE_RELOAD__/g, JSON.stringify(liveReload))
               .replace(
                 '__CRX_HMR_TOKEN__',
                 JSON.stringify(


### PR DESCRIPTION
## Summary

- replace every `__LIVE_RELOAD__` placeholder in the generated background worker client
- add a hook-level regression test that verifies no live-reload placeholder reaches the served client
- add a patch changeset for `@crxjs/vite-plugin`

The worker client uses this placeholder in both the HMR payload path and the dev-server reconnect path. A single string replacement left the reconnect occurrence undefined at runtime. The global regular expression keeps compatibility with the project's Node 14 minimum while replacing both occurrences.

Fixes #1230.

## Validation

- `pnpm --dir packages/vite-plugin exec vitest --run src/node/plugin-background.test.ts`
- `pnpm --dir packages/vite-plugin run test:run:out` (113 passed, 1 skipped)
- `pnpm --dir packages/vite-plugin run lint`
- `pnpm --dir packages/vite-plugin run lint:attw`
- Prettier and `git diff --check`
