### PR TITLE
fix(vite-plugin): union matches for scripts declared in multiple content_scripts entries

### DIFF
--- a/.changeset/small-doors-repeat.md
+++ b/.changeset/small-doors-repeat.md
@@ -1,0 +1,5 @@
+---
+"@crxjs/vite-plugin": patch
+---
+
+Union match patterns across all content_scripts entries that declare the same script file, so web_accessible_resources covers every registration instead of only the last one (fixes #1233).

--- a/.changeset/small-doors-repeat.md
+++ b/.changeset/small-doors-repeat.md
@@ -2,4 +2,4 @@
 "@crxjs/vite-plugin": patch
 ---
 
-Union match patterns across all content_scripts entries that declare the same script file, so web_accessible_resources covers every registration instead of only the last one (fixes #1233).
+Union match patterns across all content_scripts entries that declare the same script file, so web_accessible_resources covers every registration instead of only the last one (fixes #1233). When the union contains `<all_urls>`, it collapses to just `<all_urls>` since it subsumes every other pattern.

--- a/packages/vite-plugin/src/node/helpers.ts
+++ b/packages/vite-plugin/src/node/helpers.ts
@@ -120,3 +120,10 @@ export const getMatchPatternOrigin = (pattern: string): string => {
   }
   return root
 }
+
+/**
+ * `<all_urls>` matches every URL, so it subsumes every other pattern; collapse
+ * the set to avoid redundant patterns in `web_accessible_resources`.
+ */
+export const reduceMatchPatterns = (matches: string[]): string[] =>
+  matches.includes('<all_urls>') ? ['<all_urls>'] : matches

--- a/packages/vite-plugin/src/node/plugin-contentScripts_iife.ts
+++ b/packages/vite-plugin/src/node/plugin-contentScripts_iife.ts
@@ -153,11 +153,17 @@ function collectIifeEntries(
   root: string,
 ): IifeEntry[] {
   const entries: IifeEntry[] = []
-  const entryIds = new Set<string>()
+  const entriesById = new Map<string, IifeEntry>()
 
   const addEntry = (entry: IifeEntry) => {
-    if (entryIds.has(entry.id)) return
-    entryIds.add(entry.id)
+    const existing = entriesById.get(entry.id)
+    if (existing) {
+      // the same script may be declared in multiple content_scripts entries
+      // with different matches; union the matches of all registrations
+      existing.matches = [...new Set([...existing.matches, ...entry.matches])]
+      return
+    }
+    entriesById.set(entry.id, entry)
     entries.push(entry)
   }
 

--- a/packages/vite-plugin/src/node/plugin-contentScripts_iife.ts
+++ b/packages/vite-plugin/src/node/plugin-contentScripts_iife.ts
@@ -8,6 +8,7 @@ import type {
 import { build, mergeConfig, InlineConfig, ResolvedConfig, UserConfig } from 'vite'
 import { contentScripts, type ContentScript } from './contentScripts'
 import { formatFileData } from './fileWriter-utilities'
+import { reduceMatchPatterns } from './helpers'
 import type { ManifestV3 } from './manifest'
 import { basename, dirname, join } from './path'
 import { getOptions } from './plugin-optionsProvider'
@@ -160,7 +161,9 @@ function collectIifeEntries(
     if (existing) {
       // the same script may be declared in multiple content_scripts entries
       // with different matches; union the matches of all registrations
-      existing.matches = [...new Set([...existing.matches, ...entry.matches])]
+      existing.matches = reduceMatchPatterns([
+        ...new Set([...existing.matches, ...entry.matches]),
+      ])
       return
     }
     entriesById.set(entry.id, entry)

--- a/packages/vite-plugin/src/node/plugin-manifest.ts
+++ b/packages/vite-plugin/src/node/plugin-manifest.ts
@@ -7,7 +7,12 @@ import { ResolvedConfig, UserConfig, version as ViteVersion } from 'vite'
 import { contentScripts, hashScriptId } from './contentScripts'
 import { formatFileData, getFileName, prefix } from './fileWriter-utilities'
 import { htmlFiles, manifestFiles } from './files'
-import { decodeManifest, encodeManifest, isString } from './helpers'
+import {
+  decodeManifest,
+  encodeManifest,
+  isString,
+  reduceMatchPatterns,
+} from './helpers'
 import { ManifestV3 } from './manifest'
 import { basename, isAbsolute, join, normalize, relative } from './path'
 import { getOptions } from './plugin-optionsProvider'
@@ -323,7 +328,9 @@ export const pluginManifest: CrxPluginFn = () => {
                   formatFileData({
                     type: 'loader',
                     id,
-                    matches: [...(matchesByFile.get(id) ?? matches)],
+                    matches: reduceMatchPatterns([
+                      ...(matchesByFile.get(id) ?? matches),
+                    ]),
                     refId: hashScriptId({ type: 'loader', id }),
                     fileName: getFileName({ type: 'loader', id }),
                   }),
@@ -375,7 +382,7 @@ export const pluginManifest: CrxPluginFn = () => {
                   type: 'loader',
                   id: file,
                   refId,
-                  matches: [...matches],
+                  matches: reduceMatchPatterns([...matches]),
                 }),
               )
             }

--- a/packages/vite-plugin/src/node/plugin-manifest.ts
+++ b/packages/vite-plugin/src/node/plugin-manifest.ts
@@ -275,7 +275,18 @@ export const pluginManifest: CrxPluginFn = () => {
           // vite serve file writer only emits content scripts
           // - html files come directly from vite dev server
           // - service worker comes from vite dev server via loader file
-          if (manifest.content_scripts)
+          if (manifest.content_scripts) {
+            // the same file may be declared in multiple content_scripts entries
+            // with different matches; union the matches of all registrations
+            // (see the build branch below)
+            const matchesByFile = new Map<string, Set<string>>()
+            for (const { js = [], matches = [] } of manifest.content_scripts)
+              for (const id of js) {
+                const fileMatches = matchesByFile.get(id) ?? new Set()
+                for (const match of matches) fileMatches.add(match)
+                matchesByFile.set(id, fileMatches)
+              }
+
             for (let i = 0; i < manifest.content_scripts.length; i++) {
               const {
                 js = [],
@@ -312,13 +323,14 @@ export const pluginManifest: CrxPluginFn = () => {
                   formatFileData({
                     type: 'loader',
                     id,
-                    matches,
+                    matches: [...(matchesByFile.get(id) ?? matches)],
                     refId: hashScriptId({ type: 'loader', id }),
                     fileName: getFileName({ type: 'loader', id }),
                   }),
                 )
               }
             }
+          }
         } else {
           // vite build emits content scripts, html files and service worker
           // Skip IIFE/standalone content scripts - they will be built separately by the IIFE plugin
@@ -330,31 +342,44 @@ export const pluginManifest: CrxPluginFn = () => {
             const normalized = file.replace(/^\//, '')
             return standaloneFiles.includes(normalized)
           }
-          if (manifest.content_scripts)
+          if (manifest.content_scripts) {
+            // the same file may be declared in multiple content_scripts entries
+            // with different matches (e.g. a broad entry plus a narrow
+            // match_about_blank entry); union the matches of all registrations
+            // so web_accessible_resources covers every entry
+            const matchesByFile = new Map<string, Set<string>>()
             for (const { js = [], matches = [] } of manifest.content_scripts)
               for (const file of js) {
                 // Skip IIFE/standalone content scripts - they're built separately
-                if (isIifeContentScript(file) || isStandaloneFile(file)) continue
-                
-                const id = join(config.root, file)
-                const refId = this.emitFile({
-                  type: 'chunk',
-                  id,
-                  name: basename(file),
-                  // Preserve content script entry exports so the build finalizer
-                  // can decide whether the script needs a loader wrapper.
-                  preserveSignature: 'exports-only',
-                })
-                contentScripts.set(
-                  file,
-                  formatFileData({
-                    type: 'loader',
-                    id: file,
-                    refId,
-                    matches,
-                  }),
-                )
+                if (isIifeContentScript(file) || isStandaloneFile(file))
+                  continue
+
+                const fileMatches = matchesByFile.get(file) ?? new Set()
+                for (const match of matches) fileMatches.add(match)
+                matchesByFile.set(file, fileMatches)
               }
+
+            for (const [file, matches] of matchesByFile) {
+              const id = join(config.root, file)
+              const refId = this.emitFile({
+                type: 'chunk',
+                id,
+                name: basename(file),
+                // Preserve content script entry exports so the build finalizer
+                // can decide whether the script needs a loader wrapper.
+                preserveSignature: 'exports-only',
+              })
+              contentScripts.set(
+                file,
+                formatFileData({
+                  type: 'loader',
+                  id: file,
+                  refId,
+                  matches: [...matches],
+                }),
+              )
+            }
+          }
 
           if (manifest.background && 'service_worker' in manifest.background) {
             const file = manifest.background.service_worker

--- a/packages/vite-plugin/tests/e2e/mv3-content-script-multiple-registrations/manifest.json
+++ b/packages/vite-plugin/tests/e2e/mv3-content-script-multiple-registrations/manifest.json
@@ -1,0 +1,21 @@
+{
+  "description": "Test content script declared in multiple content_scripts entries",
+  "manifest_version": 3,
+  "name": "Content Script Multiple Registrations Test",
+  "version": "1.0.0",
+  "content_scripts": [
+    {
+      "matches": ["https://example.com/*"],
+      "js": ["src/content.ts"],
+      "run_at": "document_end",
+      "world": "MAIN"
+    },
+    {
+      "matches": ["https://www.google.com/*"],
+      "js": ["src/content.ts"],
+      "match_about_blank": true,
+      "run_at": "document_end",
+      "world": "MAIN"
+    }
+  ]
+}

--- a/packages/vite-plugin/tests/e2e/mv3-content-script-multiple-registrations/src/banner.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-content-script-multiple-registrations/src/banner.ts
@@ -1,0 +1,6 @@
+export function createBanner() {
+  const banner = document.createElement('div')
+  banner.id = 'multiple-registrations-banner'
+  banner.textContent = 'content script ran'
+  document.body.appendChild(banner)
+}

--- a/packages/vite-plugin/tests/e2e/mv3-content-script-multiple-registrations/src/content.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-content-script-multiple-registrations/src/content.ts
@@ -1,0 +1,12 @@
+// This MAIN world content script is declared in two content_scripts entries
+// with different matches. The dynamic import forces a loader file, and the
+// import only resolves on pages covered by web_accessible_resources — so it
+// must carry the matches of every registration, not just the last one.
+;(async () => {
+  const { createBanner } = await import('./banner')
+  createBanner()
+})().catch((err) => {
+  console.error('[multiple-registrations] dynamic import failed', err)
+})
+
+export {}

--- a/packages/vite-plugin/tests/e2e/mv3-content-script-multiple-registrations/vite-build.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-content-script-multiple-registrations/vite-build.test.ts
@@ -1,0 +1,35 @@
+import fs from 'fs-extra'
+import { join } from 'pathe'
+import { expect, test } from 'vitest'
+import { build } from '../runners'
+
+// https://github.com/crxjs/chrome-extension-tools/issues/1233
+// The same content script declared in multiple content_scripts entries must
+// get a web_accessible_resources entry that covers the matches of every
+// registration, not just the last one. Otherwise the loader's dynamic import
+// is blocked on pages matched only by the other entries and the script
+// silently never runs.
+test(
+  'content script declared in multiple entries runs on all matched pages',
+  async () => {
+    const { browser, outDir } = await build(__dirname)
+
+    // the WAR matches must be the union of both registrations
+    const manifest = await fs.readJson(join(outDir, 'manifest.json'))
+    const warMatches = (manifest.web_accessible_resources ?? [])
+      .filter((r: { matches?: string[] }) => Array.isArray(r.matches))
+      .flatMap((r: { matches: string[] }) => r.matches)
+    expect(warMatches).toContain('https://example.com/*')
+    expect(warMatches).toContain('https://www.google.com/*')
+
+    // the page is matched only by the first content_scripts entry; the
+    // banner only appears if the loader's dynamic import was allowed here
+    const page = await browser.newPage()
+    await page.goto('https://example.com')
+
+    const banner = page.locator('#multiple-registrations-banner')
+    await banner.waitFor({ state: 'attached', timeout: 10000 })
+    expect(await banner.textContent()).toBe('content script ran')
+  },
+  { retry: process.env.CI ? 5 : 0 },
+)

--- a/packages/vite-plugin/tests/e2e/mv3-content-script-multiple-registrations/vite.config.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-content-script-multiple-registrations/vite.config.ts
@@ -1,0 +1,10 @@
+import { crx } from '../../plugin-testOptionsProvider'
+import { defineConfig } from 'vite'
+import manifest from './manifest.json'
+
+export default defineConfig({
+  build: { minify: false },
+  clearScreen: false,
+  logLevel: 'error',
+  plugins: [crx({ manifest })],
+})

--- a/packages/vite-plugin/tests/out/content-script-multiple-registrations/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/content-script-multiple-registrations/__snapshots__/build.test.ts.snap
@@ -1,0 +1,134 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`build fs output > _00 manifest.json 1`] = `
+Object {
+  "content_scripts": Array [
+    Object {
+      "js": Array [
+        "assets/content.js-loader.hash0.js",
+      ],
+      "matches": Array [
+        "https://example.com/*",
+      ],
+      "run_at": "document_end",
+      "world": "MAIN",
+    },
+    Object {
+      "js": Array [
+        "assets/content.js-loader.hash0.js",
+      ],
+      "match_about_blank": true,
+      "matches": Array [
+        "https://outlook.office.com/*",
+      ],
+      "run_at": "document_end",
+      "world": "MAIN",
+    },
+  ],
+  "description": "test content script declared in multiple content_scripts entries",
+  "manifest_version": 3,
+  "name": "Test Content Script Multiple Registrations",
+  "version": "1.0.0",
+  "web_accessible_resources": Array [
+    Object {
+      "matches": Array [
+        "https://example.com/*",
+        "https://outlook.office.com/*",
+      ],
+      "resources": Array [
+        "assets/content.js.hash1.js",
+        "assets/message.hash2.js",
+      ],
+      "use_dynamic_url": false,
+    },
+  ],
+}
+`;
+
+exports[`build fs output > _01 output files 1`] = `
+Array [
+  "assets/content.js-loader.hash0.js",
+  "assets/content.js.hash1.js",
+  "assets/message.hash2.js",
+  "manifest.json",
+]
+`;
+
+exports[`build fs output > assets/content.js.hash1.js 1`] = `
+"const scriptRel = \\"modulepreload\\";
+const assetsURL = function(dep) {
+  return \\"/\\" + dep;
+};
+const seen = {};
+const __vitePreload = function preload(baseModule, deps, importerUrl) {
+  if (!deps || deps.length === 0) {
+    return baseModule();
+  }
+  const links = document.getElementsByTagName(\\"link\\");
+  return Promise.all(deps.map((dep) => {
+    dep = assetsURL(dep);
+    if (dep in seen)
+      return;
+    seen[dep] = true;
+    const isCss = dep.endsWith(\\".css\\");
+    const cssSelector = isCss ? '[rel=\\"stylesheet\\"]' : \\"\\";
+    const isBaseRelative = !!importerUrl;
+    if (isBaseRelative) {
+      for (let i = links.length - 1; i >= 0; i--) {
+        const link2 = links[i];
+        if (link2.href === dep && (!isCss || link2.rel === \\"stylesheet\\")) {
+          return;
+        }
+      }
+    } else if (document.querySelector(\`link[href=\\"\${dep}\\"]\${cssSelector}\`)) {
+      return;
+    }
+    const link = document.createElement(\\"link\\");
+    link.rel = isCss ? \\"stylesheet\\" : scriptRel;
+    if (!isCss) {
+      link.as = \\"script\\";
+      link.crossOrigin = \\"\\";
+    }
+    link.href = dep;
+    document.head.appendChild(link);
+    if (isCss) {
+      return new Promise((res, rej) => {
+        link.addEventListener(\\"load\\", res);
+        link.addEventListener(\\"error\\", () => rej(new Error(\`Unable to preload CSS for \${dep}\`)));
+      });
+    }
+  })).then(() => baseModule());
+};
+(async () => {
+  const { logMessage } = await __vitePreload(() => import(\\"./message.hash2.js\\"), true ? [] : void 0);
+  logMessage();
+})().catch(console.error);
+"
+`;
+
+exports[`build fs output > assets/content.js-loader.hash0.js 1`] = `
+"(function () {
+  'use strict';
+
+  const injectTime = performance.now();
+  (async () => {
+    const { onExecute } = await import(
+      /* @vite-ignore */
+      \\"./content.js.hash1.js\\"
+    );
+    onExecute?.({ perf: { injectTime, loadTime: performance.now() - injectTime } });
+  })().catch(console.error);
+
+})();
+"
+`;
+
+exports[`build fs output > assets/message.hash2.js 1`] = `
+"function logMessage() {
+  console.log(\\"content script running\\");
+}
+export {
+  logMessage
+};
+"
+`;

--- a/packages/vite-plugin/tests/out/content-script-multiple-registrations/__snapshots__/build.test.ts.snap
+++ b/packages/vite-plugin/tests/out/content-script-multiple-registrations/__snapshots__/build.test.ts.snap
@@ -24,6 +24,27 @@ Object {
       "run_at": "document_end",
       "world": "MAIN",
     },
+    Object {
+      "js": Array [
+        "assets/content2.js-loader.hash1.js",
+      ],
+      "matches": Array [
+        "<all_urls>",
+      ],
+      "run_at": "document_end",
+      "world": "MAIN",
+    },
+    Object {
+      "js": Array [
+        "assets/content2.js-loader.hash1.js",
+      ],
+      "match_about_blank": true,
+      "matches": Array [
+        "https://outlook.office.com/*",
+      ],
+      "run_at": "document_end",
+      "world": "MAIN",
+    },
   ],
   "description": "test content script declared in multiple content_scripts entries",
   "manifest_version": 3,
@@ -36,8 +57,20 @@ Object {
         "https://outlook.office.com/*",
       ],
       "resources": Array [
-        "assets/content.js.hash1.js",
-        "assets/message.hash2.js",
+        "assets/content.js.hash2.js",
+        "assets/message.hash3.js",
+        "assets/preload-helper.hash4.js",
+      ],
+      "use_dynamic_url": false,
+    },
+    Object {
+      "matches": Array [
+        "<all_urls>",
+      ],
+      "resources": Array [
+        "assets/content2.js.hash5.js",
+        "assets/message.hash3.js",
+        "assets/preload-helper.hash4.js",
       ],
       "use_dynamic_url": false,
     },
@@ -48,13 +81,78 @@ Object {
 exports[`build fs output > _01 output files 1`] = `
 Array [
   "assets/content.js-loader.hash0.js",
-  "assets/content.js.hash1.js",
-  "assets/message.hash2.js",
+  "assets/content.js.hash2.js",
+  "assets/content2.js-loader.hash1.js",
+  "assets/content2.js.hash5.js",
+  "assets/message.hash3.js",
+  "assets/preload-helper.hash4.js",
   "manifest.json",
 ]
 `;
 
-exports[`build fs output > assets/content.js.hash1.js 1`] = `
+exports[`build fs output > assets/content.js.hash2.js 1`] = `
+"import { _ as __vitePreload } from \\"./preload-helper.hash4.js\\";
+(async () => {
+  const { logMessage } = await __vitePreload(() => import(\\"./message.hash3.js\\"), true ? [] : void 0);
+  logMessage();
+})().catch(console.error);
+"
+`;
+
+exports[`build fs output > assets/content.js-loader.hash0.js 1`] = `
+"(function () {
+  'use strict';
+
+  const injectTime = performance.now();
+  (async () => {
+    const { onExecute } = await import(
+      /* @vite-ignore */
+      \\"./content.js.hash2.js\\"
+    );
+    onExecute?.({ perf: { injectTime, loadTime: performance.now() - injectTime } });
+  })().catch(console.error);
+
+})();
+"
+`;
+
+exports[`build fs output > assets/content2.js.hash5.js 1`] = `
+"import { _ as __vitePreload } from \\"./preload-helper.hash4.js\\";
+(async () => {
+  const { logMessage } = await __vitePreload(() => import(\\"./message.hash3.js\\"), true ? [] : void 0);
+  logMessage();
+})().catch(console.error);
+"
+`;
+
+exports[`build fs output > assets/content2.js-loader.hash1.js 1`] = `
+"(function () {
+  'use strict';
+
+  const injectTime = performance.now();
+  (async () => {
+    const { onExecute } = await import(
+      /* @vite-ignore */
+      \\"./content2.js.hash5.js\\"
+    );
+    onExecute?.({ perf: { injectTime, loadTime: performance.now() - injectTime } });
+  })().catch(console.error);
+
+})();
+"
+`;
+
+exports[`build fs output > assets/message.hash3.js 1`] = `
+"function logMessage() {
+  console.log(\\"content script running\\");
+}
+export {
+  logMessage
+};
+"
+`;
+
+exports[`build fs output > assets/preload-helper.hash4.js 1`] = `
 "const scriptRel = \\"modulepreload\\";
 const assetsURL = function(dep) {
   return \\"/\\" + dep;
@@ -99,36 +197,8 @@ const __vitePreload = function preload(baseModule, deps, importerUrl) {
     }
   })).then(() => baseModule());
 };
