### PR TITLE
ci: avoid redundant Playwright browser downloads

### DIFF
--- a/.github/workflows/vite-plugin.yml
+++ b/.github/workflows/vite-plugin.yml
@@ -85,6 +85,8 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ env.cache-name }}-
 
       - name: Install dependencies
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
         run: pnpm install --filter "vite-plugin"
 
       - name: Run unit and output tests
@@ -124,6 +126,8 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ env.cache-name }}-
 
       - name: Install dependencies
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
         run: pnpm install --filter "vite-plugin"
 
       - name: Build plugin (always on Vite 3)
@@ -177,7 +181,13 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ env.cache-name }}-
 
       - name: Install dependencies
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
         run: pnpm install --filter "vite-plugin"
+
+      - name: Install Chromium
+        timeout-minutes: 10
+        run: pnpm exec playwright install --no-shell chromium
 
       - name: Build plugin (always on Vite 3)
         run: pnpm build

--- a/packages/vite-plugin/tests/e2e/mv3-vite-background-module-cache/vite-serve.test.ts
+++ b/packages/vite-plugin/tests/e2e/mv3-vite-background-module-cache/vite-serve.test.ts
@@ -26,7 +26,7 @@ test('background dependency update does not duplicate service worker modules', a
   const src2 = path.join(__dirname, 'src2')
 
   await fs.remove(src)
-  await fs.copy(src1, src, { recursive: true })
+  await fs.copy(src1, src)
 
   const { browser, routes } = await serve(__dirname)
   const page = await browser.newPage()


### PR DESCRIPTION
## Summary

- skip Playwright's automatic browser download in unit/output and compatibility jobs, which do not launch a browser
- skip the automatic download during E2E dependency installation and install Chromium explicitly
- use `--no-shell` because the E2E runner launches full Chromium with `--headless=new`, not Playwright's separate headless shell
- cap the explicit browser installation step at 10 minutes
- remove the unsupported `recursive` option from `fs-extra.copy()`, matching the lint fix already validated in #1236

Local developer installs are unchanged: `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` is scoped only to the CI dependency-install steps.

## Impact

In [a recent full Vite Plugin CI run](https://github.com/crxjs/chrome-extension-tools/actions/runs/32949950783), Playwright downloaded browser artifacts in all 18 matrix jobs. Ten non-E2E jobs can avoid them entirely. The eight E2E jobs still install full Chromium and FFmpeg, but no longer download the unused headless shell. Based on the artifact sizes in that run, this avoids approximately 3.8 GiB of downloads per full workflow run.

## Validation

Local:

- `git diff --check`
- YAML parse with Ruby Psych
- `actionlint .github/workflows/vite-plugin.yml` (only pre-existing warnings for `actions/*@v3`)
- `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 pnpm install --filter "vite-plugin" --frozen-lockfile`
- `pnpm exec playwright install --dry-run --no-shell chromium` (lists full Chromium and FFmpeg only)
- `pnpm test:run:out` (122 passed, 1 skipped)
- clean isolated worktree: `pnpm install --filter "vite-plugin" --ignore-scripts` and `pnpm lint`

[Final PR CI run](https://github.com/crxjs/chrome-extension-tools/actions/runs/33006631884):

- all 19 jobs passed, including lint, unit/output, compatibility, and E2E jobs on Ubuntu and Windows
- dependency install logs confirm Playwright skipped browser downloads
- E2E install logs confirm only full Chrome, FFmpeg, and the small Windows Winldd helper were downloaded; no headless shell
- the Chromium install step took about 6.4 seconds on Ubuntu and 10.9 seconds on Windows in representative Vite 3 jobs