-(async () => {
-  const { logMessage } = await __vitePreload(() => import(\\"./message.hash2.js\\"), true ? [] : void 0);
-  logMessage();
-})().catch(console.error);
-"
-`;
-
-exports[`build fs output > assets/content.js-loader.hash0.js 1`] = `
-"(function () {
-  'use strict';
-
-  const injectTime = performance.now();
-  (async () => {
-    const { onExecute } = await import(
-      /* @vite-ignore */
-      \\"./content.js.hash1.js\\"
-    );
-    onExecute?.({ perf: { injectTime, loadTime: performance.now() - injectTime } });
-  })().catch(console.error);
-
-})();
-"
-`;
-
-exports[`build fs output > assets/message.hash2.js 1`] = `
-"function logMessage() {
-  console.log(\\"content script running\\");
-}
 export {
-  logMessage
+  __vitePreload as _
 };
 "
 `;

--- a/packages/vite-plugin/tests/out/content-script-multiple-registrations/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/content-script-multiple-registrations/__snapshots__/serve.test.ts.snap
@@ -28,6 +28,27 @@ Object {
       "run_at": "document_end",
       "world": "MAIN",
     },
+    Object {
+      "js": Array [
+        "src/content2.js-loader.js",
+      ],
+      "matches": Array [
+        "<all_urls>",
+      ],
+      "run_at": "document_end",
+      "world": "MAIN",
+    },
+    Object {
+      "js": Array [
+        "src/content2.js-loader.js",
+      ],
+      "match_about_blank": true,
+      "matches": Array [
+        "https://outlook.office.com/*",
+      ],
+      "run_at": "document_end",
+      "world": "MAIN",
+    },
   ],
   "description": "test content script declared in multiple content_scripts entries",
   "externally_connectable": Object {
@@ -60,6 +81,8 @@ Array [
   "service-worker-loader.js",
   "src/content.js-loader.js",
   "src/content.js.js",
+  "src/content2.js-loader.js",
+  "src/content2.js.js",
   "src/message.js.js",
   "vendor/crx-client-port.js",
   "vendor/vite-client.js",
@@ -71,6 +94,7 @@ Array [
 exports[`serve fs output > _02 optimized deps 1`] = `
 Set {
   "src/content.js",
+  "src/content2.js",
 }
 `;
 
@@ -112,6 +136,48 @@ exports[`serve fs output > src/content.js-loader.js 1`] = `
     const { onExecute } = await import(
       /* @vite-ignore */
       \\"./content.js.js\\"
+    );
+    onExecute?.({
+      perf: { injectTime, loadTime: performance.now() - injectTime }
+    });
+  })().catch(console.error);
+
+})();
+"
+`;
+
+exports[`serve fs output > src/content2.js.js 1`] = `
+"// declared with <all_urls> plus a narrower match_about_blank entry; the
+// web_accessible_resources matches should collapse to just <all_urls>
+;(async () => {
+  const { logMessage } = await import(\\"/src/message.js.js\\")
+  logMessage()
+})().catch(console.error)
+"
+`;
+
+exports[`serve fs output > src/content2.js-loader.js 1`] = `
+"(function () {
+  'use strict';
+
+  const injectTime = performance.now();
+  (async () => {
+    try {
+      if (\\"\\")
+        await import(
+          /* @vite-ignore */
+          \\"\\"
+        );
+      await import(
+        /* @vite-ignore */
+        \\"../vendor/vite-client.js\\"
+      );
+    } catch (error) {
+      console.warn(\\"[crx] MAIN world HMR client failed to load\\", error);
+    }
+    const { onExecute } = await import(
+      /* @vite-ignore */
+      \\"./content2.js.js\\"
     );
     onExecute?.({
       perf: { injectTime, loadTime: performance.now() - injectTime }

--- a/packages/vite-plugin/tests/out/content-script-multiple-registrations/__snapshots__/serve.test.ts.snap
+++ b/packages/vite-plugin/tests/out/content-script-multiple-registrations/__snapshots__/serve.test.ts.snap
@@ -1,0 +1,130 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`serve fs output > _00 manifest.json 1`] = `
+Object {
+  "background": Object {
+    "service_worker": "service-worker-loader.js",
+    "type": "module",
+  },
+  "content_scripts": Array [
+    Object {
+      "js": Array [
+        "src/content.js-loader.js",
+      ],
+      "matches": Array [
+        "https://example.com/*",
+      ],
+      "run_at": "document_end",
+      "world": "MAIN",
+    },
+    Object {
+      "js": Array [
+        "src/content.js-loader.js",
+      ],
+      "match_about_blank": true,
+      "matches": Array [
+        "https://outlook.office.com/*",
+      ],
+      "run_at": "document_end",
+      "world": "MAIN",
+    },
+  ],
+  "description": "test content script declared in multiple content_scripts entries",
+  "externally_connectable": Object {
+    "matches": Array [
+      "https://example.com/*",
+      "https://outlook.office.com/*",
+    ],
+  },
+  "manifest_version": 3,
+  "name": "Test Content Script Multiple Registrations",
+  "version": "1.0.0",
+  "web_accessible_resources": Array [
+    Object {
+      "matches": Array [
+        "<all_urls>",
+      ],
+      "resources": Array [
+        "*",
+        "**/*",
+      ],
+      "use_dynamic_url": false,
+    },
+  ],
+}
+`;
+
+exports[`serve fs output > _01 output files 1`] = `
+Array [
+  "manifest.json",
+  "service-worker-loader.js",
+  "src/content.js-loader.js",
+  "src/content.js.js",
+  "src/message.js.js",
+  "vendor/crx-client-port.js",
+  "vendor/vite-client.js",
+  "vendor/vite-dist-client-env.mjs.js",
+  "vendor/webcomponents-custom-elements.js",
+]
+`;
+
+exports[`serve fs output > _02 optimized deps 1`] = `
+Set {
+  "src/content.js",
+}
+`;
+
+exports[`serve fs output > service-worker-loader.js 1`] = `
+"import 'http://localhost:3000/@vite/env';
+import 'http://localhost:3000/@crx/client-worker';
+"
+`;
+
+exports[`serve fs output > src/content.js.js 1`] = `
+"// the dynamic import forces a loader file, so the imported chunk is only
+// usable on pages covered by web_accessible_resources
+;(async () => {
+  const { logMessage } = await import(\\"/src/message.js.js\\")
+  logMessage()
+})().catch(console.error)
+"
+`;
+
+exports[`serve fs output > src/content.js-loader.js 1`] = `
+"(function () {
+  'use strict';
+
+  const injectTime = performance.now();
+  (async () => {
+    try {
+      if (\\"\\")
+        await import(
+          /* @vite-ignore */
+          \\"\\"
+        );
+      await import(
+        /* @vite-ignore */
+        \\"../vendor/vite-client.js\\"
+      );
+    } catch (error) {
+      console.warn(\\"[crx] MAIN world HMR client failed to load\\", error);
+    }
+    const { onExecute } = await import(
+      /* @vite-ignore */
+      \\"./content.js.js\\"
+    );
+    onExecute?.({
+      perf: { injectTime, loadTime: performance.now() - injectTime }
+    });
+  })().catch(console.error);
+
+})();
+"
+`;
+
+exports[`serve fs output > src/message.js.js 1`] = `
+"export function logMessage() {
+  console.log('content script running')
+}
+"
+`;

--- a/packages/vite-plugin/tests/out/content-script-multiple-registrations/build.test.ts
+++ b/packages/vite-plugin/tests/out/content-script-multiple-registrations/build.test.ts
@@ -1,0 +1,8 @@
+import { build } from 'tests/runners'
+import { testOutput } from 'tests/testOutput'
+import { test } from 'vitest'
+
+test('build fs output', async () => {
+  const result = await build(__dirname)
+  await testOutput(result)
+})

--- a/packages/vite-plugin/tests/out/content-script-multiple-registrations/manifest.json
+++ b/packages/vite-plugin/tests/out/content-script-multiple-registrations/manifest.json
@@ -12,6 +12,19 @@
       "match_about_blank": true,
       "run_at": "document_end",
       "world": "MAIN"
+    },
+    {
+      "js": ["src/content2.js"],
+      "matches": ["<all_urls>"],
+      "run_at": "document_end",
+      "world": "MAIN"
+    },
+    {
+      "js": ["src/content2.js"],
+      "matches": ["https://outlook.office.com/*"],
+      "match_about_blank": true,
+      "run_at": "document_end",
+      "world": "MAIN"
     }
   ],
   "description": "test content script declared in multiple content_scripts entries",

--- a/packages/vite-plugin/tests/out/content-script-multiple-registrations/manifest.json
+++ b/packages/vite-plugin/tests/out/content-script-multiple-registrations/manifest.json
@@ -1,0 +1,21 @@
+{
+  "content_scripts": [
+    {
+      "js": ["src/content.js"],
+      "matches": ["https://example.com/*"],
+      "run_at": "document_end",
+      "world": "MAIN"
+    },
+    {
+      "js": ["src/content.js"],
+      "matches": ["https://outlook.office.com/*"],
+      "match_about_blank": true,
+      "run_at": "document_end",
+      "world": "MAIN"
+    }
+  ],
+  "description": "test content script declared in multiple content_scripts entries",
+  "manifest_version": 3,
+  "name": "Test Content Script Multiple Registrations",
+  "version": "1.0.0"
+}

--- a/packages/vite-plugin/tests/out/content-script-multiple-registrations/serve.test.ts
+++ b/packages/vite-plugin/tests/out/content-script-multiple-registrations/serve.test.ts
@@ -1,0 +1,8 @@
+import { serve } from 'tests/runners'
+import { testOutput } from 'tests/testOutput'
+import { test } from 'vitest'
+
+test('serve fs output', async () => {
+  const result = await serve(__dirname)
+  await testOutput(result)
+})

--- a/packages/vite-plugin/tests/out/content-script-multiple-registrations/src/content.js
+++ b/packages/vite-plugin/tests/out/content-script-multiple-registrations/src/content.js
@@ -1,0 +1,6 @@
+// the dynamic import forces a loader file, so the imported chunk is only
+// usable on pages covered by web_accessible_resources
+;(async () => {
+  const { logMessage } = await import('./message.js')
+  logMessage()
+})().catch(console.error)

--- a/packages/vite-plugin/tests/out/content-script-multiple-registrations/src/content2.js
+++ b/packages/vite-plugin/tests/out/content-script-multiple-registrations/src/content2.js
@@ -1,0 +1,6 @@
+// declared with <all_urls> plus a narrower match_about_blank entry; the
+// web_accessible_resources matches should collapse to just <all_urls>
+;(async () => {
+  const { logMessage } = await import('./message.js')
+  logMessage()
+})().catch(console.error)

--- a/packages/vite-plugin/tests/out/content-script-multiple-registrations/src/message.js
+++ b/packages/vite-plugin/tests/out/content-script-multiple-registrations/src/message.js
@@ -1,0 +1,3 @@
+export function logMessage() {
+  console.log('content script running')
+}

--- a/packages/vite-plugin/tests/out/content-script-multiple-registrations/vite.config.ts
+++ b/packages/vite-plugin/tests/out/content-script-multiple-registrations/vite.config.ts
@@ -1,0 +1,20 @@
+import { crx } from '../../plugin-testOptionsProvider'
+import { defineConfig } from 'vite'
+import manifest from './manifest.json'
+
+export default defineConfig({
+  build: {
+    minify: false,
+    rollupOptions: {
+      output: {
+        // the hash randomly changes between environments
+        assetFileNames: 'assets/[name].hash[hash].[ext]',
+        chunkFileNames: 'assets/[name].hash[hash].js',
+        entryFileNames: 'assets/[name].hash[hash].js',
+      },
+    },
+  },
+  clearScreen: false,
+  logLevel: 'error',
+  plugins: [crx({ manifest })],
+})


### PR DESCRIPTION
Fixes #1233

## Problem

When the same content script file is declared in multiple `content_scripts` entries with different `matches` (a common pattern — e.g. one broad entry plus a separate entry for domains that need `match_about_blank: true`), the `contentScripts` RxMap keeps one entry per script file, so the second manifest registration overwrites the first. The generated `web_accessible_resources` entry for that script then carries the `matches` of only **one** registration.

Since v2.6.0 the *last* registration wins (before that, the *first*), so upgrading silently broke extensions that listed their broad entry first: the loader's `await import(chrome-extension://…)` is blocked on every page matched only by the other entries, and the script never runs — fatal and completely silent for `world: "MAIN"` scripts.

## Fix

Neither first-wins nor last-wins is correct — the WAR entry must cover the **union of `matches` across all registrations** of the same script. This PR computes that union:

- in `plugin-manifest.ts` when registering manifest-declared content scripts (both the build and serve branches), and
- in `plugin-contentScripts_iife.ts` when collecting IIFE entries (its first-wins dedupe had the same class of bug).

As a side benefit, the build branch now emits each unique content script file once instead of once per registration.

## Tests

- **`tests/out/content-script-multiple-registrations`** — snapshot test asserting the built manifest's `web_accessible_resources` contains the union of matches (`https://example.com/*` + `https://outlook.office.com/*`) for a script declared in two entries.
- **`tests/e2e/mv3-content-script-multiple-registrations`** — browser e2e test mirroring the issue's repro: a MAIN-world content script with a dynamic import (forcing a loader), declared broad-entry-first / narrow-entry-last. It verifies the WAR union in the output manifest **and** that the script actually executes on a page matched only by the first entry.

Both tests were verified to fail against the current `main` (last-wins) and pass with the fix. Full `--mode out` suite (114 tests) and the related WAR/MAIN-world/IIFE e2e tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)